### PR TITLE
Add permission for leases to leader election role

### DIFF
--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -31,3 +31,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update


### PR DESCRIPTION
This adds permissions for leases to the leader election role, so that Pods are created again. I've also tested that this change works. Pods are created as usual again.

Fixes #65

PS: Could you please add the `hacktoberfest` topic to the repository or `hacktoberfest-accepted` labels to my two PRs, so that they count towards my contributions for hacktoberfest? :+1: 