### PR TITLE
Apply nodeSelector/tolerations/affinity to webhook hook jobs

### DIFF
--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -115,6 +115,26 @@ securityContext:
 {{- end -}}
 
 {{/*
+Pod scheduling constraints (nodeSelector, affinity, tolerations) shared by
+the operator Deployment and the helm-managed webhook certificate Jobs so a
+single set of values controls where every operator-produced pod runs.
+*/}}
+{{- define "seaweedfs-operator.scheduling" -}}
+{{- with .Values.nodeSelector }}
+nodeSelector:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .Values.affinity }}
+affinity:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .Values.tolerations }}
+tolerations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Webhook init container for waiting until webhook service is ready
 */}}
 {{- define "seaweedfs-operator.webhookWaitInitContainer" -}}

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -35,18 +35,7 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "seaweedfs-operator.scheduling" . | nindent 6 }}
       containers:
       - name: seaweedfs-operator
         {{- with .Values.securityContext }}

--- a/deploy/helm/templates/webhook/job-update-webhook-certificates.yaml
+++ b/deploy/helm/templates/webhook/job-update-webhook-certificates.yaml
@@ -17,6 +17,7 @@ spec:
       {{ end }}
       serviceAccountName: {{ include "seaweedfs-operator.fullname" . }}-update-webhook-certificates
       {{- include "seaweedfs-operator.webhookPodSecurityContext" . | nindent 6 }}
+      {{- include "seaweedfs-operator.scheduling" . | nindent 6 }}
       containers:
       - name: certgen
         image: {{ .Values.webhook.certgen.registry }}/{{ .Values.webhook.certgen.repository }}:{{ .Values.webhook.certgen.tag }}
@@ -51,6 +52,7 @@ spec:
       {{ end }}
       serviceAccountName: {{ include "seaweedfs-operator.fullname" . }}-update-webhook-certificates
       {{- include "seaweedfs-operator.webhookPodSecurityContext" . | nindent 6 }}
+      {{- include "seaweedfs-operator.scheduling" . | nindent 6 }}
       initContainers:
       {{- include "seaweedfs-operator.webhookWaitInitContainer" (dict "Chart" .Chart "Values" .Values "Release" .Release "webhookPath" (include "seaweedfs-operator.mutatingWebhookPath" .)) | nindent 8 }}
       containers:
@@ -90,6 +92,7 @@ spec:
       {{ end }}
       serviceAccountName: {{ include "seaweedfs-operator.fullname" . }}-update-webhook-certificates
       {{- include "seaweedfs-operator.webhookPodSecurityContext" . | nindent 6 }}
+      {{- include "seaweedfs-operator.scheduling" . | nindent 6 }}
       initContainers:
       {{- include "seaweedfs-operator.webhookWaitInitContainer" (dict "Chart" .Chart "Values" .Values "Release" .Release "webhookPath" (include "seaweedfs-operator.validatingWebhookPath" .)) | nindent 8 }}
       containers:


### PR DESCRIPTION
## Summary
- Extract the operator pod's scheduling block (`nodeSelector`/`affinity`/`tolerations`) into a shared `seaweedfs-operator.scheduling` helper
- Include the helper in the three webhook certgen helm-hook Jobs (`create`, `patch-mutating`, `patch-validating`) so they respect the same `Values.nodeSelector`/`tolerations`/`affinity` as the operator Deployment

The operator Deployment already honored these values, but the pre/post-install webhook hook pods did not — so users pinning the operator to a particular node pool (or running on a tainted cluster) saw those hook pods schedule elsewhere or fail. With this change a single set of values controls every pod the chart produces.

Fixes #128

## Test plan
- [x] `helm template seaweedfs-operator deploy/helm` with default values renders no `nodeSelector`/`tolerations`/`affinity` keys on the Deployment or any Job
- [x] `helm template ... --set 'nodeSelector.disktype=ssd' --set 'tolerations[0].key=foo,tolerations[0].operator=Exists'` renders the keys identically on the Deployment and on all three webhook Jobs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated Kubernetes pod scheduling configuration across deployment and webhook templates into a shared reusable template for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->