### PR TITLE
Fix controler crash by checking if persistence is not nil

### DIFF
--- a/controllers/controller_filer_statefulset.go
+++ b/controllers/controller_filer_statefulset.go
@@ -77,7 +77,7 @@ func (r *SeaweedReconciler) createFilerStatefulSet(m *seaweedv1.Seaweed) *appsv1
 		},
 	}
 	var persistentVolumeClaims []corev1.PersistentVolumeClaim
-	if m.Spec.Filer.Persistence.Enabled {
+	if m.Spec.Filer.Persistence != nil && m.Spec.Filer.Persistence.Enabled {
 		claimName := m.Name + "-filer"
 		if m.Spec.Filer.Persistence.ExistingClaim != nil {
 			claimName = *m.Spec.Filer.Persistence.ExistingClaim


### PR DESCRIPTION
Fixes https://github.com/seaweedfs/seaweedfs-operator/issues/101

successfully tested with generated image `greenmaid/seaweedfs-operator:33793af`