### PR TITLE
Setup qemu for cross-platform builds of the operator container image

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -19,6 +19,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Set up QEMU (for cross-platform builds)
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     - name: Login into GitHub Container Registry
       uses: docker/login-action@v2
       with:


### PR DESCRIPTION
I've tried to deploy the operator in an arm64 k3s cluster but found out that this is not supported. I hope this fixes the latest build failure and allow us to test seaweedfs :grimacing: 