### PR TITLE
Update deprecated Ingress API

### DIFF
--- a/controllers/controller_filer_ingress.go
+++ b/controllers/controller_filer_ingress.go
@@ -3,36 +3,41 @@ package controllers
 import (
 	"fmt"
 
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
 )
 
-func (r *SeaweedReconciler) createAllIngress(m *seaweedv1.Seaweed) *extensionsv1beta1.Ingress {
+func (r *SeaweedReconciler) createAllIngress(m *seaweedv1.Seaweed) *networkingv1.Ingress {
 	labels := labelsForIngress(m.Name)
+	pathType := networkingv1.PathTypePrefix
 
-	dep := &extensionsv1beta1.Ingress{
+	dep := &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      m.Name + "-ingress",
 			Namespace: m.Namespace,
 			Labels:    labels,
 		},
-		Spec: extensionsv1beta1.IngressSpec{
+		Spec: networkingv1.IngressSpec{
 			// TLS:   ingressSpec.TLS,
-			Rules: []extensionsv1beta1.IngressRule{
+			Rules: []networkingv1.IngressRule{
 				{
 					Host: "filer." + *m.Spec.HostSuffix,
-					IngressRuleValue: extensionsv1beta1.IngressRuleValue{
-						HTTP: &extensionsv1beta1.HTTPIngressRuleValue{
-							Paths: []extensionsv1beta1.HTTPIngressPath{
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{
 								{
-									Path: "/",
-									Backend: extensionsv1beta1.IngressBackend{
-										ServiceName: m.Name + "-filer",
-										ServicePort: intstr.FromInt(seaweedv1.FilerHTTPPort),
+									Path:     "/",
+									PathType: &pathType,
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: m.Name + "-filer",
+											Port: networkingv1.ServiceBackendPort{
+												Number: seaweedv1.FilerHTTPPort,
+											},
+										},
 									},
 								},
 							},
@@ -41,14 +46,19 @@ func (r *SeaweedReconciler) createAllIngress(m *seaweedv1.Seaweed) *extensionsv1
 				},
 				{
 					Host: "s3." + *m.Spec.HostSuffix,
-					IngressRuleValue: extensionsv1beta1.IngressRuleValue{
-						HTTP: &extensionsv1beta1.HTTPIngressRuleValue{
-							Paths: []extensionsv1beta1.HTTPIngressPath{
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{
 								{
-									Path: "/",
-									Backend: extensionsv1beta1.IngressBackend{
-										ServiceName: m.Name + "-filer",
-										ServicePort: intstr.FromInt(seaweedv1.FilerS3Port),
+									Path:     "/",
+									PathType: &pathType,
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: m.Name + "-filer",
+											Port: networkingv1.ServiceBackendPort{
+												Number: seaweedv1.FilerS3Port,
+											},
+										},
 									},
 								},
 							},
@@ -61,16 +71,21 @@ func (r *SeaweedReconciler) createAllIngress(m *seaweedv1.Seaweed) *extensionsv1
 
 	// add ingress for volume servers
 	for i := 0; i < int(m.Spec.Volume.Replicas); i++ {
-		dep.Spec.Rules = append(dep.Spec.Rules, extensionsv1beta1.IngressRule{
+		dep.Spec.Rules = append(dep.Spec.Rules, networkingv1.IngressRule{
 			Host: fmt.Sprintf("%s-volume-%d.%s", m.Name, i, *m.Spec.HostSuffix),
-			IngressRuleValue: extensionsv1beta1.IngressRuleValue{
-				HTTP: &extensionsv1beta1.HTTPIngressRuleValue{
-					Paths: []extensionsv1beta1.HTTPIngressPath{
+			IngressRuleValue: networkingv1.IngressRuleValue{
+				HTTP: &networkingv1.HTTPIngressRuleValue{
+					Paths: []networkingv1.HTTPIngressPath{
 						{
-							Path: "/",
-							Backend: extensionsv1beta1.IngressBackend{
-								ServiceName: fmt.Sprintf("%s-volume-%d", m.Name, i),
-								ServicePort: intstr.FromInt(seaweedv1.VolumeHTTPPort),
+							Path:     "/",
+							PathType: &pathType,
+							Backend: networkingv1.IngressBackend{
+								Service: &networkingv1.IngressServiceBackend{
+									Name: fmt.Sprintf("%s-volume-%d", m.Name, i),
+									Port: networkingv1.ServiceBackendPort{
+										Number: seaweedv1.VolumeHTTPPort,
+									},
+								},
 							},
 						},
 					},

--- a/controllers/controller_util.go
+++ b/controllers/controller_util.go
@@ -7,7 +7,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -183,10 +183,10 @@ func (r *SeaweedReconciler) CreateOrUpdateService(svc *corev1.Service) (*corev1.
 	return result.(*corev1.Service), nil
 }
 
-func (r *SeaweedReconciler) CreateOrUpdateIngress(ingress *extensionsv1beta1.Ingress) (*extensionsv1beta1.Ingress, error) {
+func (r *SeaweedReconciler) CreateOrUpdateIngress(ingress *networkingv1.Ingress) (*networkingv1.Ingress, error) {
 	result, err := r.CreateOrUpdate(ingress, func(existing, desired runtime.Object) error {
-		existingIngress := existing.(*extensionsv1beta1.Ingress)
-		desiredIngress := desired.(*extensionsv1beta1.Ingress)
+		existingIngress := existing.(*networkingv1.Ingress)
+		desiredIngress := desired.(*networkingv1.Ingress)
 
 		if existingIngress.Annotations == nil {
 			existingIngress.Annotations = map[string]string{}
@@ -213,7 +213,7 @@ func (r *SeaweedReconciler) CreateOrUpdateIngress(ingress *extensionsv1beta1.Ing
 	if err != nil {
 		return nil, err
 	}
-	return result.(*extensionsv1beta1.Ingress), nil
+	return result.(*networkingv1.Ingress), nil
 }
 
 func (r *SeaweedReconciler) CreateOrUpdateConfigMap(configMap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
@@ -310,8 +310,8 @@ func ServiceEqual(newSvc, oldSvc *corev1.Service) (bool, error) {
 	return false, nil
 }
 
-func IngressEqual(newIngress, oldIngres *extensionsv1beta1.Ingress) (bool, error) {
-	oldIngressSpec := extensionsv1beta1.IngressSpec{}
+func IngressEqual(newIngress, oldIngres *networkingv1.Ingress) (bool, error) {
+	oldIngressSpec := networkingv1.IngressSpec{}
 	if lastAppliedConfig, ok := oldIngres.Annotations[LastAppliedConfigAnnotation]; ok {
 		err := json.Unmarshal([]byte(lastAppliedConfig), &oldIngressSpec)
 		if err != nil {


### PR DESCRIPTION
Updates the Ingress API to networking v1; the beta API is not supported anymore since 1.22.
Note: the build failure has been in the build pipeline before, local builds seem to go through.