### PR TITLE
Add platform for docker build action

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -49,5 +49,6 @@ jobs:
       with:
         context: .
         push: true
+        platforms: linux/amd64, linux/arm, linux/arm64, linux/386
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
I was trying to get the operator working on my Macbook and noticed the operator lacks a multi arch build. 
This change enables everyone to run the operator on ARM devices.