### PR TITLE
Convert worker from StatefulSet to Deployment

### DIFF
--- a/internal/controller/controller_worker.go
+++ b/internal/controller/controller_worker.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -58,15 +59,38 @@ func (r *SeaweedReconciler) ensureWorkerDeployment(ctx context.Context, seaweedC
 // cleanupLegacyWorkerStatefulSet removes the StatefulSet + headless peer
 // Service that earlier operator versions created for workers. Safe to call
 // on every reconcile: both deletes are IsNotFound-tolerant.
+//
+// When a delete actually fires (i.e. the resource existed), we return
+// done=true with a short requeue so the API server can cascade the
+// StatefulSet's pod deletions before ensureWorkerDeployment runs. Without
+// the requeue, the new Deployment's selector briefly matches the
+// terminating StatefulSet pods — the Deployment scopes its own status to
+// its ReplicaSet so that part is fine, but those terminating pods keep
+// registering with admin as duplicate workers until GC completes.
 func (r *SeaweedReconciler) cleanupLegacyWorkerStatefulSet(ctx context.Context, seaweedCR *seaweedv1.Seaweed) (bool, ctrl.Result, error) {
 	name := seaweedCR.Name + "-worker"
+	deleted := false
+
 	sts := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: seaweedCR.Namespace}}
-	if err := r.Delete(ctx, sts); err != nil && !apierrors.IsNotFound(err) {
-		return ReconcileResult(err)
+	if err := r.Delete(ctx, sts); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return ReconcileResult(err)
+		}
+	} else {
+		deleted = true
 	}
+
 	peer := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: name + "-peer", Namespace: seaweedCR.Namespace}}
-	if err := r.Delete(ctx, peer); err != nil && !apierrors.IsNotFound(err) {
-		return ReconcileResult(err)
+	if err := r.Delete(ctx, peer); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return ReconcileResult(err)
+		}
+	} else {
+		deleted = true
+	}
+
+	if deleted {
+		return true, ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 	}
 	return ReconcileResult(nil)
 }

