### PR TITLE
Use numeric user id for nonroot verification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,6 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
-USER nonroot:nonroot
+USER 65532:65532
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
The numeric ID of `nonroot` user and group should be used, so that `spec.template.spec.containers.securityContext.runAsNonRoot` of the Kubernetes deployment can be set and verified. This check only supports numeric users at the moment.

Here can be seen, that the user and group ID of `nonroot` is `65532`: https://github.com/GoogleContainerTools/distroless/blob/main/base/base.bzl#L8

And here is the problem: https://stackoverflow.com/a/49729786