### PR TITLE
Create helm_chart_release.yml to add helm chart release GitHub Actions Workflow

### DIFF
--- a/.github/workflows/helm_chart_release.yml
+++ b/.github/workflows/helm_chart_release.yml
@@ -1,0 +1,44 @@
+name: Release Helm Chart
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'deploy/helm/**'
+
+permissions:
+  contents: write
+  pages: write
+
+jobs:
+  release:
+    environment: helm-release
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3.5
+        id: helm-install
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run chart-releaser
+        id: helm-release
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          charts_dir: deploy/helm
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_GENERATE_RELEASE_NOTES: true


### PR DESCRIPTION
This new file, `helm_chart_release.yml`, uses [helm/chart-releaser-action](https://github.com/helm/chart-releaser-action) to create helm chart releases on any push to the `master` branch that changes a file in the `deploy/helm` directory. This also adds automatic release notes generation which will link to the PR that was merged.

Fixes #79 (Publish Helm Charts).

You can see an example of this in action in the nextcloud helm chart repo:
https://github.com/nextcloud/helm/blob/main/.github/workflows/release.yaml

This is what our releases look like for the nextcloud helm chart:
https://github.com/nextcloud/helm/releases

Let me know if there's anything you'd like me to amend :+1: 