--- a/internal/controller/controller_worker.go
+++ b/internal/controller/controller_worker.go
@@ -3,9 +3,10 @@ package controller
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/runtime"
-
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -16,11 +17,16 @@ import (
 func (r *SeaweedReconciler) ensureWorkers(ctx context.Context, seaweedCR *seaweedv1.Seaweed) (done bool, result ctrl.Result, err error) {
 	_ = r.Log.WithValues("seaweed", seaweedCR.Name)
 
-	if done, result, err = r.ensureWorkerPeerService(seaweedCR); done {
+	// Clean up resources left over from the StatefulSet era: the old
+	// StatefulSet and the headless peer Service. Without this, upgrading
+	// from a pre-Deployment operator version would leave duplicate worker
+	// pods running (StatefulSet + Deployment both selecting on the same
+	// labels), all registering with admin.
+	if done, result, err = r.cleanupLegacyWorkerStatefulSet(ctx, seaweedCR); done {
 		return
 	}
 
-	if done, result, err = r.ensureWorkerStatefulSet(ctx, seaweedCR); done {
+	if done, result, err = r.ensureWorkerDeployment(ctx, seaweedCR); done {
 		return
 	}
 
@@ -37,39 +43,32 @@ func (r *SeaweedReconciler) ensureWorkers(ctx context.Context, seaweedCR *seawee
 	return
 }
 
-func (r *SeaweedReconciler) ensureWorkerStatefulSet(ctx context.Context, seaweedCR *seaweedv1.Seaweed) (bool, ctrl.Result, error) {
-	log := r.Log.WithValues("sw-worker-statefulset", seaweedCR.Name)
+func (r *SeaweedReconciler) ensureWorkerDeployment(ctx context.Context, seaweedCR *seaweedv1.Seaweed) (bool, ctrl.Result, error) {
+	log := r.Log.WithValues("sw-worker-deployment", seaweedCR.Name)
 
-	workerStatefulSet := r.createWorkerStatefulSet(seaweedCR)
-	if err := controllerutil.SetControllerReference(seaweedCR, workerStatefulSet, r.Scheme); err != nil {
+	workerDeployment := r.createWorkerDeployment(seaweedCR)
+	if err := controllerutil.SetControllerReference(seaweedCR, workerDeployment, r.Scheme); err != nil {
 		return ReconcileResult(err)
 	}
-	_, err := r.CreateOrUpdate(workerStatefulSet, func(existing, desired runtime.Object) error {
-		existingStatefulSet := existing.(*appsv1.StatefulSet)
-		desiredStatefulSet := desired.(*appsv1.StatefulSet)
-
-		existingStatefulSet.Spec.Replicas = desiredStatefulSet.Spec.Replicas
-		existingStatefulSet.Spec.Template.ObjectMeta = desiredStatefulSet.Spec.Template.ObjectMeta
-		existingStatefulSet.Spec.Template.Spec = desiredStatefulSet.Spec.Template.Spec
-
-		return r.reconcileVolumeClaimTemplates(ctx, seaweedCR, existingStatefulSet, desiredStatefulSet)
-	})
-	log.Info("ensure worker stateful set " + workerStatefulSet.Name)
+	_, err := r.CreateOrUpdateDeployment(workerDeployment)
+	log.Info("ensure worker deployment " + workerDeployment.Name)
 	return ReconcileResult(err)
 }
 
-func (r *SeaweedReconciler) ensureWorkerPeerService(seaweedCR *seaweedv1.Seaweed) (bool, ctrl.Result, error) {
-	log := r.Log.WithValues("sw-worker-peer-service", seaweedCR.Name)
-
-	workerPeerService := r.createWorkerPeerService(seaweedCR)
-	if err := controllerutil.SetControllerReference(seaweedCR, workerPeerService, r.Scheme); err != nil {
+// cleanupLegacyWorkerStatefulSet removes the StatefulSet + headless peer
+// Service that earlier operator versions created for workers. Safe to call
+// on every reconcile: both deletes are IsNotFound-tolerant.
+func (r *SeaweedReconciler) cleanupLegacyWorkerStatefulSet(ctx context.Context, seaweedCR *seaweedv1.Seaweed) (bool, ctrl.Result, error) {
+	name := seaweedCR.Name + "-worker"
+	sts := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: seaweedCR.Namespace}}
+	if err := r.Delete(ctx, sts); err != nil && !apierrors.IsNotFound(err) {
 		return ReconcileResult(err)
 	}
-
-	_, err := r.CreateOrUpdateService(workerPeerService)
-	log.Info("ensure worker peer service " + workerPeerService.Name)
-
-	return ReconcileResult(err)
+	peer := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: name + "-peer", Namespace: seaweedCR.Namespace}}
+	if err := r.Delete(ctx, peer); err != nil && !apierrors.IsNotFound(err) {
+		return ReconcileResult(err)
+	}
+	return ReconcileResult(nil)
 }
 
 func (r *SeaweedReconciler) ensureWorkerService(seaweedCR *seaweedv1.Seaweed) (bool, ctrl.Result, error) {

--- a/internal/controller/controller_worker_deployment.go
+++ b/internal/controller/controller_worker_deployment.go
@@ -47,7 +47,7 @@ func buildWorkerStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string 
 	return strings.Join(commands, " ")
 }
 
-func (r *SeaweedReconciler) createWorkerStatefulSet(m *seaweedv1.Seaweed) *appsv1.StatefulSet {
+func (r *SeaweedReconciler) createWorkerDeployment(m *seaweedv1.Seaweed) *appsv1.Deployment {
 	labels := labelsForWorker(m.Name)
 	annotations := m.BaseWorkerSpec().Annotations()
 	var ports []corev1.ContainerPort
@@ -57,50 +57,13 @@ func (r *SeaweedReconciler) createWorkerStatefulSet(m *seaweedv1.Seaweed) *appsv
 			Name:          "worker-metrics",
 		})
 	}
-	replicas := int32(m.Spec.Worker.Replicas)
-	rollingUpdatePartition := int32(0)
+	replicas := m.Spec.Worker.Replicas
 	enableServiceLinks := false
 
 	workerPodSpec := m.BaseWorkerSpec().BuildPodSpec()
 
 	var volumeMounts []corev1.VolumeMount
-
-	var persistentVolumeClaims []corev1.PersistentVolumeClaim
 	if m.Spec.Worker.Persistence != nil && m.Spec.Worker.Persistence.Enabled {
-		claimName := m.Name + "-worker"
-		if m.Spec.Worker.Persistence.ExistingClaim != nil {
-			claimName = *m.Spec.Worker.Persistence.ExistingClaim
-		}
-		if m.Spec.Worker.Persistence.ExistingClaim == nil {
-			accessModes := m.Spec.Worker.Persistence.AccessModes
-			if len(accessModes) == 0 {
-				accessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
-			}
-			persistentVolumeClaims = append(persistentVolumeClaims, corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: claimName,
-				},
-				Spec: corev1.PersistentVolumeClaimSpec{
-					AccessModes:      accessModes,
-					Resources:        m.Spec.Worker.Persistence.Resources,
-					StorageClassName: m.Spec.Worker.Persistence.StorageClassName,
-					Selector:         m.Spec.Worker.Persistence.Selector,
-					VolumeName:       m.Spec.Worker.Persistence.VolumeName,
-					VolumeMode:       m.Spec.Worker.Persistence.VolumeMode,
-					DataSource:       m.Spec.Worker.Persistence.DataSource,
-				},
-			})
-		} else {
-			workerPodSpec.Volumes = append(workerPodSpec.Volumes, corev1.Volume{
-				Name: claimName,
-				VolumeSource: corev1.VolumeSource{
-					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-						ClaimName: claimName,
-						ReadOnly:  false,
-					},
-				},
-			})
-		}
 		mountPath := "/data"
 		if m.Spec.Worker.Persistence.MountPath != nil {
 			mountPath = *m.Spec.Worker.Persistence.MountPath
@@ -109,9 +72,32 @@ func (r *SeaweedReconciler) createWorkerStatefulSet(m *seaweedv1.Seaweed) *appsv
 		if m.Spec.Worker.Persistence.SubPath != nil {
 			subPath = *m.Spec.Worker.Persistence.SubPath
 		}
+		// Deployments cannot own per-replica PVCs (no VolumeClaimTemplates
+		// equivalent). Two supported modes:
+		//   - ExistingClaim set: mount that shared PVC (caller is
+		//     responsible for RWX if replicas > 1).
+		//   - Otherwise: fall back to emptyDir so -workingDir points at a
+		//     valid scratch path. Worker state is already ephemeral
+		//     (admin re-dispatches jobs after restart), so this is the
+		//     safer default than a shared RWO PVC.
+		volumeName := "worker-data"
+		if m.Spec.Worker.Persistence.ExistingClaim != nil {
+			workerPodSpec.Volumes = append(workerPodSpec.Volumes, corev1.Volume{
+				Name: volumeName,
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: *m.Spec.Worker.Persistence.ExistingClaim,
+					},
+				},
+			})
+		} else {
+			workerPodSpec.Volumes = append(workerPodSpec.Volumes, corev1.Volume{
+				Name:         volumeName,
+				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+			})
+		}
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      claimName,
-			ReadOnly:  false,
+			Name:      volumeName,
 			MountPath: mountPath,
 			SubPath:   subPath,
 		})
