### PR TITLE
kind-create: fall back across minors when patch search exhausted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,19 +198,23 @@ kind-create: kind yq ## Create kubernetes cluster using Kind.
 	IMAGE_TRY=$(KIND_IMAGE); \
 	if ! $(CONTAINER_TOOL) pull $$IMAGE_TRY >/dev/null 2>&1; then \
 		echo "KIND image $$IMAGE_TRY not found, searching for a published kindest/node..."; \
+		FAILED_IMAGE=$$IMAGE_TRY; \
 		V=$$(echo "$(K8S_VERSION)" | sed 's/^v//'); \
 		MAJOR=$$(echo $$V | cut -d. -f1); \
 		MINOR=$$(echo $$V | cut -d. -f2); \
 		PATCH=$$(echo $$V | cut -d. -f3 2>/dev/null || echo 0); \
+		if [ -z "$$MAJOR" ]; then MAJOR=1; fi; \
+		if [ -z "$$MINOR" ]; then MINOR=0; fi; \
 		if [ -z "$$PATCH" ]; then PATCH=0; fi; \
 		FOUND=0; \
 		MAX_MINOR_STEPBACK=3; \
 		for m_off in $$(seq 0 $$MAX_MINOR_STEPBACK); do \
-			m=$$((MINOR - m_off)); \
+			m=$$(( MINOR - m_off )); \
 			if [ $$m -lt 0 ]; then break; fi; \
 			if [ $$m_off -eq 0 ]; then p_start=$$PATCH; else p_start=20; fi; \
 			for p in $$(seq $$p_start -1 0); do \
 				try=kindest/node:v$$MAJOR.$$m.$$p; \
+				if [ "$$try" = "$$FAILED_IMAGE" ]; then continue; fi; \
 				echo "Trying $$try"; \
 				if $(CONTAINER_TOOL) pull $$try >/dev/null 2>&1; then \
 					IMAGE_TRY=$$try; FOUND=1; break 2; \

--- a/Makefile
+++ b/Makefile
@@ -197,23 +197,29 @@ kind-create: kind yq ## Create kubernetes cluster using Kind.
 	@set -e; \
 	IMAGE_TRY=$(KIND_IMAGE); \
 	if ! $(CONTAINER_TOOL) pull $$IMAGE_TRY >/dev/null 2>&1; then \
-		echo "KIND image $$IMAGE_TRY not found, attempting fallback patches..."; \
+		echo "KIND image $$IMAGE_TRY not found, searching for a published kindest/node..."; \
 		V=$$(echo "$(K8S_VERSION)" | sed 's/^v//'); \
 		MAJOR=$$(echo $$V | cut -d. -f1); \
 		MINOR=$$(echo $$V | cut -d. -f2); \
 		PATCH=$$(echo $$V | cut -d. -f3 2>/dev/null || echo 0); \
 		if [ -z "$$PATCH" ]; then PATCH=0; fi; \
 		FOUND=0; \
-		for p in $$(seq $$PATCH -1 0); do \
-			try=kindest/node:v$$MAJOR.$$MINOR.$$p; \
-			echo "Trying $$try"; \
-			if $(CONTAINER_TOOL) pull $$try >/dev/null 2>&1; then \
-				IMAGE_TRY=$$try; FOUND=1; break; \
-			fi; \
+		MAX_MINOR_STEPBACK=3; \
+		for m_off in $$(seq 0 $$MAX_MINOR_STEPBACK); do \
+			m=$$((MINOR - m_off)); \
+			if [ $$m -lt 0 ]; then break; fi; \
+			if [ $$m_off -eq 0 ]; then p_start=$$PATCH; else p_start=20; fi; \
+			for p in $$(seq $$p_start -1 0); do \
+				try=kindest/node:v$$MAJOR.$$m.$$p; \
+				echo "Trying $$try"; \
+				if $(CONTAINER_TOOL) pull $$try >/dev/null 2>&1; then \
+					IMAGE_TRY=$$try; FOUND=1; break 2; \
+				fi; \
+			done; \
 		done; \
 		if [ $$FOUND -eq 0 ]; then \
-			echo "No matching patch image found, falling back to v$$MAJOR.$$MINOR.0"; \
-			IMAGE_TRY=kindest/node:v$$MAJOR.$$MINOR.0; \
+			echo "No published kindest/node image found within $$MAX_MINOR_STEPBACK minors of $$V" >&2; \
+			exit 1; \
 		fi; \
 	fi; \
 	echo "Using KIND image: $$IMAGE_TRY"; \


### PR DESCRIPTION
## Why
`Integration Tests on k8s v1.36.0` is failing on every PR right now (#211, #213, and any future PR too) with:

> ERROR: failed to create cluster: failed to pull image \"kindest/node:v1.36.0\": command \"docker pull kindest/node:v1.36.0\" failed with error: exit status 1
> Command Output: Error response from daemon: manifest for kindest/node:v1.36.0 not found: manifest unknown: manifest unknown

The workflow's `determine-versions` step picks up the latest 3 minors from `api.github.com/repos/kubernetes/kubernetes/tags`. As soon as upstream Kubernetes tags `v1.36.0`, it lands in the matrix — but `kindest/node:v1.36.0` hasn't been published yet, so `kind create` can't start the cluster.

## Root cause
The existing `kind-create` fallback walks patch numbers within the requested minor:

```sh
for p in $(seq $PATCH -1 0); do ...
```

For `v1.Y.0`, `seq 0 -1 0` emits just `0`, so the loop retries the same image that just failed. The "No matching patch image found, falling back to v$MAJOR.$MINOR.0" branch then sets `IMAGE_TRY` to that same failing image, and `kind create --image` inherits the pull failure.

## Fix
Walk up to 3 minors back (`v1.36 → v1.35 → v1.34 → v1.33`) and scan patches `20..0` within each, stopping as soon as one pulls. Fail hard if the whole search exhausts instead of silently re-trying the missing image.

For the v1.36.0 case this probes `v1.36.0` (fails fast on manifest-unknown), then walks `v1.35.{20..0}` until hitting a published tag — typically within the first few probes.

## Test plan
- [x] `make -n kind-create` produces valid shell (syntax-checked with `sh -n`)
- [x] Traced the loop for `K8S_VERSION=v1.36.0` — probes the expected sequence
- [ ] Merge + observe that Integration Tests on k8s v1.36.0 now succeeds on a subsequent PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kind cluster creation robustness by enhancing image selection logic to search across multiple available Kubernetes versions when the requested image is unavailable. The system now checks previous minor versions with various patch levels and provides clearer error reporting when no suitable image is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->