### PR TITLE
fix #153

### DIFF
--- a/deploy/helm/templates/webhook/job-update-webhook-certificates.yaml
+++ b/deploy/helm/templates/webhook/job-update-webhook-certificates.yaml
@@ -99,11 +99,17 @@ kind: ServiceAccount
 metadata:
   name: {{ include "seaweedfs-operator.fullname" . }}-update-webhook-certificates
   namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "seaweedfs-operator.fullname" . }}-update-webhook-certificates
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
 rules:
   - apiGroups:
       - ""
@@ -117,6 +123,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "seaweedfs-operator.fullname" . }}-update-webhook-certificates
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-9"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -130,6 +139,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "seaweedfs-operator.fullname" . }}-update-webhook-certificates
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
 rules:
   - apiGroups:
       - admissionregistration.k8s.io
@@ -144,6 +156,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "seaweedfs-operator.fullname" . }}-update-webhook-certificates
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-9"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -95,7 +95,7 @@ webhook:
   # -- Configuration for webhook certificate jobs
   initContainer:
     # -- Image for webhook readiness check init container
-    image: busybox:1.36
+    image: busybox:1.37
 
 ## seaweedfs-operator containers' resource requests and limits.
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
This PR resolves the ‘service account not found’ issue by assigning appropriate Helm weights to the individual Kubernetes objects, and also updates the BusyBox version.