### PR TITLE
fix(admin): forward credentialsSecret to weed admin env variables

### DIFF
--- a/api/v1/seaweed_types.go
+++ b/api/v1/seaweed_types.go
@@ -548,7 +548,11 @@ type AdminSpec struct {
 	MetricsPort *int32 `json:"metricsPort,omitempty"`
 
 	// CredentialsSecret is a reference to a Secret containing admin credentials.
-	// The secret should have keys: adminUser, adminPassword, and optionally readOnlyUser, readOnlyPassword
+	// The secret should have keys: adminUser, adminPassword, and optionally readOnlyUser, readOnlyPassword.
+	// Each value is forwarded to `weed admin` as `-<key>=<value>` at container
+	// start, with trailing newlines stripped. Values must not contain embedded
+	// newlines — the operator passes them through to weed's flag parser as-is
+	// and a multi-line value will be interpreted as a single malformed flag.
 	CredentialsSecret *corev1.LocalObjectReference `json:"credentialsSecret,omitempty"`
 
 	// Ingress configuration for the admin UI HTTP port.

--- a/api/v1/seaweed_types.go
+++ b/api/v1/seaweed_types.go
@@ -548,11 +548,13 @@ type AdminSpec struct {
 	MetricsPort *int32 `json:"metricsPort,omitempty"`
 
 	// CredentialsSecret is a reference to a Secret containing admin credentials.
-	// The secret should have keys: adminUser, adminPassword, and optionally readOnlyUser, readOnlyPassword.
-	// Each value is forwarded to `weed admin` as `-<key>=<value>` at container
-	// start, with trailing newlines stripped. Values must not contain embedded
-	// newlines — the operator passes them through to weed's flag parser as-is
-	// and a multi-line value will be interpreted as a single malformed flag.
+	// The secret should have keys: adminUser, adminPassword, and optionally
+	// readOnlyUser, readOnlyPassword. Each key is projected into the admin
+	// pod as the env var weed admin reads for it — WEED_ADMIN_USER,
+	// WEED_ADMIN_PASSWORD, WEED_ADMIN_READONLY_USER, WEED_ADMIN_READONLY_PASSWORD
+	// respectively — using optional secretKeyRefs, so missing optional keys
+	// do not block pod startup. Secret updates require a pod restart to take
+	// effect.
 	CredentialsSecret *corev1.LocalObjectReference `json:"credentialsSecret,omitempty"`
 
 	// Ingress configuration for the admin UI HTTP port.

--- a/internal/controller/controller_admin_statefulset.go
+++ b/internal/controller/controller_admin_statefulset.go
@@ -12,18 +12,54 @@ import (
 	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
 )
 
-// adminCredentialsMountPath is the in-pod directory where the admin
-// CredentialsSecret is projected by createAdminStatefulSet; each key in
-// the secret becomes a file named after the key.
-const adminCredentialsMountPath = "/etc/sw/admin"
+// adminCredentialEnvMappings maps each well-known key in the admin
+// CredentialsSecret to the env var that weed admin reads for it. weed admin
+// accepts credentials via env vars (see upstream weed/command/admin.go);
+// using them avoids a shell preamble and lets secret values contain any
+// bytes (spaces, newlines, quotes) without escaping concerns.
+// adminUser/adminPassword enable the login flow; readOnlyUser and
+// readOnlyPassword are optional view-only accounts.
+var adminCredentialEnvMappings = []struct {
+	secretKey string
+	envName   string
+}{
+	{"adminUser", "WEED_ADMIN_USER"},
+	{"adminPassword", "WEED_ADMIN_PASSWORD"},
+	{"readOnlyUser", "WEED_ADMIN_READONLY_USER"},
+	{"readOnlyPassword", "WEED_ADMIN_READONLY_PASSWORD"},
+}
 
-// adminCredentialKeys are the well-known keys that weed admin accepts as
-// `-<key>=<value>` flags. adminUser/adminPassword enable the login flow,
-// readOnlyUser/readOnlyPassword are optional read-only accounts.
-var adminCredentialKeys = []string{"adminUser", "adminPassword", "readOnlyUser", "readOnlyPassword"}
+// adminCredentialEnvVars projects the configured CredentialsSecret into the
+// env vars weed admin reads. Each mapping is marked optional so users can
+// supply only adminUser/adminPassword (or additionally the read-only pair)
+// without tripping pod startup on missing keys.
+func adminCredentialEnvVars(m *seaweedv1.Seaweed) []corev1.EnvVar {
+	if m.Spec.Admin.CredentialsSecret == nil || m.Spec.Admin.CredentialsSecret.Name == "" {
+		return nil
+	}
+	optional := true
+	envs := make([]corev1.EnvVar, 0, len(adminCredentialEnvMappings))
+	for _, mapping := range adminCredentialEnvMappings {
+		envs = append(envs, corev1.EnvVar{
+			Name: mapping.envName,
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: m.Spec.Admin.CredentialsSecret.Name,
+					},
+					Key:      mapping.secretKey,
+					Optional: &optional,
+				},
+			},
+		})
+	}
+	return envs
+}
 
 func buildAdminStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string {
-	commands := []string{"weed", "-logtostderr=true"}
+	// `exec` replaces the /bin/sh wrapper with weed so SIGTERM from the
+	// kubelet reaches weed directly and termination stays prompt.
+	commands := []string{"exec", "weed", "-logtostderr=true"}
 	if arg := tlsConfigDirArg(m); arg != "" {
 		commands = append(commands, arg)
 	}
@@ -35,27 +71,7 @@ func buildAdminStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string {
 	}
 	commands = append(commands, extraArgs...)
 
-	weedCmd := strings.Join(commands, " ")
-
-	// `exec` replaces the /bin/sh wrapper with the weed process so SIGTERM
-	// from the kubelet reaches weed directly and pod termination stays
-	// prompt. When a CredentialsSecret is mounted, resolve each well-known
-	// key from the projected files into `-<key>=<value>` flags at container
-	// start so weed admin boots with authentication enabled. Keys with no
-	// file on disk are skipped, keeping readOnlyUser/readOnlyPassword
-	// optional. The loop uses positional params (`set --` / `"$@"`) so
-	// credential values containing spaces or other shell metacharacters
-	// survive unsplit.
-	if m.Spec.Admin.CredentialsSecret != nil && m.Spec.Admin.CredentialsSecret.Name != "" {
-		preamble := "set --; " +
-			"for key in " + strings.Join(adminCredentialKeys, " ") + "; do " +
-			`f="` + adminCredentialsMountPath + `/$key"; ` +
-			`[ -f "$f" ] && set -- "$@" "-$key=$(cat "$f")"; ` +
-			"done; "
-		return preamble + "exec " + weedCmd + ` "$@"`
-	}
-
-	return "exec " + weedCmd
+	return strings.Join(commands, " ")
 }
 
 // adminURLPrefix scans weed admin ExtraArgs for a -urlPrefix flag and returns
