### PR TITLE
Added missing namespace to namespaced resources in helm template as {{ .Release.Namespace }}

### DIFF
--- a/deploy/helm/templates/configmap-grafana-dashboard.yaml
+++ b/deploy/helm/templates/configmap-grafana-dashboard.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "seaweedfs-operator.fullname" . }}-grafana-dashboard
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "seaweedfs-operator.fullname" . }}
     grafana_dashboard: {{ include "seaweedfs-operator.fullname" . }}

--- a/deploy/helm/templates/container-registry-secret.yaml
+++ b/deploy/helm/templates/container-registry-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "seaweedfs-operator.fullname" . }}-container-registry
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "seaweedfs-operator.fullname" . }}
 type: kubernetes.io/dockerconfigjson

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "seaweedfs-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "seaweedfs-operator.labels" . | nindent 4 }}
     {{- with .Values.commonLabels }}

--- a/deploy/helm/templates/rbac/leader_election_role.yaml
+++ b/deploy/helm/templates/rbac/leader_election_role.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "seaweedfs-operator.fullname" . }}-leader-election-role
+  namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:
   - ""

--- a/deploy/helm/templates/rbac/leader_election_role_binding.yaml
+++ b/deploy/helm/templates/rbac/leader_election_role_binding.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "seaweedfs-operator.fullname" . }}-leader-election-rolebinding
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/deploy/helm/templates/service.yaml
+++ b/deploy/helm/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "seaweedfs-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "seaweedfs-operator.fullname" . }}
     app.kubernetes.io/component: metrics

--- a/deploy/helm/templates/serviceaccount.yaml
+++ b/deploy/helm/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "seaweedfs-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "seaweedfs-operator.labels" . | nindent 4 }}
   {{- with .Values.rbac.serviceAccount.annotations }}

--- a/deploy/helm/templates/servicemonitor.yaml
+++ b/deploy/helm/templates/servicemonitor.yaml
@@ -4,6 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "seaweedfs-operator.fullname" . }}-metrics-monitor
+  namespace: {{ .Release.Namespace }}
 spec:
   endpoints:
     - port: {{ .Values.service.portName }}

--- a/deploy/helm/templates/webhook/job-update-webhook-certificates.yaml
+++ b/deploy/helm/templates/webhook/job-update-webhook-certificates.yaml
@@ -112,6 +112,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "seaweedfs-operator.fullname" . }}-update-webhook-certificates
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-10"
@@ -129,6 +130,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "seaweedfs-operator.fullname" . }}-update-webhook-certificates
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-9"

--- a/deploy/helm/templates/webhook/service.yaml
+++ b/deploy/helm/templates/webhook/service.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "seaweedfs-operator.fullname" . }}-webhook
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "seaweedfs-operator.fullname" . }}
 spec:


### PR DESCRIPTION
Hello,
I was deploying seaweedfs-operator 0.1.9 with helm today using the template created with the command:
```bash
helm template seaweedfs-operator seaweedfs-operator \
    --repo https://seaweedfs.github.io/seaweedfs-operator/ \
    --version 0.1.9 \
    --namespace seaweedfs-operator \
    --set serviceMonitor.enabled=true
```
and I realized, most of the resources were deployed in `default` namespace instead of `seaweedfs-operator`. So I created this PR to add the namespace to namespaced resources I could find in the helm template. I hope I was able to cover all. Please feel free to let me know or modify if I missed any. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Helm templates updated to explicitly scope all deployed Kubernetes resources to the release namespace (services, service accounts, roles/rolebindings, deployments, secrets, configmaps, monitoring and webhook resources) to ensure consistent namespace isolation and predictable multi-namespace behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->