### PR TITLE
Enable operator metrics listener

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -19,5 +19,6 @@ spec:
           name: https
       - name: manager
         args:
+          - --metrics-bind-address=127.0.0.1:8080
           - --leader-elect
           - --health-probe-bind-address=:8081

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -59,6 +59,7 @@ spec:
         - /manager
         args:
         - --leader-elect
+        - --metrics-bind-address=:{{ .Values.port.number }}
         env:
         {{- if eq .Values.webhook.enabled false }}
         - name: ENABLE_WEBHOOKS


### PR DESCRIPTION
## Summary

Fixes #207.

The Helm chart already creates a Service and optional ServiceMonitor for `/metrics`, but the operator process was only started with `--leader-elect`. Since `cmd/main.go` defaults `--metrics-bind-address` to `0`, the metrics server stayed disabled and Prometheus saw connection refused on port 8080.

This PR starts the manager metrics endpoint on the chart's configured container port and aligns the default kustomize auth-proxy patch with its `127.0.0.1:8080` upstream.

## Validation

- `helm lint deploy/helm`
- `helm template seaweedfs-operator deploy/helm --namespace seaweedfs --set serviceMonitor.enabled=true`
- `kubectl kustomize config/default`
- `go test $(go list ./... | grep -v '/test/e2e')`
- `git diff --check`

`go test ./...` reaches the e2e suite and fails before specs run because the local Docker buildx driver does not support `--output type=docker,dest=/tmp/kind-image.tar`; non-e2e package tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated metrics server binding configuration across deployment templates to explicitly specify address and port settings for container startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->