### PR TITLE
Publish official docker image

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,40 @@
+name: Create and publish Docker image
+
+on:
+  push:
+    branches: [ master ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: seaweedfs/seaweedfs-operator
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Log in to the Container registry
+      uses: docker/login-action@v1.12.0
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v3.6.2
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v2.7.0
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -2,11 +2,11 @@ name: Create and publish Docker image
 
 on:
   push:
-    branches: [ master ]
+    branches:
+    - master
+    tags:
+    - v*
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: seaweedfs/seaweedfs-operator
 
 jobs:
   build-and-push-image:
@@ -15,24 +15,36 @@ jobs:
       contents: read
       packages: write
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
 
-    - name: Log in to the Container registry
-      uses: docker/login-action@v1.12.0
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Login into GitHub Container Registry
+      uses: docker/login-action@v2
       with:
-        registry: ${{ env.REGISTRY }}
+        registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Login into Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
     - name: Extract metadata (tags, labels) for Docker
       id: meta
-      uses: docker/metadata-action@v3.6.2
+      uses: docker/metadata-action@v4
       with:
-        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        images: |
+          chrislusf/seaweedfs-operator
+          ghcr.io/seaweedfs/seaweedfs-operator
+        tags: |
+          type=ref,event=branch
+          type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@v2.7.0
+      uses: docker/build-push-action@v3
       with:
         context: .
         push: true

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/seaweedfs/seaweedfs-operator
-  newTag: master
+  newTag: latest

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: chrislusf/seaweedfs-operator
-  newTag: v0.0.1
+  newName: ghcr.io/seaweedfs/seaweedfs-operator
+  newTag: master


### PR DESCRIPTION
This PR adds a public docker image to this repository. That simplifies the deployment of the seaweedfs-operator in Kubernetes clusters and removes the need to run anything but kustomize. This change should be fully compatible with the existing workflows as the image is overridden in Makefile's `deploy` job. Therefore people that modify the image will still be use to update their operator with the same commands and new users can just deploy it with the official docker image.

The image will be deployed to the free github container registry of this repository.

If this PR gets merged, I'd be happy if you could add the `hacktoberfest-accepted` label again! :+1: 