### PR TITLE
Conditionally create webhook-related resources

### DIFF
--- a/deploy/helm/templates/webhook/job-update-webhook-certificates.yaml
+++ b/deploy/helm/templates/webhook/job-update-webhook-certificates.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.webhook.enabled }}
+{{- if .Values.webhook.enabled -}}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -169,4 +169,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "seaweedfs-operator.fullname" . }}-update-webhook-certificates
     namespace: {{ .Release.Namespace }}
-{{- end }}
+{{- end -}}


### PR DESCRIPTION

fix https://github.com/seaweedfs/seaweedfs-operator/issues/157

webhook-related resources (jobs, service account, roles, webhooks, and service) are only created when webhook.enabled=true.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webhook resources can now be toggled on or off via configuration, enabling flexible deployments and easier environment-specific management without code changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->