### PR TITLE
Add more comments to the values.yaml, including type hints, and generate a README.md based on those values.

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,9 @@
 apiVersion: v2
 name: seaweedfs-operator
-description: A Helm chart for seaweedfs-operator
+description: A Helm chart for the seaweedfs-operator
 type: application
-version: 0.0.1
+version: 0.0.2
 appVersion: "0.0.1"
+maintainers:
+  - name: chrislusf
+    url: https://github.com/chrislusf

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -1,0 +1,47 @@
+# seaweedfs-operator
+
+![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+
+A Helm chart for the seaweedfs-operator
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| chrislusf |  | <https://github.com/chrislusf> |
+
+## Values
+
+| Key                             | Type   | Default                         | Description                                                                                                                                                                                                          |
+|---------------------------------|--------|---------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| commonAnnotations               | object | `{}`                            | Annotations for all the deployed objects                                                                                                                                                                             |
+| commonLabels                    | object | `{}`                            | Labels for all the deployed objects                                                                                                                                                                                  |
+| fullnameOverride                | string | `""`                            | String to fully override common.names.fullname template                                                                                                                                                              |
+| global                          | object | `{"imageRegistry":"chrislusf"}` | Global Docker image parameters Please, note that this will override the image parameters, including dependencies, configured to use the global value Current available global Docker image parameters: imageRegistry |
+| grafanaDashboard.enabled        | bool   | `true`                          | Enable or disable Grafana Dashboard configmap                                                                                                                                                                        |
+| image.pullPolicy                | string | `"Always"`                      | Specify a imagePullPolicy # Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent' # ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images                                         |
+| image.registry                  | string | `"chrislusf"`                   |                                                                                                                                                                                                                      |
+| image.repository                | string | `"seaweedfs-operator"`          |                                                                                                                                                                                                                      |
+| image.tag                       | string | `""`                            | tag of image to use. Defaults to appVersion in Chart.yaml                                                                                                                                                            |
+| nameOverride                    | string | `""`                            | String to partially override common.names.fullname template (will maintain the release name)                                                                                                                         |
+| port.name                       | string | `"http"`                        | name of the container port to use for the Kubernete service and ingress                                                                                                                                              |
+| port.number                     | int    | `8080`                          | container port number to use for the Kubernete service and ingress                                                                                                                                                   |
+| rbac.serviceAccount.name        | string | `"default"`                     | name of the Kubernetes service account to create                                                                                                                                                                     |
+| rbac.serviceAccount.namespace   | string | `"operators"`                   | Kubernetes namespace to create the Kubernetes service account in                                                                                                                                                     |
+| replicaCount                    | int    | `1`                             | Set number of pod replicas                                                                                                                                                                                           |
+| resources.limits.cpu            | string | `"500m"`                        | seaweedfs-operator containers' cpu limit (maximum allowes CPU)                                                                                                                                                       |
+| resources.limits.memory         | string | `"500Mi"`                       | seaweedfs-operator containers' memory limit (maximum allowes memory)                                                                                                                                                 |
+| resources.requests.cpu          | string | `"100m"`                        | seaweedfs-operator containers' cpu request (how much is requested by default)                                                                                                                                        |
+| resources.requests.memory       | string | `"50Mi"`                        | seaweedfs-operator containers' memory request (how much is requested by default)                                                                                                                                     |
+| service.port                    | int    | `8080`                          | port to use for Kubernetes service                                                                                                                                                                                   |
+| service.portName                | string | `"http"`                        | name of the port to use for Kubernetes service                                                                                                                                                                       |
+| serviceMonitor.additionalLabels | object | `{}`                            | Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with                                                                                                |
+| serviceMonitor.enabled          | bool   | `true`                          | Enable or disable ServiceMonitor for prometheus metrics                                                                                                                                                              |
+| serviceMonitor.honorLabels      | bool   | `true`                          | Specify honorLabels parameter to add the scrape endpoint                                                                                                                                                             |
+| serviceMonitor.interval         | string | `"10s"`                         | Specify the interval at which metrics should be scraped                                                                                                                                                              |
+| serviceMonitor.namespace        | string | `""`                            | Specify the namespace in which the serviceMonitor resource will be created                                                                                                                                           |
+| serviceMonitor.scrapeTimeout    | string | `"10s"`                         | Specify the timeout after which the scrape is ended                                                                                                                                                                  |
+| webhook.enabled                 | bool   | `true`                          | Enable or disable webhooks                                                                                                                                                                                           |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.11.3](https://github.com/norwoodj/helm-docs/releases/v1.11.3)

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,42 +1,37 @@
-## Global Docker image parameters
-## Please, note that this will override the image parameters, including dependencies, configured to use the global value
-## Current available global Docker image parameters: imageRegistry
-##
-# global:
-#   imageRegistry: myRegistryName
+# -- Global Docker image parameters
+# Please, note that this will override the image parameters, including dependencies, configured to use the global value
+# Current available global Docker image parameters: imageRegistry
+global:
+  imageRegistry: "chrislusf"
 
-## String to partially override common.names.fullname template (will maintain the release name)
-##
-# nameOverride:
+# -- String to partially override common.names.fullname template (will maintain the release name)
+nameOverride: ""
 
-## String to fully override common.names.fullname template
-##
-# fullnameOverride:
+# -- String to fully override common.names.fullname template
+fullnameOverride: ""
 
-## Annotations for all the deployed objects
-##
-# commonAnnotations: {}
+# -- Annotations for all the deployed objects
+commonAnnotations: {}
 
-## Labels for all the deployed objects
-##
-# commonLabels: {}
+# -- Labels for all the deployed objects
+commonLabels: {}
 
-## Configure rbac parameters
-##
+## Configure Kubernetes Rbac parameters
 rbac:
   serviceAccount:
+    # -- name of the Kubernetes service account to create
     name: default
+    # -- Kubernetes namespace to create the Kubernetes service account in
     namespace: operators
 
 image:
   registry: chrislusf
   repository: seaweedfs-operator
-  ## tag value taken from appVersion of Chart.yaml
-  ## tag: 3.0.0.
-  ## Specify a imagePullPolicy
+  # -- tag of image to use. Defaults to appVersion in Chart.yaml
+  tag: ""
+  # -- Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
-  ##
   pullPolicy: Always
 
   ## Specify credentials to authorize in docker registry or set existing secrets in pullSecrets
@@ -51,65 +46,59 @@ image:
   ##
   # pullSecrets: myRegistryKeySecretName
 
-## Set number of replicas
-##
+# -- Set number of pod replicas
 replicaCount: 1
 
 ## Configure container port
-##
 port:
+  # -- name of the container port to use for the Kubernete service and ingress
   name: http
+  # -- container port number to use for the Kubernete service and ingress
   number: 8080
 
 ## Configure Service
-##
 service:
+  # -- name of the port to use for Kubernetes service
   portName: http
+  # -- port to use for Kubernetes service
   port: 8080
 
-## Enable or disable Grafana Dashboard configmap
-##
 grafanaDashboard:
+  # -- Enable or disable Grafana Dashboard configmap
   enabled: true
 
-## Enable or disable ServiceMonitor
-##
 serviceMonitor:
+  # -- Enable or disable ServiceMonitor for prometheus metrics
   enabled: true
-  ## Specify the namespace in which the serviceMonitor resource will be created
-  ##
-  # namespace: ""
-  ## Specify the interval at which metrics should be scraped
-  ##
+  # -- Specify the namespace in which the serviceMonitor resource will be created
+  namespace: ""
+  # -- Specify the interval at which metrics should be scraped
   interval: 10s
-  ## Specify the timeout after which the scrape is ended
-  ##
+  # -- Specify the timeout after which the scrape is ended
   scrapeTimeout: 10s
   ## Specify Metric Relabellings to add to the scrape endpoint
-  ##
-  ## Specify honorLabels parameter to add the scrape endpoint
-  ##
+  # -- Specify honorLabels parameter to add the scrape endpoint
   honorLabels: true
   ## Specify the release for ServiceMonitor. Sometimes it should be custom for prometheus operator to work
-  ##
   # release: ""
-  ## Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with
   ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
-  ##
+  # -- Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with
   additionalLabels: {}
 
-## Enable or disable webhooks
-##
 webhook:
+  # -- Enable or disable webhooks
   enabled: true
 
-## seaweedfs-operators containers' resource requests and limits.
+## seaweedfs-operator containers' resource requests and limits.
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-##
 resources:
   limits:
+    # -- seaweedfs-operator containers' cpu limit (maximum allowes CPU)
     cpu: 500m
+    # -- seaweedfs-operator containers' memory limit (maximum allowes memory)
     memory: 500Mi
   requests:
+    # -- seaweedfs-operator containers' cpu request (how much is requested by default)
     cpu: 100m
+    # -- seaweedfs-operator containers' memory request (how much is requested by default)
     memory: 50Mi


### PR DESCRIPTION
This PR adds some more comments to the values.yaml, bumps the chart version a patch, and sets defaults so that typing can be determined easier. I also generated a README.md in the helm chart directory to help guide users a bit easier.

I used [norwoodj/helm-docs](https://github.com/norwoodj/helm-docs) to generate the docs, which is why you see this for example:

```yaml
# -- I'm a comment
parameter: "some value"
```

The `# --` signifies that the comment should be part of the autogenerated documentation. I've also set defaults for several parameters, keeping in mind that they should be empty if they're not in use by default, as this helps the auto-generated docs determine the defaults/type of the parameter.

You can see an example of what the docs look like here on my feature branch:
https://github.com/jessebot/seaweedfs-operator/tree/add-values-docs/deploy/helm

# Additional Notes

We could use [shaybentk/helm-docs-action](https://github.com/shaybentk/helm-docs-action) to automatically generate these on pull requests.

If a user would like to use [pre-commit](https://pre-commit.com/) git hooks to generate these docs locally, they can add this to their `.pre-commit-config.yaml` file:

```yaml
repos:
  - repo: https://github.com/norwoodj/helm-docs
    rev: v1.2.0
    hooks:
      - id: helm-docs
```

If/When this is merged, it will also generate a helm chart release for the operator.

Let me know if you have questions or suggestions :+1: Happy to help!