### PR TITLE
Podman for build and push steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,11 +91,11 @@ generate: controller-gen
 # Build the docker image
 docker-build: # test
 	echo ${IMG}
-	docker build . -t ${IMG}
+	${CONTAINER_TOOL} build . -t ${IMG}
 
 # Push the docker image
 docker-push:
-	docker push ${IMG}
+	${CONTAINER_TOOL} push ${IMG}
 
 # Generate bundle manifests and metadata, then validate generated files.
 bundle: manifests


### PR DESCRIPTION
This PR updates the `docker-build` and `docker-push` commands within the Makefile to respect the `CONTAINER_TOOL` variable already used elsewhere. 