### PR TITLE
Update manifests.yaml

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -14,6 +14,10 @@ webhooks:
       path: /mutate-seaweed-seaweedfs-com-v1-seaweed
   failurePolicy: Fail
   name: mseaweed.kb.io
+  sideEffects: None
+  admissionReviewVersions:
+  - v1
+  - v1beta1
   rules:
   - apiGroups:
     - seaweed.seaweedfs.com


### PR DESCRIPTION
When sideEffects & admissionReviewVersions blocks are missing, `make deploy` fails with error.