### PR TITLE
Fix component service monitors

### DIFF
--- a/controllers/controller_filer_servicemonitor.go
+++ b/controllers/controller_filer_servicemonitor.go
@@ -12,7 +12,7 @@ func (r *SeaweedReconciler) createFilerServiceMonitor(m *seaweedv1.Seaweed) *mon
 
 	dep := &monitorv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      m.Name + "-filer-metrics-monitor",
+			Name:      m.Name + "-filer",
 			Namespace: m.Namespace,
 			Labels:    labels,
 		},

--- a/controllers/controller_master_servicemonitor.go
+++ b/controllers/controller_master_servicemonitor.go
@@ -11,7 +11,7 @@ func (r *SeaweedReconciler) createMasterServiceMonitor(m *seaweedv1.Seaweed) *mo
 
 	dep := &monitorv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      m.Name + "-master-metrics-monitor",
+			Name:      m.Name + "-master",
 			Namespace: m.Namespace,
 			Labels:    labels,
 		},

--- a/controllers/controller_volume_servicemonitor.go
+++ b/controllers/controller_volume_servicemonitor.go
@@ -12,7 +12,7 @@ func (r *SeaweedReconciler) createVolumeServerServiceMonitor(m *seaweedv1.Seawee
 
 	dep := &monitorv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      m.Name + "-volume-metrics-monitor",
+			Name:      m.Name + "-volume",
 			Namespace: m.Namespace,
 			Labels:    labels,
 		},

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	monitorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"os"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -39,6 +40,8 @@ var (
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+
+	utilruntime.Must(monitorv1.AddToScheme(scheme))
 
 	utilruntime.Must(seaweedv1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme


### PR DESCRIPTION
This fixes the newly added ServiceMonitors for the components. In my initial PR, I forgot to add ServiceMonitor to the scheme and I used this opportunity to align the names of the service monitors with what most applications use.