### PR TITLE
Fix Helm chart installation by correcting release URLs in workflow

### DIFF
--- a/.github/workflows/helm_chart_release.yml
+++ b/.github/workflows/helm_chart_release.yml
@@ -48,6 +48,7 @@ jobs:
           sed -i "s/appVersion: .*/appVersion: \"$TAG\"/" deploy/helm/Chart.yaml
 
       - name: Set chart version based on tag
+        id: set_chart_version
         run: |
           # Increment the chart version for each release
           CURRENT_VERSION=$(grep '^version:' deploy/helm/Chart.yaml | awk '{print $2}')
@@ -55,6 +56,7 @@ jobs:
           VERSION="$major.$minor.$((patch + 1))"
           echo "Setting chart version to: $VERSION"
           sed -i "s/version: .*/version: $VERSION/" deploy/helm/Chart.yaml
+          echo "chart_version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Checkout branch
         run: git checkout master
@@ -79,7 +81,7 @@ jobs:
       - name: Upload chart to release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.get_tag.outputs.tag }}
+          tag_name: seaweedfs-operator-${{ steps.set_chart_version.outputs.chart_version }}
           files: .cr-release-packages/*.tgz
 
       - name: Update Helm repo index
@@ -93,13 +95,13 @@ jobs:
           
           # Update index.yaml in the helm/ subdirectory (where users expect it)
           if [ -f helm/index.yaml ]; then
-            helm repo index .cr-release-packages --url https://github.com/${{ github.repository }}/releases/download/${{ steps.get_tag.outputs.tag }} --merge helm/index.yaml
+            helm repo index .cr-release-packages --url https://github.com/${{ github.repository }}/releases/download/seaweedfs-operator-${{ steps.set_chart_version.outputs.chart_version }} --merge helm/index.yaml
             cp .cr-release-packages/index.yaml helm/index.yaml
           else
-            helm repo index .cr-release-packages --url https://github.com/${{ github.repository }}/releases/download/${{ steps.get_tag.outputs.tag }}
+            helm repo index .cr-release-packages --url https://github.com/${{ github.repository }}/releases/download/seaweedfs-operator-${{ steps.set_chart_version.outputs.chart_version }}
             cp .cr-release-packages/index.yaml helm/index.yaml
           fi
           
           git add helm/index.yaml
-          git commit -m "Update Helm repo index for ${{ steps.get_tag.outputs.tag }}" || true
+          git commit -m "Update Helm repo index for seaweedfs-operator-${{ steps.set_chart_version.outputs.chart_version }}" || true
           git push origin gh-pages


### PR DESCRIPTION
This PR fixes the Helm install issue described in #163 by updating the GitHub Actions workflow for publishing Helm charts.

## Changes Made

- Modified `.github/workflows/helm_chart_release.yml` to create chart releases using the chart version tag format (`seaweedfs-operator-{version}`)
- Updated the Helm repo index update to use the correct download URLs pointing to the chart-specific releases
- Added proper step ID for the chart version setting to enable output usage

## Problem

The original workflow was uploading chart packages to app version releases (e.g., 1.0.6) but the index.yaml was pointing to non-existent URLs, causing 404 errors when users tried to install via Helm.

## Solution

By creating dedicated releases for each chart version with the format `seaweedfs-operator-{chart_version}`, the download URLs in index.yaml will always be correct and point to existing assets.

## Testing

To fix the existing broken index.yaml entry for version 0.1.5:
1. Go to the Actions tab in the repository
2. Run the "helm: publish charts" workflow manually with tag "1.0.6"
3. This will create the missing `seaweedfs-operator-0.1.5` release with the chart package
4. The index.yaml will be updated with the correct URL

Future releases will automatically have correct URLs.

Fixes #163

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Helm chart release workflow with automated version incrementing. The release process now dynamically computes and applies chart versions, ensuring consistent versioning across chart artifacts and repository updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->