### PR TITLE
Pass annotations for the StatefulSets through

### DIFF
--- a/controllers/controller_filer_statefulset.go
+++ b/controllers/controller_filer_statefulset.go
@@ -29,6 +29,7 @@ func buildFilerStartupScript(m *seaweedv1.Seaweed) string {
 
 func (r *SeaweedReconciler) createFilerStatefulSet(m *seaweedv1.Seaweed) *appsv1.StatefulSet {
 	labels := labelsForFiler(m.Name)
+	annotations := m.Spec.Filer.Annotations
 	ports := []corev1.ContainerPort{
 		{
 			ContainerPort: seaweedv1.FilerHTTPPort,
@@ -137,7 +138,8 @@ func (r *SeaweedReconciler) createFilerStatefulSet(m *seaweedv1.Seaweed) *appsv1
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
+					Labels:      labels,
+					Annotations: annotations,
 				},
 				Spec: filerPodSpec,
 			},

--- a/controllers/controller_master_statefulset.go
+++ b/controllers/controller_master_statefulset.go
@@ -46,6 +46,7 @@ func buildMasterStartupScript(m *seaweedv1.Seaweed) string {
 
 func (r *SeaweedReconciler) createMasterStatefulSet(m *seaweedv1.Seaweed) *appsv1.StatefulSet {
 	labels := labelsForMaster(m.Name)
+	annotations := m.Spec.Master.Annotations
 	ports := []corev1.ContainerPort{
 		{
 			ContainerPort: seaweedv1.MasterHTTPPort,
@@ -148,7 +149,8 @@ func (r *SeaweedReconciler) createMasterStatefulSet(m *seaweedv1.Seaweed) *appsv
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
+					Labels:      labels,
+					Annotations: annotations,
 				},
 				Spec: masterPodSpec,
 			},

--- a/controllers/controller_volume_statefulset.go
+++ b/controllers/controller_volume_statefulset.go
@@ -31,6 +31,7 @@ func buildVolumeServerStartupScript(m *seaweedv1.Seaweed, dirs []string) string 
 
 func (r *SeaweedReconciler) createVolumeServerStatefulSet(m *seaweedv1.Seaweed) *appsv1.StatefulSet {
 	labels := labelsForVolumeServer(m.Name)
+	annotations := m.Spec.Volume.Annotations
 	ports := []corev1.ContainerPort{
 		{
 			ContainerPort: seaweedv1.VolumeHTTPPort,
@@ -158,7 +159,8 @@ func (r *SeaweedReconciler) createVolumeServerStatefulSet(m *seaweedv1.Seaweed) 
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
+					Labels:      labels,
+					Annotations: annotations,
 				},
 				Spec: volumePodSpec,
 			},


### PR DESCRIPTION
Currently annotations can be specified in the CRD, but are never passed through to the templates of the StatefulSets. This PR adds functionality for those annotations in the seaweed CRD.