### PR TITLE
Fix: "no kind ServiceMonitor is registered for version monitoring.coreos.com/v1"

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"crypto/tls"
 	"flag"
+	monitorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"os"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -48,6 +49,7 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
 	utilruntime.Must(seaweedv1.AddToScheme(scheme))
+	utilruntime.Must(monitorv1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }
 

--- a/deploy/helm/templates/rbac/role.yaml
+++ b/deploy/helm/templates/rbac/role.yaml
@@ -36,6 +36,7 @@ rules:
   - pods
   verbs:
   - get
+  - watch
   - list
 - apiGroups:
   - ""
@@ -100,6 +101,8 @@ rules:
     - servicemonitors
   verbs:
     - get
+    - list
+    - watch
     - patch
     - update
     - create

--- a/deploy/helm/templates/rbac/role.yaml
+++ b/deploy/helm/templates/rbac/role.yaml
@@ -93,3 +93,15 @@ rules:
   - get
   - patch
   - update
+{{- if .Values.serviceMonitor.enabled }}
+- apiGroups:
+    - monitoring.coreos.com
+  resources:
+    - servicemonitors
+  verbs:
+    - get
+    - patch
+    - update
+    - create
+    - delete
+{{- end }}


### PR DESCRIPTION
### What problem are we solving?

When the Metrics port is specified for the master or volume's spec in values.yaml,  the operator tries to deploy an object "ServiceMonitor" in order to notify Prometheus of the deployed probe. 

However, ServiceMonitor is a custom object that requires to be included in the operator's schema before being used (for creation or update). Currently, the operator fails when managing the object, and cannot go further:

`"error": "no kind \"ServiceMonitor\" is registered for version \"monitoring.coreos.com/v1\" in scheme \"pkg/runtime/scheme.go:100\""`

### How are we solving the problem?
We need to include the monitorv1 API Spec in the Reconciler schema at the init phase before trying to manage ServiceMonitors via Kube API
Moreover, some RBAC rules need to be included in the Chart to leverage sufficient privileges.
  