### PR TITLE
Support for multi-architecture docker builds using environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,12 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # Image URL to use all building/pushing image targets
 IMG ?= ghcr.io/seaweedfs/seaweedfs-operator:$(VERSION)
 
+# Default target operating system.
+TARGETOS ?= linux
+
+# Default target architecture.
+TARGETARCH ?= $(shell go env GOARCH)
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -89,9 +95,13 @@ generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 # Build the docker image
-docker-build: # test
+.PHONY: docker-build
+docker-build:
 	echo ${IMG}
-	${CONTAINER_TOOL} build . -t ${IMG}
+	${CONTAINER_TOOL} build . -t ${IMG} \
+	  --platform ${TARGETOS}/${TARGETARCH} \
+	  --build-arg TARGETARCH=${TARGETARCH} \
+	  --build-arg TARGETOS=${TARGETOS}
 
 # Push the docker image
 docker-push:

--- a/README.md
+++ b/README.md
@@ -39,9 +39,19 @@ Lastly, change the value of `ENABLE_WEBHOOKS` to `"true"` in `config/manager/man
 Manager image must be locally built and published into a registry accessible from your k8s cluster:
 
 ```bash
-export IMG=<registry/image>
+export IMG=<registry/image:tag>
+
+# Build and push for amd64
+export TARGETARCH=amd64
+
+# Optional if you want to change TARGETOS
+# export TARGETOS=linux
+
 make docker-build
-make docker-push
+
+# Build and push for arm64
+export TARGETARCH=arm64
+make docker-build
 ```
 
 Afterwards fire up to install CRDs:


### PR DESCRIPTION
This PR makes it easier to build and deploy the SeaweedFS Operator across different architectures (like amd64 and arm64). Changes include:

- Added `TARGETARCH` and `TARGETOS` support in the Makefile
- Docker builds now pass `--platform` and `--build-arg` correctly
- Marked Makefile targets as `.PHONY` to avoid weird issues
- Updated the README:
  - Explained new build options with examples

Should make local dev + CI/CD workflows smoother, especially on arm machines.

I'm not sure about the contribution guidelines for this repo, so if you have any feedback or preferred conventions, feel free to let me know and I’ll be happy to adjust this PR accordingly.