### PR TITLE
helm: add permission for leases to leader election role

### DIFF
--- a/deploy/helm/templates/rbac/leader_election_role.yaml
+++ b/deploy/helm/templates/rbac/leader_election_role.yaml
@@ -31,3 +31,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update


### PR DESCRIPTION
Fixes error: `E0517 17:50:21.216754       1 leaderelection.go:330] error retrieving resource lock seaweedfs/674006ec.seaweedfs.com: leases.coordination.k8s.io "674006ec.seaweedfs.com" is forbidden: User "system:serviceaccount:seaweedfs:default" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "seaweedfs"`

Same as https://github.com/seaweedfs/seaweedfs-operator/pull/68 but for helm template