### PR TITLE
Make SecurityContext configurable for webhook jobs

### DIFF
--- a/.github/workflows/helm_chart_release.yml
+++ b/.github/workflows/helm_chart_release.yml
@@ -97,13 +97,13 @@ jobs:
           # Checkout gh-pages branch
           git fetch origin gh-pages:gh-pages || true
           git checkout gh-pages || git checkout --orphan gh-pages
-          
+
           # Ensure helm directory exists
           mkdir -p helm
-          
+
           CHART_VERSION="${{ steps.set_chart_version.outputs.chart_version }}"
           RELEASE_URL="https://github.com/${{ github.repository }}/releases/download/seaweedfs-operator-${CHART_VERSION}"
-          
+
           # Update index.yaml in the helm/ subdirectory
           if [ -f helm/index.yaml ]; then
             helm repo index .cr-release-packages --url "${RELEASE_URL}" --merge helm/index.yaml
@@ -112,10 +112,10 @@ jobs:
             helm repo index .cr-release-packages --url "${RELEASE_URL}"
             cp .cr-release-packages/index.yaml helm/index.yaml
           fi
-          
+
           # Also update the root index.yaml (some users add repo without /helm suffix)
           cp helm/index.yaml index.yaml
-          
+
           git add helm/index.yaml index.yaml
           git commit -m "Update Helm repo index for seaweedfs-operator-${CHART_VERSION}" || true
           git push origin gh-pages

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -95,10 +95,31 @@ Validating webhook path
 {{- define "seaweedfs-operator.validatingWebhookPath" -}}/validate-seaweed-seaweedfs-com-v1-seaweed{{- end -}}
 
 {{/*
+Webhook Pod Security Context
+*/}}
+{{- define "seaweedfs-operator.webhookPodSecurityContext" -}}
+{{- with .Values.webhook.podSecurityContext }}
+securityContext:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Webhook Container Security Context
+*/}}
+{{- define "seaweedfs-operator.webhookContainerSecurityContext" -}}
+{{- with .Values.webhook.securityContext }}
+securityContext:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Webhook init container for waiting until webhook service is ready
 */}}
 {{- define "seaweedfs-operator.webhookWaitInitContainer" -}}
 - name: wait-for-webhook
   image: {{ .Values.webhook.initContainer.image }}
+  {{- include "seaweedfs-operator.webhookContainerSecurityContext" . | nindent 2 }}
   command: ['sh', '-c', 'set -e; until curl -sk --fail --head --max-time 5 https://{{ include "seaweedfs-operator.fullname" . }}-webhook.{{ .Release.Namespace }}.svc:443{{ .webhookPath }} >/dev/null; do echo waiting for webhook; sleep 1; done;']
 {{- end -}}

--- a/deploy/helm/templates/webhook/job-update-webhook-certificates.yaml
+++ b/deploy/helm/templates/webhook/job-update-webhook-certificates.yaml
@@ -12,9 +12,11 @@ spec:
   template:
     spec:
       serviceAccountName: {{ include "seaweedfs-operator.fullname" . }}-update-webhook-certificates
+      {{- include "seaweedfs-operator.webhookPodSecurityContext" . | nindent 6 }}
       containers:
       - name: certgen
         image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20231011-8b53cabe0
+        {{- include "seaweedfs-operator.webhookContainerSecurityContext" . | nindent 8 }}
         args:
           - create
           - --host={{ include "seaweedfs-operator.fullname" . }}-webhook,{{ include "seaweedfs-operator.fullname" . }}-webhook.{{ .Release.Namespace }}.svc
@@ -40,11 +42,13 @@ spec:
   template:
     spec:
       serviceAccountName: {{ include "seaweedfs-operator.fullname" . }}-update-webhook-certificates
+      {{- include "seaweedfs-operator.webhookPodSecurityContext" . | nindent 6 }}
       initContainers:
       {{- include "seaweedfs-operator.webhookWaitInitContainer" (dict "Chart" .Chart "Values" .Values "Release" .Release "webhookPath" (include "seaweedfs-operator.mutatingWebhookPath" .)) | nindent 8 }}
       containers:
       - name: certgen
         image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20231011-8b53cabe0
+        {{- include "seaweedfs-operator.webhookContainerSecurityContext" . | nindent 8 }}
         args:
           - patch
           - --webhook-name=mutating-webhook-configuration
@@ -53,7 +57,6 @@ spec:
           - --patch-validating=false
           - --secret-name={{ include "seaweedfs-operator.fullname" . }}-webhook-server-cert
           - --patch-failure-policy=Fail
-
         env:
           - name: POD_NAMESPACE
             valueFrom:
@@ -74,11 +77,13 @@ spec:
   template:
     spec:
       serviceAccountName: {{ include "seaweedfs-operator.fullname" . }}-update-webhook-certificates
+      {{- include "seaweedfs-operator.webhookPodSecurityContext" . | nindent 6 }}
       initContainers:
       {{- include "seaweedfs-operator.webhookWaitInitContainer" (dict "Chart" .Chart "Values" .Values "Release" .Release "webhookPath" (include "seaweedfs-operator.validatingWebhookPath" .)) | nindent 8 }}
       containers:
       - name: certgen
         image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20231011-8b53cabe0
+        {{- include "seaweedfs-operator.webhookContainerSecurityContext" . | nindent 8 }}
         args:
           - patch
           - --webhook-name=validating-webhook-configuration
@@ -87,7 +92,6 @@ spec:
           - --patch-validating=true
           - --secret-name={{ include "seaweedfs-operator.fullname" . }}-webhook-server-cert
           - --patch-failure-policy=Fail
-
         env:
           - name: POD_NAMESPACE
             valueFrom:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -96,6 +96,22 @@ webhook:
   initContainer:
     # -- Image for webhook readiness check init container
     image: curlimages/curl:8.8.0
+  # -- Pod security context for webhook jobs
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    fsGroup: 65532
+    seccompProfile:
+      type: RuntimeDefault
+  # -- Container security context for webhook jobs
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
 
 ## seaweedfs-operator containers' resource requests and limits.
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
## Summary

Fixes #165

Add configurable `podSecurityContext` and `securityContext` for webhook certificate jobs to support clusters with restrictive PodSecurity policies.

## Changes

- Add `webhook.podSecurityContext` and `webhook.securityContext` to `values.yaml`
- Update job template to use configurable security contexts for all three webhook jobs
- Update `webhookWaitInitContainer` helper to include security context for init containers

## Default Values

Default values are compliant with PodSecurity `restricted` profile:

```yaml
webhook:
  podSecurityContext:
    runAsNonRoot: true
    runAsUser: 65532
    fsGroup: 65532
    seccompProfile:
      type: RuntimeDefault
  securityContext:
    allowPrivilegeEscalation: false
    capabilities:
      drop:
      - ALL
    readOnlyRootFilesystem: true
    runAsNonRoot: true
```

## Testing

Verified templates render correctly with `helm template` command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional security context configuration for webhook components in Helm deployments
  * Webhook init container now supports pod security context settings including user privileges, filesystem groups, and seccomp profiles
  * Container-level security settings now configurable with privilege escalation controls, capability restrictions, read-only filesystem options, and runtime user configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->