### PR TITLE
Always use dns names with namespace

### DIFF
--- a/controllers/controller_filer_statefulset.go
+++ b/controllers/controller_filer_statefulset.go
@@ -15,8 +15,8 @@ import (
 func buildFilerStartupScript(m *seaweedv1.Seaweed) string {
 	commands := []string{"weed", "filer"}
 	commands = append(commands, fmt.Sprintf("-port=%d", seaweedv1.FilerHTTPPort))
-	commands = append(commands, fmt.Sprintf("-ip=$(POD_NAME).%s-filer-peer", m.Name))
-	commands = append(commands, fmt.Sprintf("-peers=%s", getFilerPeersString(m.Name, m.Spec.Filer.Replicas)))
+	commands = append(commands, fmt.Sprintf("-ip=$(POD_NAME).%s-filer-peer.%s", m.Name, m.Namespace))
+	commands = append(commands, fmt.Sprintf("-peers=%s", getFilerPeersString(m.Name, m.Namespace, m.Spec.Filer.Replicas)))
 	commands = append(commands, fmt.Sprintf("-master=%s", getMasterPeersString(m)))
 	commands = append(commands, "-s3")
 

--- a/controllers/controller_volume_statefulset.go
+++ b/controllers/controller_volume_statefulset.go
@@ -16,7 +16,7 @@ func buildVolumeServerStartupScript(m *seaweedv1.Seaweed, dirs []string) string 
 	commands := []string{"weed", "volume"}
 	commands = append(commands, fmt.Sprintf("-port=%d", seaweedv1.VolumeHTTPPort))
 	commands = append(commands, "-max=0")
-	commands = append(commands, fmt.Sprintf("-ip=$(POD_NAME).%s-volume-peer", m.Name))
+	commands = append(commands, fmt.Sprintf("-ip=$(POD_NAME).%s-volume-peer,%s", m.Name, m.Namespace))
 	if m.Spec.HostSuffix != nil && *m.Spec.HostSuffix != "" {
 		commands = append(commands, fmt.Sprintf("-publicUrl=$(POD_NAME).%s", *m.Spec.HostSuffix))
 	}

--- a/controllers/helper.go
+++ b/controllers/helper.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	masterPeerAddressPattern = "%s-master-%d.%s-master-peer.%s:9333"
-	filerPeerAddressPattern  = "%s-filer-%d.%s-filer-peer:8888"
+	filerPeerAddressPattern  = "%s-filer-%d.%s-filer-peer.%s:8888"
 )
 
 var (
@@ -50,16 +50,16 @@ func ReconcileResult(err error) (bool, ctrl.Result, error) {
 	return false, ctrl.Result{}, nil
 }
 
-func getFilerAddresses(name string, replicas int32) []string {
+func getFilerAddresses(name string, namespace string, replicas int32) []string {
 	peersAddresses := make([]string, 0, replicas)
 	for i := int32(0); i < replicas; i++ {
-		peersAddresses = append(peersAddresses, fmt.Sprintf(filerPeerAddressPattern, name, i, name))
+		peersAddresses = append(peersAddresses, fmt.Sprintf(filerPeerAddressPattern, name, i, name, namespace))
 	}
 	return peersAddresses
 }
 
-func getFilerPeersString(name string, replicas int32) string {
-	return strings.Join(getFilerAddresses(name, replicas), ",")
+func getFilerPeersString(name string, namespace string, replicas int32) string {
+	return strings.Join(getFilerAddresses(name, namespace, replicas), ",")
 }
 
 func getMasterAddresses(namespace string, name string, replicas int32) []string {


### PR DESCRIPTION
Fuse mounts with direct connections to volume servers will not work when app and seaweedfs deployments are in different namespaces. Seaweedfs should report volume server addresses with namespace.