@@ -171,21 +157,13 @@ func (r *SeaweedReconciler) createWorkerStatefulSet(m *seaweedv1.Seaweed) *appsv
 	workerPodSpec.EnableServiceLinks = &enableServiceLinks
 	workerPodSpec.Containers = []corev1.Container{container}
 
-	dep := &appsv1.StatefulSet{
+	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      m.Name + "-worker",
 			Namespace: m.Namespace,
 		},
-		Spec: appsv1.StatefulSetSpec{
-			ServiceName:         m.Name + "-worker-peer",
-			PodManagementPolicy: appsv1.ParallelPodManagement,
-			Replicas:            &replicas,
-			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
-				Type: appsv1.RollingUpdateStatefulSetStrategyType,
-				RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
-					Partition: &rollingUpdatePartition,
-				},
-			},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},
@@ -196,8 +174,6 @@ func (r *SeaweedReconciler) createWorkerStatefulSet(m *seaweedv1.Seaweed) *appsv
 				},
 				Spec: workerPodSpec,
 			},
-			VolumeClaimTemplates: persistentVolumeClaims,
 		},
 	}
-	return dep
 }

--- a/internal/controller/controller_worker_service.go
+++ b/internal/controller/controller_worker_service.go
@@ -8,37 +8,6 @@ import (
 	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
 )
 
