### PR TITLE
Honor -urlPrefix in admin pod health probes

### DIFF
--- a/internal/controller/controller_admin_servicemonitor.go
+++ b/internal/controller/controller_admin_servicemonitor.go
@@ -19,7 +19,7 @@ func (r *SeaweedReconciler) createAdminServiceMonitor(m *seaweedv1.Seaweed) *mon
 		Spec: monitorv1.ServiceMonitorSpec{
 			Endpoints: []monitorv1.Endpoint{
 				{
-					Path: "/metrics",
+					Path: adminRoutePath(m.BaseAdminSpec().ExtraArgs(), "/metrics"),
 					Port: "admin-metrics",
 				},
 			},

--- a/internal/controller/controller_admin_statefulset.go
+++ b/internal/controller/controller_admin_statefulset.go
@@ -28,16 +28,26 @@ func buildAdminStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string {
 	return strings.Join(commands, " ")
 }
 
-// extractURLPrefix scans weed ExtraArgs for a -urlPrefix flag and returns
-// its value normalized to a leading slash with no trailing slash. The weed
-// admin server honors `-urlPrefix` (and its double-dash form) to mount its
-// routes — including `/health` — under that prefix, so probes must target
-// the prefixed path or the kubelet will fail them and restart the pod.
+// adminURLPrefix scans weed admin ExtraArgs for a -urlPrefix flag and returns
+// its value normalized to a leading slash with no trailing slash. The admin
+// server mounts every route — including `/health` and `/metrics` — behind
+// `http.StripPrefix(urlPrefix, r)` when this flag is set (see upstream
+// weed/command/admin.go), so any k8s probes or ServiceMonitor endpoints must
+// target the prefixed path or they will 404.
+//
+// Parsing follows the same semantics as upstream's fla9 parser (a clone of
+// Go's `flag` package): a string flag always consumes the next arg as its
+// value when the `=` form is not used, even if that next arg looks like
+// another flag. Only a bare flag at the very end of the slice has no value.
 // Returns "" when no prefix is configured.
-func extractURLPrefix(extraArgs []string) string {
+func adminURLPrefix(extraArgs []string) string {
 	const flag = "urlPrefix"
-	var raw string
-	for i, a := range extraArgs {
+	var (
+		raw   string
+		found bool
+	)
+	for i := 0; i < len(extraArgs); i++ {
+		a := extraArgs[i]
 		if !strings.HasPrefix(a, "-") {
 			continue
 		}
@@ -46,12 +56,18 @@ func extractURLPrefix(extraArgs []string) string {
 			continue
 		}
 		if hasValue {
-			raw = value
-		} else if i+1 < len(extraArgs) && !strings.HasPrefix(extraArgs[i+1], "-") {
-			raw = extraArgs[i+1]
-		} else {
-			raw = ""
+			raw, found = value, true
+			continue
 		}
+		if i+1 < len(extraArgs) {
+			i++
+			raw, found = extraArgs[i], true
+			continue
+		}
+		raw, found = "", true
+	}
+	if !found {
+		return ""
 	}
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -63,10 +79,11 @@ func extractURLPrefix(extraArgs []string) string {
 	return strings.TrimRight(raw, "/")
 }
 
-// adminHealthPath returns the probe path for the admin server, honoring any
-// -urlPrefix supplied via ExtraArgs (see issue #204).
-func adminHealthPath(extraArgs []string) string {
-	return extractURLPrefix(extraArgs) + "/health"
+// adminRoutePath returns `route` prefixed with any `-urlPrefix` supplied via
+// the admin ExtraArgs. `route` must already start with a `/`.
+// See issue #204.
+func adminRoutePath(extraArgs []string, route string) string {
+	return adminURLPrefix(extraArgs) + route
 }
 
 func (r *SeaweedReconciler) createAdminStatefulSet(m *seaweedv1.Seaweed) *appsv1.StatefulSet {
@@ -118,7 +135,7 @@ func (r *SeaweedReconciler) createAdminStatefulSet(m *seaweedv1.Seaweed) *appsv1
 	}
 
 	extraArgs := m.BaseAdminSpec().ExtraArgs()
-	healthPath := adminHealthPath(extraArgs)
+	healthPath := adminRoutePath(extraArgs, "/health")
 
 	adminPodSpec.EnableServiceLinks = &enableServiceLinks
 	adminPodSpec.Containers = []corev1.Container{{

--- a/internal/controller/controller_admin_statefulset.go
+++ b/internal/controller/controller_admin_statefulset.go
@@ -28,6 +28,42 @@ func buildAdminStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string {
 	return strings.Join(commands, " ")
 }
 
+// extractURLPrefix scans weed ExtraArgs for a -urlPrefix flag and returns
+// its value normalized to a leading slash with no trailing slash. The weed
+// admin server honors `-urlPrefix` (and its double-dash form) to mount its
+// routes — including `/health` — under that prefix, so probes must target
+// the prefixed path or the kubelet will fail them and restart the pod.
+// Returns "" when no prefix is configured.
+func extractURLPrefix(extraArgs []string) string {
+	const flag = "urlPrefix"
+	var raw string
+	for i, a := range extraArgs {
+		name, value, hasValue := strings.Cut(strings.TrimLeft(a, "-"), "=")
+		if name != flag {
+			continue
+		}
+		if hasValue {
+			raw = value
+		} else if i+1 < len(extraArgs) {
+			raw = extraArgs[i+1]
+		}
+	}
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if !strings.HasPrefix(raw, "/") {
+		raw = "/" + raw
+	}
+	return strings.TrimRight(raw, "/")
+}
+
+// adminHealthPath returns the probe path for the admin server, honoring any
+// -urlPrefix supplied via ExtraArgs (see issue #204).
+func adminHealthPath(extraArgs []string) string {
+	return extractURLPrefix(extraArgs) + "/health"
+}
+
 func (r *SeaweedReconciler) createAdminStatefulSet(m *seaweedv1.Seaweed) *appsv1.StatefulSet {
 	labels := labelsForAdmin(m.Name)
 	annotations := m.BaseAdminSpec().Annotations()
@@ -76,6 +112,9 @@ func (r *SeaweedReconciler) createAdminStatefulSet(m *seaweedv1.Seaweed) *appsv1
 		volumeMounts = append(volumeMounts, tlsMounts...)
 	}
 
+	extraArgs := m.BaseAdminSpec().ExtraArgs()
+	healthPath := adminHealthPath(extraArgs)
+
 	adminPodSpec.EnableServiceLinks = &enableServiceLinks
 	adminPodSpec.Containers = []corev1.Container{{
 		Name:            "admin",
@@ -87,13 +126,13 @@ func (r *SeaweedReconciler) createAdminStatefulSet(m *seaweedv1.Seaweed) *appsv1
 		Command: []string{
 			"/bin/sh",
 			"-ec",
-			buildAdminStartupScript(m, m.BaseAdminSpec().ExtraArgs()...),
+			buildAdminStartupScript(m, extraArgs...),
 		},
 		Ports: ports,
 		ReadinessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
-					Path:   "/health",
+					Path:   healthPath,
 					Port:   intstr.FromInt(seaweedv1.AdminHTTPPort),
 					Scheme: corev1.URISchemeHTTP,
 				},
@@ -107,7 +146,7 @@ func (r *SeaweedReconciler) createAdminStatefulSet(m *seaweedv1.Seaweed) *appsv1
 		LivenessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
-					Path:   "/health",
+					Path:   healthPath,
 					Port:   intstr.FromInt(seaweedv1.AdminHTTPPort),
 					Scheme: corev1.URISchemeHTTP,
 				},

--- a/internal/controller/controller_admin_statefulset.go
+++ b/internal/controller/controller_admin_statefulset.go
@@ -41,7 +41,7 @@ func extractURLPrefix(extraArgs []string) string {
 		if !strings.HasPrefix(a, "-") {
 			continue
 		}
-		name, value, hasValue := strings.Cut(strings.TrimLeft(a, "-"), "=")
+		name, value, hasValue := strings.Cut(strings.TrimPrefix(strings.TrimPrefix(a, "--"), "-"), "=")
 		if name != flag {
 			continue
 		}

--- a/internal/controller/controller_admin_statefulset.go
+++ b/internal/controller/controller_admin_statefulset.go
@@ -38,14 +38,19 @@ func extractURLPrefix(extraArgs []string) string {
 	const flag = "urlPrefix"
 	var raw string
 	for i, a := range extraArgs {
+		if !strings.HasPrefix(a, "-") {
+			continue
+		}
 		name, value, hasValue := strings.Cut(strings.TrimLeft(a, "-"), "=")
 		if name != flag {
 			continue
 		}
 		if hasValue {
 			raw = value
-		} else if i+1 < len(extraArgs) {
+		} else if i+1 < len(extraArgs) && !strings.HasPrefix(extraArgs[i+1], "-") {
 			raw = extraArgs[i+1]
+		} else {
+			raw = ""
 		}
 	}
 	raw = strings.TrimSpace(raw)

--- a/internal/controller/controller_admin_statefulset_test.go
+++ b/internal/controller/controller_admin_statefulset_test.go
@@ -20,6 +20,9 @@ func TestAdminHealthPath(t *testing.T) {
 		{"empty value", []string{"-urlPrefix="}, "/health"},
 		{"last occurrence wins", []string{"-urlPrefix=/a", "-urlPrefix=/b"}, "/b/health"},
 		{"prefix among other args", []string{"-foo=bar", "-urlPrefix=/x", "-baz"}, "/x/health"},
+		{"positional urlPrefix token ignored", []string{"urlPrefix=/nope"}, "/health"},
+		{"next token is a flag", []string{"-urlPrefix", "-port=8080"}, "/health"},
+		{"trailing bare flag", []string{"-urlPrefix"}, "/health"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/controller/controller_admin_statefulset_test.go
+++ b/internal/controller/controller_admin_statefulset_test.go
@@ -2,32 +2,36 @@ package controller
 
 import "testing"
 
-func TestAdminHealthPath(t *testing.T) {
+func TestAdminRoutePath(t *testing.T) {
 	cases := []struct {
 		name      string
 		extraArgs []string
+		route     string
 		want      string
 	}{
-		{"no prefix", nil, "/health"},
-		{"empty args", []string{}, "/health"},
-		{"unrelated flag", []string{"-master=m:9333"}, "/health"},
-		{"single dash equals", []string{"-urlPrefix=/seaweedfs"}, "/seaweedfs/health"},
-		{"double dash equals", []string{"--urlPrefix=/seaweedfs"}, "/seaweedfs/health"},
-		{"space separated", []string{"-urlPrefix", "/seaweedfs"}, "/seaweedfs/health"},
-		{"missing leading slash", []string{"-urlPrefix=seaweedfs"}, "/seaweedfs/health"},
-		{"trailing slash", []string{"-urlPrefix=/seaweedfs/"}, "/seaweedfs/health"},
-		{"nested prefix", []string{"-urlPrefix=/ops/admin"}, "/ops/admin/health"},
-		{"empty value", []string{"-urlPrefix="}, "/health"},
-		{"last occurrence wins", []string{"-urlPrefix=/a", "-urlPrefix=/b"}, "/b/health"},
-		{"prefix among other args", []string{"-foo=bar", "-urlPrefix=/x", "-baz"}, "/x/health"},
-		{"positional urlPrefix token ignored", []string{"urlPrefix=/nope"}, "/health"},
-		{"next token is a flag", []string{"-urlPrefix", "-port=8080"}, "/health"},
-		{"trailing bare flag", []string{"-urlPrefix"}, "/health"},
+		{"no prefix health", nil, "/health", "/health"},
+		{"no prefix metrics", nil, "/metrics", "/metrics"},
+		{"empty args", []string{}, "/health", "/health"},
+		{"unrelated flag", []string{"-master=m:9333"}, "/health", "/health"},
+		{"single dash equals", []string{"-urlPrefix=/seaweedfs"}, "/health", "/seaweedfs/health"},
+		{"double dash equals", []string{"--urlPrefix=/seaweedfs"}, "/metrics", "/seaweedfs/metrics"},
+		{"space separated", []string{"-urlPrefix", "/seaweedfs"}, "/health", "/seaweedfs/health"},
+		{"missing leading slash", []string{"-urlPrefix=seaweedfs"}, "/health", "/seaweedfs/health"},
+		{"trailing slash", []string{"-urlPrefix=/seaweedfs/"}, "/health", "/seaweedfs/health"},
+		{"nested prefix", []string{"-urlPrefix=/ops/admin"}, "/metrics", "/ops/admin/metrics"},
+		{"empty value", []string{"-urlPrefix="}, "/health", "/health"},
+		{"last occurrence wins", []string{"-urlPrefix=/a", "-urlPrefix=/b"}, "/health", "/b/health"},
+		{"prefix among other args", []string{"-foo=bar", "-urlPrefix=/x", "-baz"}, "/health", "/x/health"},
+		{"positional urlPrefix token ignored", []string{"urlPrefix=/nope"}, "/health", "/health"},
+		// Upstream's fla9 parser (like Go's flag pkg) always consumes the next
+		// arg as the value for a string flag, so the probe must mirror that.
+		{"next token is a flag is consumed", []string{"-urlPrefix", "-port=8080"}, "/health", "/-port=8080/health"},
+		{"trailing bare flag has no value", []string{"-urlPrefix"}, "/health", "/health"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := adminHealthPath(tc.extraArgs); got != tc.want {
-				t.Errorf("adminHealthPath(%v) = %q, want %q", tc.extraArgs, got, tc.want)
+			if got := adminRoutePath(tc.extraArgs, tc.route); got != tc.want {
+				t.Errorf("adminRoutePath(%v, %q) = %q, want %q", tc.extraArgs, tc.route, got, tc.want)
 			}
 		})
 	}

--- a/internal/controller/controller_admin_statefulset_test.go
+++ b/internal/controller/controller_admin_statefulset_test.go
@@ -1,0 +1,31 @@
+package controller
+
+import "testing"
+
+func TestAdminHealthPath(t *testing.T) {
+	cases := []struct {
+		name      string
+		extraArgs []string
+		want      string
+	}{
+		{"no prefix", nil, "/health"},
+		{"empty args", []string{}, "/health"},
+		{"unrelated flag", []string{"-master=m:9333"}, "/health"},
+		{"single dash equals", []string{"-urlPrefix=/seaweedfs"}, "/seaweedfs/health"},
+		{"double dash equals", []string{"--urlPrefix=/seaweedfs"}, "/seaweedfs/health"},
+		{"space separated", []string{"-urlPrefix", "/seaweedfs"}, "/seaweedfs/health"},
+		{"missing leading slash", []string{"-urlPrefix=seaweedfs"}, "/seaweedfs/health"},
+		{"trailing slash", []string{"-urlPrefix=/seaweedfs/"}, "/seaweedfs/health"},
+		{"nested prefix", []string{"-urlPrefix=/ops/admin"}, "/ops/admin/health"},
+		{"empty value", []string{"-urlPrefix="}, "/health"},
+		{"last occurrence wins", []string{"-urlPrefix=/a", "-urlPrefix=/b"}, "/b/health"},
+		{"prefix among other args", []string{"-foo=bar", "-urlPrefix=/x", "-baz"}, "/x/health"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := adminHealthPath(tc.extraArgs); got != tc.want {
+				t.Errorf("adminHealthPath(%v) = %q, want %q", tc.extraArgs, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `internal/controller/controller_admin_statefulset.go` hardcoded `/health` for the admin readiness and liveness probes. When users pass `-urlPrefix=/seaweedfs` via `Spec.Admin.ExtraArgs` (as the upstream docs suggest), the weed admin server mounts all routes — including `/health` — under that prefix, so the kubelet's probes 404 and pods get restarted in a loop.
- Added `extractURLPrefix` / `adminHealthPath` helpers that parse ExtraArgs for a `-urlPrefix` flag (single- or double-dash, `=`- or space-separated, with or without leading slash) and apply the normalized prefix to both probe paths.
- No API/CRD changes; the prefix continues to be a pure passthrough ExtraArg.

Fixes #204.

## Test plan
- [x] `go test ./internal/controller/ -run TestAdminHealthPath` covers: no prefix, both dash forms, `=` vs space, missing leading slash, trailing slash, nested prefix, empty value, last-wins, and interleaving with unrelated flags.
- [x] `go build ./...` and `go vet ./...` clean.
- [ ] Manual: deploy a Seaweed CR with `spec.admin.extraArgs: ["-urlPrefix=/seaweedfs"]` and confirm the admin pod stays Ready instead of restart-looping.