### PR TITLE
Sync Helm ClusterRole with config/rbac/role.yaml

### DIFF
--- a/deploy/helm/templates/rbac/role.yaml
+++ b/deploy/helm/templates/rbac/role.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -7,40 +6,9 @@ metadata:
   name: {{ include "seaweedfs-operator.fullname" . }}-manager-role
 rules:
 - apiGroups:
-  - apps
-  resources:
-  - statefulsets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - ""
   resources:
   - configmaps
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - watch
-  - list
-- apiGroups:
-  - ""
-  resources:
   - services
   verbs:
   - create
@@ -51,9 +19,24 @@ rules:
   - update
   - watch
 - apiGroups:
-  - extensions
+  - ""
   resources:
-  - ingresses
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
   verbs:
   - create
   - delete
@@ -63,6 +46,20 @@ rules:
   - update
   - watch
 - apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  - issuers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - extensions
   - networking.k8s.io
   resources:
   - ingresses
@@ -96,15 +93,15 @@ rules:
   - update
 {{- if .Values.serviceMonitor.enabled }}
 - apiGroups:
-    - monitoring.coreos.com
+  - monitoring.coreos.com
   resources:
-    - servicemonitors
+  - servicemonitors
   verbs:
-    - get
-    - list
-    - watch
-    - patch
-    - update
-    - create
-    - delete
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 {{- end }}


### PR DESCRIPTION
## Summary
- Syncs `deploy/helm/templates/rbac/role.yaml` with the authoritative controller-gen output in `config/rbac/role.yaml`, which had drifted.
- Adds three missing rules that the operator already requires at runtime: `apps/deployments` (the standalone S3 gateway Deployment from #200), `""/events` (event recorder), and `cert-manager.io/certificates,issuers` (mTLS between components).
- Behavior preserved: naming still uses the `seaweedfs-operator.fullname` helper and the ServiceMonitor rule stays gated behind `.Values.serviceMonitor.enabled`.

Fixes #209.

## Test plan
- [x] `helm lint deploy/helm/` passes
- [x] `helm template test deploy/helm/` renders the new rules (deployments, events, cert-manager.io)
- [x] `helm template test deploy/helm/ --set serviceMonitor.enabled=true` still includes the ServiceMonitor rule
- [ ] Confirm in a real cluster that installing the chart no longer blocks the S3 gateway Deployment on missing RBAC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes cluster role permissions to refine resource access controls and API group configurations, optimizing the deployment security model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->