### PR TITLE
Removed linux/386 to preserve compatibility with gcr.io/distroless/static:nonroot image

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -55,6 +55,6 @@ jobs:
       with:
         context: .
         push: true
-        platforms: linux/amd64, linux/arm, linux/arm64, linux/386
+        platforms: linux/amd64, linux/arm, linux/arm64
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
As we can see in: https://console.cloud.google.com/artifacts/docker/distroless/us/gcr.io/static/sha256:627d6c5a23ad24e6bdff827f16c7b60e0289029b0c79e9f7ccd54ae3279fb45f;tab=manifest?inv=1&invt=Ab2lFw 

linux/386 is not supported by gcr.io/distroless/static:nonroot image.