### PR TITLE
remove seaweedfs/service-role: peer labels #181

### DIFF
--- a/internal/controller/controller_volume_service.go
+++ b/internal/controller/controller_volume_service.go
@@ -119,7 +119,6 @@ func (r *SeaweedReconciler) createVolumeServerService(m *seaweedv1.Seaweed, i in
 
 func (r *SeaweedReconciler) createVolumeServerTopologyPeerService(m *seaweedv1.Seaweed, topologyName string) *corev1.Service {
 	labels := labelsForVolumeServerTopology(m.Name, topologyName)
-	labels["seaweedfs/service-role"] = "peer"
 	ports := []corev1.ServicePort{
 		{
 			Name:       "volume-http",

--- a/internal/controller/controller_volume_servicemonitor.go
+++ b/internal/controller/controller_volume_servicemonitor.go
@@ -34,7 +34,6 @@ func (r *SeaweedReconciler) createVolumeServerServiceMonitor(m *seaweedv1.Seawee
 
 func (r *SeaweedReconciler) createVolumeServerTopologyServiceMonitor(m *seaweedv1.Seaweed, topologyName string, topologySpec *seaweedv1.VolumeTopologySpec) *monitorv1.ServiceMonitor {
 	labels := labelsForVolumeServerTopology(m.Name, topologyName)
-	labels["seaweedfs/service-role"] = "peer"
 
 	dep := &monitorv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This PR addresses issue #181 by removing seaweedfs/service-role: peer` lable.