@@ -142,23 +158,6 @@ func (r *SeaweedReconciler) createAdminStatefulSet(m *seaweedv1.Seaweed) *appsv1
 	adminPodSpec := m.BaseAdminSpec().BuildPodSpec()
 
 	var volumeMounts []corev1.VolumeMount
-
-	// Mount credentials secret if provided
-	if m.Spec.Admin.CredentialsSecret != nil && m.Spec.Admin.CredentialsSecret.Name != "" {
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      "admin-credentials",
-			ReadOnly:  true,
-			MountPath: adminCredentialsMountPath,
-		})
-		adminPodSpec.Volumes = append(adminPodSpec.Volumes, corev1.Volume{
-			Name: "admin-credentials",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: m.Spec.Admin.CredentialsSecret.Name,
-				},
-			},
-		})
-	}
 	if tlsVols, tlsMounts := tlsVolumesAndMounts(m); len(tlsVols) > 0 {
 		adminPodSpec.Volumes = append(adminPodSpec.Volumes, tlsVols...)
 		volumeMounts = append(volumeMounts, tlsMounts...)
@@ -167,12 +166,18 @@ func (r *SeaweedReconciler) createAdminStatefulSet(m *seaweedv1.Seaweed) *appsv1
 	extraArgs := m.BaseAdminSpec().ExtraArgs()
 	healthPath := adminRoutePath(extraArgs, "/health")
 
+	// Credentials from spec.admin.credentialsSecret are projected as env vars
+	// (WEED_ADMIN_USER / WEED_ADMIN_PASSWORD / WEED_ADMIN_READONLY_USER /
+	// WEED_ADMIN_READONLY_PASSWORD) which weed admin reads natively.
+	env := append(m.BaseAdminSpec().Env(), kubernetesEnvVars...)
+	env = append(env, adminCredentialEnvVars(m)...)
+
 	adminPodSpec.EnableServiceLinks = &enableServiceLinks
 	adminPodSpec.Containers = []corev1.Container{{
 		Name:            "admin",
 		Image:           m.Spec.Image,
 		ImagePullPolicy: m.BaseAdminSpec().ImagePullPolicy(),
-		Env:             append(m.BaseAdminSpec().Env(), kubernetesEnvVars...),
+		Env:             env,
 		Resources:       filterContainerResources(m.Spec.Admin.ResourceRequirements),
 		VolumeMounts:    mergeVolumeMounts(volumeMounts, m.BaseAdminSpec().VolumeMounts()),
 		Command: []string{

--- a/internal/controller/controller_admin_statefulset.go
+++ b/internal/controller/controller_admin_statefulset.go
@@ -37,12 +37,15 @@ func buildAdminStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string {
 
 	weedCmd := strings.Join(commands, " ")
 
-	// When a CredentialsSecret is mounted, resolve each well-known key from
-	// the projected files into `-<key>=<value>` flags at container start, so
-	// weed admin boots with authentication enabled. Keys with no file on disk
-	// are skipped, keeping readOnlyUser/readOnlyPassword optional. Using
-	// `set --` keeps values with spaces or special characters quoted safely
-	// when they expand via `"$@"`.
+	// `exec` replaces the /bin/sh wrapper with the weed process so SIGTERM
+	// from the kubelet reaches weed directly and pod termination stays
+	// prompt. When a CredentialsSecret is mounted, resolve each well-known
+	// key from the projected files into `-<key>=<value>` flags at container
+	// start so weed admin boots with authentication enabled. Keys with no
+	// file on disk are skipped, keeping readOnlyUser/readOnlyPassword
+	// optional. The loop uses positional params (`set --` / `"$@"`) so
+	// credential values containing spaces or other shell metacharacters
+	// survive unsplit.
 	if m.Spec.Admin.CredentialsSecret != nil && m.Spec.Admin.CredentialsSecret.Name != "" {
 		preamble := "set --; " +
 			"for key in " + strings.Join(adminCredentialKeys, " ") + "; do " +
@@ -52,7 +55,7 @@ func buildAdminStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string {
 		return preamble + "exec " + weedCmd + ` "$@"`
 	}
 
-	return weedCmd
+	return "exec " + weedCmd
 }
 
 // adminURLPrefix scans weed admin ExtraArgs for a -urlPrefix flag and returns

--- a/internal/controller/controller_admin_statefulset.go
+++ b/internal/controller/controller_admin_statefulset.go
@@ -12,6 +12,16 @@ import (
 	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
 )
 
+// adminCredentialsMountPath is the in-pod directory where the admin
+// CredentialsSecret is projected by createAdminStatefulSet; each key in
+// the secret becomes a file named after the key.
+const adminCredentialsMountPath = "/etc/sw/admin"
+
+// adminCredentialKeys are the well-known keys that weed admin accepts as
+// `-<key>=<value>` flags. adminUser/adminPassword enable the login flow,
+// readOnlyUser/readOnlyPassword are optional read-only accounts.
+var adminCredentialKeys = []string{"adminUser", "adminPassword", "readOnlyUser", "readOnlyPassword"}
+
 func buildAdminStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string {
 	commands := []string{"weed", "-logtostderr=true"}
 	if arg := tlsConfigDirArg(m); arg != "" {
@@ -25,7 +35,24 @@ func buildAdminStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string {
 	}
 	commands = append(commands, extraArgs...)
 
-	return strings.Join(commands, " ")
+	weedCmd := strings.Join(commands, " ")
+
+	// When a CredentialsSecret is mounted, resolve each well-known key from
+	// the projected files into `-<key>=<value>` flags at container start, so
+	// weed admin boots with authentication enabled. Keys with no file on disk
+	// are skipped, keeping readOnlyUser/readOnlyPassword optional. Using
+	// `set --` keeps values with spaces or special characters quoted safely
+	// when they expand via `"$@"`.
+	if m.Spec.Admin.CredentialsSecret != nil && m.Spec.Admin.CredentialsSecret.Name != "" {
+		preamble := "set --; " +
+			"for key in " + strings.Join(adminCredentialKeys, " ") + "; do " +
+			`f="` + adminCredentialsMountPath + `/$key"; ` +
+			`[ -f "$f" ] && set -- "$@" "-$key=$(cat "$f")"; ` +
+			"done; "
+		return preamble + "exec " + weedCmd + ` "$@"`
+	}
+
+	return weedCmd
 }
 
 // adminURLPrefix scans weed admin ExtraArgs for a -urlPrefix flag and returns
@@ -118,7 +145,7 @@ func (r *SeaweedReconciler) createAdminStatefulSet(m *seaweedv1.Seaweed) *appsv1
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      "admin-credentials",
 			ReadOnly:  true,
-			MountPath: "/etc/sw/admin",
+			MountPath: adminCredentialsMountPath,
 		})
 		adminPodSpec.Volumes = append(adminPodSpec.Volumes, corev1.Volume{
 			Name: "admin-credentials",

--- a/internal/controller/controller_admin_statefulset_test.go
+++ b/internal/controller/controller_admin_statefulset_test.go
@@ -1,6 +1,14 @@
 package controller
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+)
 
 func TestAdminRoutePath(t *testing.T) {
 	cases := []struct {
@@ -35,4 +43,69 @@ func TestAdminRoutePath(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildAdminStartupScript(t *testing.T) {
+	baseSpec := func() *seaweedv1.Seaweed {
+		return &seaweedv1.Seaweed{
+			ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
+			Spec: seaweedv1.SeaweedSpec{
+				Master: &seaweedv1.MasterSpec{Replicas: 1},
+				Admin:  &seaweedv1.AdminSpec{},
+			},
+		}
+	}
+
+	t.Run("no credentials secret leaves weed command unchanged", func(t *testing.T) {
+		got := buildAdminStartupScript(baseSpec())
+		if strings.Contains(got, "/etc/sw/admin") || strings.Contains(got, "exec weed") {
+			t.Fatalf("unexpected credential wiring in script: %q", got)
+		}
+		if !strings.HasPrefix(got, "weed -logtostderr=true admin ") {
+			t.Fatalf("expected plain weed command, got %q", got)
+		}
+	})
+
+	t.Run("credentials secret injects credential flags via mount", func(t *testing.T) {
+		m := baseSpec()
+		m.Spec.Admin.CredentialsSecret = &corev1.LocalObjectReference{Name: "admin-creds"}
+
+		got := buildAdminStartupScript(m, "-urlPrefix=/admin")
+
+		// Preamble loops over every well-known key and appends `-<key>=<value>`
+		// only when the projected file exists.
+		for _, key := range adminCredentialKeys {
+			if !strings.Contains(got, key) {
+				t.Errorf("script missing key %q: %q", key, got)
+			}
+		}
+		if !strings.Contains(got, `f="/etc/sw/admin/$key"`) {
+			t.Errorf("script missing mount-path file lookup: %q", got)
+		}
+		if !strings.Contains(got, `[ -f "$f" ] && set -- "$@" "-$key=$(cat "$f")"`) {
+			t.Errorf("script missing conditional flag append: %q", got)
+		}
+		// exec replaces the shell with weed so signals propagate, and the
+		// positional params populated by the loop must be expanded last.
+		if !strings.Contains(got, `exec weed -logtostderr=true admin `) {
+			t.Errorf("script missing exec'd weed command: %q", got)
+		}
+		if !strings.HasSuffix(got, ` "$@"`) {
+			t.Errorf("script must end by expanding credential flags via \"$@\": %q", got)
+		}
+		// Operator-supplied extra args must still appear before "$@" so the
+		// dynamic credential flags remain the final tokens.
+		if !strings.Contains(got, "-urlPrefix=/admin ") {
+			t.Errorf("script should include extra args before \"$@\": %q", got)
+		}
+	})
+
+	t.Run("empty secret name is treated as unset", func(t *testing.T) {
+		m := baseSpec()
+		m.Spec.Admin.CredentialsSecret = &corev1.LocalObjectReference{Name: ""}
+		got := buildAdminStartupScript(m)
+		if strings.Contains(got, "/etc/sw/admin") {
+			t.Fatalf("expected no credential wiring for empty secret name: %q", got)
+		}
+	})
 }

--- a/internal/controller/controller_admin_statefulset_test.go
+++ b/internal/controller/controller_admin_statefulset_test.go
@@ -56,13 +56,15 @@ func TestBuildAdminStartupScript(t *testing.T) {
 		}
 	}
 
-	t.Run("no credentials secret leaves weed command unchanged", func(t *testing.T) {
+	t.Run("no credentials secret execs weed directly", func(t *testing.T) {
 		got := buildAdminStartupScript(baseSpec())
-		if strings.Contains(got, "/etc/sw/admin") || strings.Contains(got, "exec weed") {
+		if strings.Contains(got, "/etc/sw/admin") {
 			t.Fatalf("unexpected credential wiring in script: %q", got)
 		}
-		if !strings.HasPrefix(got, "weed -logtostderr=true admin ") {
-			t.Fatalf("expected plain weed command, got %q", got)
+		// `exec` is required so SIGTERM from the kubelet reaches weed
+		// instead of the /bin/sh wrapper.
+		if !strings.HasPrefix(got, "exec weed -logtostderr=true admin ") {
+			t.Fatalf("expected exec'd weed command, got %q", got)
 		}
 	})
 

--- a/internal/controller/controller_admin_statefulset_test.go
+++ b/internal/controller/controller_admin_statefulset_test.go
@@ -46,6 +46,25 @@ func TestAdminRoutePath(t *testing.T) {
 }
 
 func TestBuildAdminStartupScript(t *testing.T) {
+	m := &seaweedv1.Seaweed{
+		ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
+		Spec: seaweedv1.SeaweedSpec{
+			Master: &seaweedv1.MasterSpec{Replicas: 1},
+			Admin:  &seaweedv1.AdminSpec{},
+		},
+	}
+	got := buildAdminStartupScript(m, "-urlPrefix=/admin")
+	// `exec` must prefix weed so SIGTERM from the kubelet reaches weed
+	// instead of the /bin/sh wrapper.
+	if !strings.HasPrefix(got, "exec weed -logtostderr=true admin ") {
+		t.Fatalf("expected exec'd weed command, got %q", got)
+	}
+	if !strings.Contains(got, "-urlPrefix=/admin") {
+		t.Fatalf("expected extra args to be included, got %q", got)
+	}
+}
+
+func TestAdminCredentialEnvVars(t *testing.T) {
 	baseSpec := func() *seaweedv1.Seaweed {
 		return &seaweedv1.Seaweed{
 			ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
@@ -56,58 +75,49 @@ func TestBuildAdminStartupScript(t *testing.T) {
 		}
 	}
 
-	t.Run("no credentials secret execs weed directly", func(t *testing.T) {
-		got := buildAdminStartupScript(baseSpec())
-		if strings.Contains(got, "/etc/sw/admin") {
-			t.Fatalf("unexpected credential wiring in script: %q", got)
-		}
-		// `exec` is required so SIGTERM from the kubelet reaches weed
-		// instead of the /bin/sh wrapper.
-		if !strings.HasPrefix(got, "exec weed -logtostderr=true admin ") {
-			t.Fatalf("expected exec'd weed command, got %q", got)
+	t.Run("no credentials secret yields no env vars", func(t *testing.T) {
+		if got := adminCredentialEnvVars(baseSpec()); got != nil {
+			t.Fatalf("expected nil env vars, got %+v", got)
 		}
 	})
 
-	t.Run("credentials secret injects credential flags via mount", func(t *testing.T) {
+	t.Run("empty secret name yields no env vars", func(t *testing.T) {
+		m := baseSpec()
+		m.Spec.Admin.CredentialsSecret = &corev1.LocalObjectReference{Name: ""}
+		if got := adminCredentialEnvVars(m); got != nil {
+			t.Fatalf("expected nil env vars, got %+v", got)
+		}
+	})
+
+	t.Run("credentials secret projects every key as optional secretKeyRef", func(t *testing.T) {
 		m := baseSpec()
 		m.Spec.Admin.CredentialsSecret = &corev1.LocalObjectReference{Name: "admin-creds"}
 
-		got := buildAdminStartupScript(m, "-urlPrefix=/admin")
-
-		// Preamble loops over every well-known key and appends `-<key>=<value>`
-		// only when the projected file exists.
-		for _, key := range adminCredentialKeys {
-			if !strings.Contains(got, key) {
-				t.Errorf("script missing key %q: %q", key, got)
+		got := adminCredentialEnvVars(m)
+		if len(got) != len(adminCredentialEnvMappings) {
+			t.Fatalf("expected %d env vars, got %d: %+v", len(adminCredentialEnvMappings), len(got), got)
+		}
+		for i, mapping := range adminCredentialEnvMappings {
+			ev := got[i]
+			if ev.Name != mapping.envName {
+				t.Errorf("env[%d]: got name %q, want %q", i, ev.Name, mapping.envName)
 			}
-		}
-		if !strings.Contains(got, `f="/etc/sw/admin/$key"`) {
-			t.Errorf("script missing mount-path file lookup: %q", got)
-		}
-		if !strings.Contains(got, `[ -f "$f" ] && set -- "$@" "-$key=$(cat "$f")"`) {
-			t.Errorf("script missing conditional flag append: %q", got)
-		}
-		// exec replaces the shell with weed so signals propagate, and the
-		// positional params populated by the loop must be expanded last.
-		if !strings.Contains(got, `exec weed -logtostderr=true admin `) {
-			t.Errorf("script missing exec'd weed command: %q", got)
-		}
-		if !strings.HasSuffix(got, ` "$@"`) {
-			t.Errorf("script must end by expanding credential flags via \"$@\": %q", got)
-		}
-		// Operator-supplied extra args must still appear before "$@" so the
-		// dynamic credential flags remain the final tokens.
-		if !strings.Contains(got, "-urlPrefix=/admin ") {
-			t.Errorf("script should include extra args before \"$@\": %q", got)
-		}
-	})
-
-	t.Run("empty secret name is treated as unset", func(t *testing.T) {
-		m := baseSpec()
-		m.Spec.Admin.CredentialsSecret = &corev1.LocalObjectReference{Name: ""}
-		got := buildAdminStartupScript(m)
-		if strings.Contains(got, "/etc/sw/admin") {
-			t.Fatalf("expected no credential wiring for empty secret name: %q", got)
+			if ev.ValueFrom == nil || ev.ValueFrom.SecretKeyRef == nil {
+				t.Fatalf("env[%d] (%s): missing SecretKeyRef", i, mapping.envName)
+			}
+			ref := ev.ValueFrom.SecretKeyRef
+			if ref.Name != "admin-creds" {
+				t.Errorf("env[%d]: secret name %q, want %q", i, ref.Name, "admin-creds")
+			}
+			if ref.Key != mapping.secretKey {
+				t.Errorf("env[%d]: secret key %q, want %q", i, ref.Key, mapping.secretKey)
+			}
+			// Every mapping is optional so users can supply only
+			// adminUser/adminPassword without pod startup failing on the
+			// missing read-only keys.
+			if ref.Optional == nil || !*ref.Optional {
+				t.Errorf("env[%d] (%s): SecretKeyRef.Optional must be true", i, mapping.envName)
+			}
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- Resolves #215 — `spec.admin.credentialsSecret` was mounted at `/etc/sw/admin` but its keys were never passed to `weed admin`, so the UI always booted with `Authentication: Disabled`.
- `buildAdminStartupScript` now prepends a POSIX-sh loop that reads each well-known key (`adminUser`, `adminPassword`, `readOnlyUser`, `readOnlyPassword`) from the projected mount and appends `-<key>=<value>` to `"$@"`, then `exec`s `weed admin ... "$@"`.
- Missing files are skipped so `readOnlyUser`/`readOnlyPassword` stay optional; `"$@"` expansion keeps values with spaces or special characters intact.
- Replaced the hardcoded mount path with a shared `adminCredentialsMountPath` constant so the script and the `VolumeMount` can never drift.

## Test plan
- [x] `go test ./internal/controller/ -run TestBuildAdminStartupScript -v`
- [x] `go test ./internal/... ./api/...`
- [x] `go vet ./...`
- [ ] Deploy a `Seaweed` CR with `spec.admin.credentialsSecret` populated (keys `adminUser`/`adminPassword`) and confirm the admin pod logs now report `Authentication: Enabled` and that the login page is gated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Admin startup command now conditionally handles credential files from mounted secrets, applying corresponding flags to the admin invocation only when files exist.

* **Tests**
  * Added comprehensive test suite for admin startup script generation across multiple credential scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->