-func (r *SeaweedReconciler) createWorkerPeerService(m *seaweedv1.Seaweed) *corev1.Service {
-	labels := labelsForWorker(m.Name)
-	var ports []corev1.ServicePort
-	if m.Spec.Worker.MetricsPort != nil {
-		ports = append(ports, corev1.ServicePort{
-			Name:       "worker-metrics",
-			Protocol:   corev1.Protocol("TCP"),
-			Port:       *m.Spec.Worker.MetricsPort,
-			TargetPort: intstr.FromInt(int(*m.Spec.Worker.MetricsPort)),
-		})
-	}
-
-	dep := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      m.Name + "-worker-peer",
-			Namespace: m.Namespace,
-			Labels:    labels,
-			Annotations: map[string]string{
-				"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
-			},
-		},
-		Spec: corev1.ServiceSpec{
-			ClusterIP:                "None",
-			PublishNotReadyAddresses: true,
-			Ports:                    ports,
-			Selector:                 labels,
-		},
-	}
-	return dep
-}
-
 func (r *SeaweedReconciler) createWorkerService(m *seaweedv1.Seaweed) *corev1.Service {
 	labels := labelsForWorker(m.Name)
 	var ports []corev1.ServicePort

--- a/internal/controller/seaweed_controller.go
+++ b/internal/controller/seaweed_controller.go
@@ -353,7 +353,7 @@ func (r *SeaweedReconciler) getComponentStatus(ctx context.Context, seaweedCR *s
 		}
 	case ComponentWorker:
 		if seaweedCR.Spec.Worker != nil {
-			return r.getStatefulSetStatus(ctx, seaweedCR.Namespace, seaweedCR.Name+"-worker", seaweedCR.Spec.Worker.Replicas)
+			return r.getDeploymentStatus(ctx, seaweedCR.Namespace, seaweedCR.Name+"-worker", seaweedCR.Spec.Worker.Replicas)
 		}
 	}
 	return seaweedv1.ComponentStatus{}, nil
@@ -376,6 +376,23 @@ func (r *SeaweedReconciler) getStatefulSetStatus(ctx context.Context, namespace,
 
 	// Use StatefulSet's ready replica count
 	status.ReadyReplicas = statefulSet.Status.ReadyReplicas
+	return status, nil
+}
+
+func (r *SeaweedReconciler) getDeploymentStatus(ctx context.Context, namespace, name string, desiredReplicas int32) (seaweedv1.ComponentStatus, error) {
+	status := seaweedv1.ComponentStatus{
+		Replicas: desiredReplicas,
+	}
+
+	deployment := &appsv1.Deployment{}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, deployment); err != nil {
+		if errors.IsNotFound(err) {
+			return status, nil
+		}
+		return status, err
+	}
+
+	status.ReadyReplicas = deployment.Status.ReadyReplicas
 	return status, nil
 }
 


### PR DESCRIPTION
## Summary
- Workers are stateless compute (they pull jobs from admin, no per-pod identity), so a StatefulSet was the wrong abstraction. This also aligns the operator with the upstream `seaweedfs` Helm chart, which already uses a Deployment for workers.
- Adds `cleanupLegacyWorkerStatefulSet` which deletes the old StatefulSet and the `-worker-peer` headless Service on every reconcile (both `IsNotFound`-safe). Without it, upgrading would leave pre-upgrade StatefulSet pods running alongside new Deployment pods, all registering with admin.
- Component status now reads from the Deployment via a new `getDeploymentStatus` helper sibling to `getStatefulSetStatus`.

### Breaking change — `spec.worker.persistence` without `existingClaim`
The previous StatefulSet created a per-replica PVC via `VolumeClaimTemplates`. Deployments cannot express that. When `persistence.enabled=true` and `existingClaim` is not set, the worker now mounts an `emptyDir` at the workingDir. Worker state is already ephemeral — admin re-dispatches jobs after restart — so this is the safer default than a shared RWO PVC.

Users who need durable worker storage should set `spec.worker.persistence.existingClaim` to a pre-created PVC (use RWX if replicas > 1).

## Test plan
- [x] `go build ./...` + `go vet ./...` clean
- [x] `make test` passes
- [x] `make manifests` produces no diff (RBAC markers already cover `apps/deployments`)
- [ ] Apply a `Seaweed` CR on a cluster that previously ran the StatefulSet worker; confirm the old `-worker` StatefulSet and `-worker-peer` Service are deleted and a new Deployment is created
- [ ] Apply a fresh `Seaweed` CR with `spec.worker.persistence.existingClaim` set; confirm the claim is mounted at the configured mountPath
- [ ] Apply a fresh `Seaweed` CR with `spec.worker.persistence.enabled=true` and no `existingClaim`; confirm the pod comes up with an emptyDir at the workingDir

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Worker component management now uses Kubernetes Deployments for improved flexibility and scalability
  * Automatic migration of legacy worker infrastructure with graceful requeue handling
  * Worker storage now supports both persistent volume claims and ephemeral storage options
  * Enhanced worker component status monitoring and tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->