### PR TITLE
Add Bucket reconciler

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -136,6 +136,16 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = (&controller.BucketReconciler{
+		Client:   mgr.GetClient(),
+		Log:      ctrl.Log.WithName("controller").WithName("Bucket"),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("bucket-controller"),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "Bucket")
+		os.Exit(1)
+	}
+
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		if err = (&seaweedv1.Seaweed{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "Seaweed")

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -85,6 +85,7 @@ rules:
 - apiGroups:
   - seaweed.seaweedfs.com
   resources:
+  - buckets
   - seaweeds
   verbs:
   - create
@@ -97,6 +98,13 @@ rules:
 - apiGroups:
   - seaweed.seaweedfs.com
   resources:
+  - buckets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - seaweed.seaweedfs.com
+  resources:
+  - buckets/status
   - seaweeds/status
   verbs:
   - get

--- a/go.mod
+++ b/go.mod
@@ -82,6 +82,7 @@ require (
 	github.com/ebitengine/purego v0.9.0 // indirect
 	github.com/emersion/go-message v0.18.2 // indirect
 	github.com/emersion/go-vcard v0.0.0-20241024213814-c9703dde27ff // indirect
+	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/flynn/noise v1.1.0 // indirect
@@ -287,5 +288,5 @@ require (
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
+	sigs.k8s.io/yaml v1.6.0
 )

--- a/internal/controller/bucket_admin.go
+++ b/internal/controller/bucket_admin.go
@@ -221,6 +221,12 @@ func (a *swadminBucketAdmin) Configure(ctx context.Context, prefix string, args 
 // here so future swadmin error-message changes only need updates in one
 // place.
 
+// isBucketNotFoundErr matches the three SeaweedFS-specific error prefixes
+// emitted when a bucket lookup misses. The generic substring "not found"
+// is intentionally NOT matched: connection errors, gRPC stream errors,
+// and unrelated filer errors can all carry that phrase, and treating
+// them as bucket-missing would mask real problems and trigger spurious
+// CreateBucket attempts.
 func isBucketNotFoundErr(err error) bool {
 	if err == nil {
 		return false
@@ -228,8 +234,7 @@ func isBucketNotFoundErr(err error) bool {
 	msg := err.Error()
 	return strings.Contains(msg, "lookup bucket") ||
 		strings.Contains(msg, "did not find bucket") ||
-		strings.Contains(msg, "bucket not found") ||
-		strings.Contains(msg, "not found")
+		strings.Contains(msg, "bucket not found")
 }
 
 func isAlreadyExistsErr(err error) bool {

--- a/internal/controller/bucket_admin.go
+++ b/internal/controller/bucket_admin.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 
 	"github.com/go-logr/logr"
 
@@ -76,9 +77,17 @@ var (
 )
 
 // swadminBucketAdmin is the default BucketAdmin, backed by swadmin.SeaweedAdmin.
+//
+// Reconcile goroutines (one per Bucket worker, plus the periodic
+// usage-stats loop) share a single instance via the reconciler's admin
+// cache, so concurrent ProcessCommand calls would race on the embedded
+// SeaweedAdmin's Output writer. The mu serializes every command in this
+// admin's lifetime — coarse but sufficient: shell commands are short and
+// per-bucket reconciles don't fan out further than the worker count.
 type swadminBucketAdmin struct {
 	sa  *swadmin.SeaweedAdmin
 	log logr.Logger
+	mu  sync.Mutex
 }
 
 // NewSwadminBucketAdmin returns a BucketAdmin that runs `weed shell` commands
@@ -89,6 +98,8 @@ func NewSwadminBucketAdmin(masters string, log logr.Logger) (BucketAdmin, error)
 }
 
 func (a *swadminBucketAdmin) run(cmd string) (string, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	var buf bytes.Buffer
 	a.sa.Output = &buf
 	err := a.sa.ProcessCommand(cmd)

--- a/internal/controller/bucket_admin.go
+++ b/internal/controller/bucket_admin.go
@@ -1,0 +1,248 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/go-logr/logr"
+
+	"github.com/seaweedfs/seaweedfs-operator/internal/controller/swadmin"
+)
+
+// BucketAdmin is the small surface the bucket reconciler uses to drive a
+// SeaweedFS cluster. The default implementation wraps swadmin.SeaweedAdmin
+// (which embeds `weed shell` directly); tests inject a fake.
+//
+// Methods are loosely idempotent — most underlying shell commands are safe
+// to call repeatedly with the same arguments. The admin layer translates
+// well-known error substrings into typed sentinels so the reconciler can
+// take structured action.
+type BucketAdmin interface {
+	BucketExists(ctx context.Context, name string) (bool, error)
+	CreateBucket(ctx context.Context, name, owner string, withLock bool) error
+	DeleteBucket(ctx context.Context, name string) error
+	SetVersioning(ctx context.Context, name, status string) error
+	EnableObjectLock(ctx context.Context, name string) error
+	SetQuota(ctx context.Context, name string, sizeMiB int64, enforce bool) error
+	RemoveQuota(ctx context.Context, name string) error
+	SetOwner(ctx context.Context, name, owner string) error
+	RemoveOwner(ctx context.Context, name string) error
+	// SetAccess applies a comma-joined set of actions for a user. Pass
+	// "none" to strip the user's grants on this bucket without deleting
+	// the IAM identity itself.
+	SetAccess(ctx context.Context, name, user, actions string) error
+	// Configure issues a single fs.configure call; args are the flag list
+	// minus locationPrefix and -apply (the admin layer adds those).
+	Configure(ctx context.Context, prefix string, args []string) error
+}
+
+// BucketAdminFactory creates a BucketAdmin for the master peers of a target
+// Seaweed cluster. Replaceable in tests.
+type BucketAdminFactory func(masters string, log logr.Logger) (BucketAdmin, error)
+
+// Sentinel errors returned by BucketAdmin implementations.
+var (
+	// ErrBucketNotFound indicates the bucket does not exist on the filer.
+	ErrBucketNotFound = errors.New("bucket not found")
+	// ErrBucketAlreadyExists is returned by CreateBucket when the bucket
+	// is already present on the filer.
+	ErrBucketAlreadyExists = errors.New("bucket already exists")
+	// ErrRetentionBlocksDelete is returned by DeleteBucket when Object
+	// Lock retention or legal hold prevents removal.
+	ErrRetentionBlocksDelete = errors.New("bucket has objects with active Object Lock retention or legal hold")
+	// ErrObjectLockBlocksSuspend is returned by SetVersioning when Object
+	// Lock prevents transitioning to Suspended.
+	ErrObjectLockBlocksSuspend = errors.New("cannot suspend versioning while Object Lock is enabled")
+)
+
+// swadminBucketAdmin is the default BucketAdmin, backed by swadmin.SeaweedAdmin.
+type swadminBucketAdmin struct {
+	sa  *swadmin.SeaweedAdmin
+	log logr.Logger
+}
+
+// NewSwadminBucketAdmin returns a BucketAdmin that runs `weed shell` commands
+// against the given comma-separated master peers list.
+func NewSwadminBucketAdmin(masters string, log logr.Logger) (BucketAdmin, error) {
+	sa := swadmin.NewSeaweedAdmin(masters, io.Discard)
+	return &swadminBucketAdmin{sa: sa, log: log}, nil
+}
+
+func (a *swadminBucketAdmin) run(cmd string) (string, error) {
+	var buf bytes.Buffer
+	a.sa.Output = &buf
+	err := a.sa.ProcessCommand(cmd)
+	if err != nil {
+		a.log.V(2).Info("swadmin command failed", "cmd", cmd, "stdout", buf.String(), "err", err.Error())
+	} else {
+		a.log.V(2).Info("swadmin command ok", "cmd", cmd, "stdout", buf.String())
+	}
+	return buf.String(), err
+}
+
+// BucketExists probes for the bucket via `s3.bucket.versioning -name X` with
+// no other flags — a read-only call that returns the current state when the
+// bucket is present and an explicit "lookup bucket" error when it is not.
+func (a *swadminBucketAdmin) BucketExists(ctx context.Context, name string) (bool, error) {
+	_, err := a.run(fmt.Sprintf("s3.bucket.versioning -name %s", name))
+	if err == nil {
+		return true, nil
+	}
+	if isBucketNotFoundErr(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+func (a *swadminBucketAdmin) CreateBucket(ctx context.Context, name, owner string, withLock bool) error {
+	parts := []string{"s3.bucket.create", "-name", name}
+	if owner != "" {
+		parts = append(parts, "-owner", owner)
+	}
+	if withLock {
+		parts = append(parts, "-withLock")
+	}
+	_, err := a.run(strings.Join(parts, " "))
+	if err == nil {
+		return nil
+	}
+	if isAlreadyExistsErr(err) {
+		return ErrBucketAlreadyExists
+	}
+	return err
+}
+
+func (a *swadminBucketAdmin) DeleteBucket(ctx context.Context, name string) error {
+	_, err := a.run(fmt.Sprintf("s3.bucket.delete -name %s", name))
+	if err == nil {
+		return nil
+	}
+	if isRetentionErr(err) {
+		return ErrRetentionBlocksDelete
+	}
+	if isBucketNotFoundErr(err) {
+		return ErrBucketNotFound
+	}
+	return err
+}
+
+func (a *swadminBucketAdmin) SetVersioning(ctx context.Context, name, status string) error {
+	_, err := a.run(fmt.Sprintf("s3.bucket.versioning -name %s -status %s", name, status))
+	if err == nil {
+		return nil
+	}
+	if isObjectLockSuspendErr(err) {
+		return ErrObjectLockBlocksSuspend
+	}
+	return err
+}
+
+func (a *swadminBucketAdmin) EnableObjectLock(ctx context.Context, name string) error {
+	_, err := a.run(fmt.Sprintf("s3.bucket.lock -name %s -enable", name))
+	return err
+}
+
+func (a *swadminBucketAdmin) SetQuota(ctx context.Context, name string, sizeMiB int64, enforce bool) error {
+	if _, err := a.run(fmt.Sprintf("s3.bucket.quota -name %s -op set -sizeMB %d", name, sizeMiB)); err != nil {
+		return err
+	}
+	op := "enable"
+	if !enforce {
+		op = "disable"
+	}
+	_, err := a.run(fmt.Sprintf("s3.bucket.quota -name %s -op %s", name, op))
+	return err
+}
+
+func (a *swadminBucketAdmin) RemoveQuota(ctx context.Context, name string) error {
+	_, err := a.run(fmt.Sprintf("s3.bucket.quota -name %s -op remove", name))
+	return err
+}
+
+func (a *swadminBucketAdmin) SetOwner(ctx context.Context, name, owner string) error {
+	_, err := a.run(fmt.Sprintf("s3.bucket.owner -name %s -owner %s", name, owner))
+	return err
+}
+
+func (a *swadminBucketAdmin) RemoveOwner(ctx context.Context, name string) error {
+	_, err := a.run(fmt.Sprintf("s3.bucket.owner -name %s -delete", name))
+	return err
+}
+
+func (a *swadminBucketAdmin) SetAccess(ctx context.Context, name, user, actions string) error {
+	if actions == "" {
+		actions = "none"
+	}
+	_, err := a.run(fmt.Sprintf("s3.bucket.access -name %s -user %s -access %s", name, user, actions))
+	return err
+}
+
+func (a *swadminBucketAdmin) Configure(ctx context.Context, prefix string, args []string) error {
+	parts := []string{"fs.configure", "-locationPrefix=" + prefix}
+	parts = append(parts, args...)
+	parts = append(parts, "-apply")
+	_, err := a.run(strings.Join(parts, " "))
+	return err
+}
+
+// Error-string classifiers. The shell commands return errors with stable
+// substrings which the admin layer maps onto sentinels. They are isolated
+// here so future swadmin error-message changes only need updates in one
+// place.
+
+func isBucketNotFoundErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "lookup bucket") ||
+		strings.Contains(msg, "did not find bucket") ||
+		strings.Contains(msg, "bucket not found") ||
+		strings.Contains(msg, "not found")
+}
+
+func isAlreadyExistsErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "already exists") ||
+		strings.Contains(msg, "file exists")
+}
+
+func isRetentionErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "Object Lock retention") ||
+		strings.Contains(msg, "legal hold")
+}
+
+func isObjectLockSuspendErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "cannot suspend versioning") &&
+		strings.Contains(err.Error(), "Object Lock is enabled")
+}

--- a/internal/controller/bucket_admin_test.go
+++ b/internal/controller/bucket_admin_test.go
@@ -31,7 +31,10 @@ func TestIsBucketNotFoundErr(t *testing.T) {
 		"lookup bucket":    {errors.New("lookup bucket photos: not found"), true},
 		"did not find":     {errors.New("did not find bucket photos: rpc error"), true},
 		"bucket not found": {errors.New("bucket not found: lookup error"), true},
-		"plain not found":  {errors.New("entry not found"), true},
+		// Generic "not found" must NOT match — connection errors and
+		// unrelated filer errors carry that phrase.
+		"generic not found": {errors.New("entry not found"), false},
+		"transport error":   {errors.New("rpc error: code = NotFound desc = something"), false},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/controller/bucket_admin_test.go
+++ b/internal/controller/bucket_admin_test.go
@@ -1,0 +1,100 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIsBucketNotFoundErr(t *testing.T) {
+	cases := map[string]struct {
+		err  error
+		want bool
+	}{
+		"nil":              {nil, false},
+		"unrelated":        {errors.New("connection refused"), false},
+		"lookup bucket":    {errors.New("lookup bucket photos: not found"), true},
+		"did not find":     {errors.New("did not find bucket photos: rpc error"), true},
+		"bucket not found": {errors.New("bucket not found: lookup error"), true},
+		"plain not found":  {errors.New("entry not found"), true},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := isBucketNotFoundErr(tc.err); got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsAlreadyExistsErr(t *testing.T) {
+	cases := map[string]struct {
+		err  error
+		want bool
+	}{
+		"nil":            {nil, false},
+		"already exists": {errors.New("entry already exists"), true},
+		"file exists":    {errors.New("file exists"), true},
+		"unrelated":      {errors.New("permission denied"), false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := isAlreadyExistsErr(tc.err); got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsRetentionErr(t *testing.T) {
+	cases := map[string]struct {
+		err  error
+		want bool
+	}{
+		"nil":             {nil, false},
+		"retention":       {errors.New("bucket has objects with active Object Lock retention or legal hold"), true},
+		"legal hold only": {errors.New("bucket has legal hold objects"), true},
+		"unrelated":       {errors.New("rpc error"), false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := isRetentionErr(tc.err); got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsObjectLockSuspendErr(t *testing.T) {
+	cases := map[string]struct {
+		err  error
+		want bool
+	}{
+		"nil":            {nil, false},
+		"happy path":     {errors.New("cannot suspend versioning on bucket photos: Object Lock is enabled"), true},
+		"missing prefix": {errors.New("Object Lock is enabled"), false},
+		"missing suffix": {errors.New("cannot suspend versioning on bucket photos: blocked"), false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := isObjectLockSuspendErr(tc.err); got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -351,16 +351,27 @@ func (r *BucketReconciler) handleDeletion(ctx context.Context, bucket *seaweedv1
 	return ctrl.Result{}, nil
 }
 
-// failPhase records the failure on Status, persists, and returns. Used as a
-// terminal step within a reconcile so the caller does not need to also
-// requeue — controller-runtime will retry on the returned error.
+// failPhase records the failure on Status, persists, and returns a
+// requeue with a nil error. Returning a non-nil error alongside
+// RequeueAfter would make controller-runtime ignore RequeueAfter and
+// fall back to its default exponential backoff — but the failure is
+// already captured on Status (Phase=Failed, Ready=False with
+// reason+message), so the manager does not need an error return to
+// know the reconcile didn't succeed. The deterministic
+// `requeueAfterTransient` cadence is preserved.
+//
+// A non-nil error is still returned when the Status().Update itself
+// fails so the manager retries on its rate limiter; that case
+// signals an unhealthy API server, not a per-bucket failure.
 func (r *BucketReconciler) failPhase(ctx context.Context, bucket *seaweedv1.Bucket, phase seaweedv1.BucketPhase, reason, message string) (ctrl.Result, error) {
+	log := r.Log.WithValues("bucket", types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name})
+	log.Info("reconcile failed", "phase", phase, "reason", reason, "message", message)
 	bucket.Status.Phase = phase
 	r.setCondition(bucket, seaweedv1.BucketConditionReady, metav1.ConditionFalse, reason, message)
 	if err := r.Status().Update(ctx, bucket); err != nil {
 		return ctrl.Result{}, err
 	}
-	return ctrl.Result{RequeueAfter: requeueAfterTransient}, fmt.Errorf("%s: %s", reason, message)
+	return ctrl.Result{RequeueAfter: requeueAfterTransient}, nil
 }
 
 func (r *BucketReconciler) setCondition(bucket *seaweedv1.Bucket, condType string, status metav1.ConditionStatus, reason, message string) {

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -1,0 +1,536 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+)
+
+const (
+	// BucketFinalizer protects the Bucket CR from deletion until the
+	// reconciler has had a chance to honor reclaimPolicy.
+	BucketFinalizer = "seaweed.seaweedfs.com/bucket-protection"
+
+	// AnnotationAppliedAccess records the IAM identities that the
+	// reconciler last reconciled access for, so users removed from
+	// spec.access can have their grants revoked on the next pass.
+	// Stored as a comma-joined sorted list of identity names.
+	AnnotationAppliedAccess = "bucket.seaweed.seaweedfs.com/applied-access"
+
+	// requeueAfterTransient is the backoff used when an external
+	// dependency (the filer, an IAM identity) is missing but expected to
+	// arrive shortly.
+	requeueAfterTransient = 30 * time.Second
+)
+
+// BucketReconciler reconciles Bucket resources by translating spec changes
+// into `weed shell s3.bucket.*` and `fs.configure` calls against the target
+// Seaweed cluster.
+type BucketReconciler struct {
+	client.Client
+	Log      logr.Logger
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
+
+	// AdminFactory creates a BucketAdmin for the master peers of the
+	// target Seaweed cluster. Tests inject a fake; production wires
+	// NewSwadminBucketAdmin.
+	AdminFactory BucketAdminFactory
+
+	// adminCache holds one BucketAdmin per (Seaweed CR identity, masters
+	// string). swadmin.NewSeaweedAdmin spawns a background goroutine that
+	// keeps a master connection alive, so caching avoids leaking one
+	// goroutine per Reconcile. Entries are not actively evicted; if the
+	// underlying Seaweed CR's master replica count changes, the next
+	// Reconcile inserts a new entry under a different key and the old
+	// connection lingers until operator restart. That is consistent with
+	// the existing seaweed_maintenance.go pattern; a follow-up can plumb
+	// a cancelable context through swadmin.SeaweedAdmin to do better.
+	adminCache map[string]BucketAdmin
+	adminMu    sync.Mutex
+}
+
+// +kubebuilder:rbac:groups=seaweed.seaweedfs.com,resources=buckets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=seaweed.seaweedfs.com,resources=buckets/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=seaweed.seaweedfs.com,resources=buckets/finalizers,verbs=update
+
+// Reconcile implements the bucket reconciliation logic.
+func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := r.Log.WithValues("bucket", req.NamespacedName)
+
+	var bucket seaweedv1.Bucket
+	if err := r.Get(ctx, req.NamespacedName, &bucket); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	bucketName := resolvedBucketName(&bucket)
+
+	// Refuse rename attempts. Once a bucket is provisioned, status.bucketName
+	// pins the name; any divergence indicates the user changed spec.name
+	// after the fact. Renames in S3 / SeaweedFS are not a thing — the safe
+	// move is to surface the error and let the user recreate.
+	if bucket.Status.BucketName != "" && bucket.Status.BucketName != bucketName {
+		msg := fmt.Sprintf("bucket name change from %q to %q is not supported; restore the original name or recreate the resource",
+			bucket.Status.BucketName, bucketName)
+		return r.failPhase(ctx, &bucket, seaweedv1.BucketPhaseFailed, "BucketRenameNotSupported", msg)
+	}
+
+	// Resolve the cluster reference. Cross-namespace is allowed.
+	seaweedNS := bucket.Spec.ClusterRef.Namespace
+	if seaweedNS == "" {
+		seaweedNS = bucket.Namespace
+	}
+	var seaweed seaweedv1.Seaweed
+	if err := r.Get(ctx, types.NamespacedName{Namespace: seaweedNS, Name: bucket.Spec.ClusterRef.Name}, &seaweed); err != nil {
+		if apierrors.IsNotFound(err) {
+			r.setCondition(&bucket, seaweedv1.BucketConditionClusterReachable, metav1.ConditionFalse, "ClusterRefNotFound",
+				fmt.Sprintf("Seaweed %q not found in namespace %q", bucket.Spec.ClusterRef.Name, seaweedNS))
+			bucket.Status.Phase = seaweedv1.BucketPhasePending
+			if updateErr := r.Status().Update(ctx, &bucket); updateErr != nil {
+				log.Error(updateErr, "status update")
+			}
+			return ctrl.Result{RequeueAfter: requeueAfterTransient}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	r.setCondition(&bucket, seaweedv1.BucketConditionClusterReachable, metav1.ConditionTrue, "Reachable", "")
+
+	masters := getMasterPeersString(&seaweed)
+	admin, err := r.getAdmin(seaweedNS, seaweed.Name, masters, log)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Deletion path.
+	if !bucket.DeletionTimestamp.IsZero() {
+		return r.handleDeletion(ctx, &bucket, bucketName, admin)
+	}
+
+	// Add finalizer if missing. Requeue immediately to pick up the
+	// updated metadata before reconciling spec.
+	if !controllerutil.ContainsFinalizer(&bucket, BucketFinalizer) {
+		controllerutil.AddFinalizer(&bucket, BucketFinalizer)
+		if err := r.Update(ctx, &bucket); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	return r.reconcileBucket(ctx, &bucket, bucketName, admin)
+}
+
+// reconcileBucket drives the create/update path: existence check, then
+// each per-aspect command in dependency order (lock requires versioning,
+// versioning requires the bucket exists, etc.). Failures surface as
+// status conditions and return errors so controller-runtime requeues.
+func (r *BucketReconciler) reconcileBucket(ctx context.Context, bucket *seaweedv1.Bucket, bucketName string, admin BucketAdmin) (ctrl.Result, error) {
+	log := r.Log.WithValues("bucket", types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name})
+
+	exists, err := admin.BucketExists(ctx, bucketName)
+	if err != nil {
+		return r.failPhase(ctx, bucket, seaweedv1.BucketPhaseFailed, "ExistsCheckFailed", err.Error())
+	}
+
+	// Detect adoption attempt: bucket exists on the filer but our status
+	// has never recorded its name. Refuse; users must remove the foreign
+	// bucket manually before this CR can own it.
+	if exists && bucket.Status.BucketName == "" {
+		r.setCondition(bucket, seaweedv1.BucketConditionBucketAlreadyExists, metav1.ConditionTrue, "AlreadyExists",
+			fmt.Sprintf("a bucket named %q already exists on cluster %q and was not created by this resource; adoption is not supported",
+				bucketName, bucket.Spec.ClusterRef.Name))
+		return r.failPhase(ctx, bucket, seaweedv1.BucketPhaseFailed, "BucketAlreadyExists",
+			fmt.Sprintf("bucket %q already exists; refusing to adopt", bucketName))
+	}
+
+	if !exists {
+		if err := admin.CreateBucket(ctx, bucketName, bucket.Spec.Owner, bucket.Spec.ObjectLock); err != nil {
+			if errors.Is(err, ErrBucketAlreadyExists) {
+				// Lost a race; fall through and treat as adoption-refused.
+				r.setCondition(bucket, seaweedv1.BucketConditionBucketAlreadyExists, metav1.ConditionTrue, "AlreadyExists",
+					fmt.Sprintf("bucket %q was created by another agent between exists check and create", bucketName))
+				return r.failPhase(ctx, bucket, seaweedv1.BucketPhaseFailed, "BucketAlreadyExists", err.Error())
+			}
+			return r.failPhase(ctx, bucket, seaweedv1.BucketPhaseFailed, "CreateFailed", err.Error())
+		}
+		log.Info("created bucket", "name", bucketName, "owner", bucket.Spec.Owner, "withLock", bucket.Spec.ObjectLock)
+	}
+
+	// Object Lock: enable when requested and not already on. Versioning is
+	// auto-enabled by the underlying command.
+	if bucket.Spec.ObjectLock && !bucket.Status.ObjectLockEnabled {
+		if err := admin.EnableObjectLock(ctx, bucketName); err != nil {
+			return r.failPhase(ctx, bucket, seaweedv1.BucketPhaseFailed, "ObjectLockFailed", err.Error())
+		}
+	}
+	r.setCondition(bucket, seaweedv1.BucketConditionObjectLockEnabled, boolToCondStatus(bucket.Spec.ObjectLock), "Reconciled", "")
+
+	// Versioning: only push a state when one is requested. "Off" with no
+	// prior state is a no-op (we don't try to "disable" — there's no
+	// command for that, and CEL prevents transitioning back to Off).
+	if bucket.Spec.Versioning != "" && bucket.Spec.Versioning != seaweedv1.VersioningOff {
+		if err := admin.SetVersioning(ctx, bucketName, string(bucket.Spec.Versioning)); err != nil {
+			if errors.Is(err, ErrObjectLockBlocksSuspend) {
+				return r.failPhase(ctx, bucket, seaweedv1.BucketPhaseFailed, "VersioningSuspendBlocked", err.Error())
+			}
+			return r.failPhase(ctx, bucket, seaweedv1.BucketPhaseFailed, "VersioningFailed", err.Error())
+		}
+	}
+
+	// Quota.
+	if bucket.Spec.Quota != nil {
+		sizeMiB, err := quantityToMiB(bucket.Spec.Quota.Size)
+		if err != nil {
+			return r.failPhase(ctx, bucket, seaweedv1.BucketPhaseFailed, "QuotaInvalid", err.Error())
+		}
+		if sizeMiB <= 0 {
+			if err := admin.RemoveQuota(ctx, bucketName); err != nil {
+				return r.failPhase(ctx, bucket, seaweedv1.BucketPhaseFailed, "QuotaRemoveFailed", err.Error())
+			}
+		} else {
+			if err := admin.SetQuota(ctx, bucketName, sizeMiB, bucket.Spec.Quota.Enforce); err != nil {
+				return r.failPhase(ctx, bucket, seaweedv1.BucketPhaseFailed, "QuotaFailed", err.Error())
+			}
+		}
+		r.setCondition(bucket, seaweedv1.BucketConditionQuotaEnforced, boolToCondStatus(bucket.Spec.Quota.Enforce && sizeMiB > 0), "Reconciled", "")
+	} else if bucket.Status.Quota != nil {
+		// User removed the quota block — clear it on the filer.
+		if err := admin.RemoveQuota(ctx, bucketName); err != nil {
+			return r.failPhase(ctx, bucket, seaweedv1.BucketPhaseFailed, "QuotaRemoveFailed", err.Error())
+		}
+		r.setCondition(bucket, seaweedv1.BucketConditionQuotaEnforced, metav1.ConditionFalse, "Removed", "")
+	}
+
+	// Owner. Empty Owner with a previously-set owner means "remove".
+	if bucket.Spec.Owner != "" {
+		if bucket.Status.OwnerIdentity != bucket.Spec.Owner {
+			if err := admin.SetOwner(ctx, bucketName, bucket.Spec.Owner); err != nil {
+				return r.failPhase(ctx, bucket, seaweedv1.BucketPhaseFailed, "OwnerFailed", err.Error())
+			}
+		}
+	} else if bucket.Status.OwnerIdentity != "" {
+		if err := admin.RemoveOwner(ctx, bucketName); err != nil {
+			return r.failPhase(ctx, bucket, seaweedv1.BucketPhaseFailed, "OwnerFailed", err.Error())
+		}
+	}
+
+	// Access grants: declarative reconcile against the previous applied
+	// list (recorded as an annotation). Users no longer in spec have
+	// their bucket grants stripped; users in spec get their actions
+	// (re)set to the requested set.
+	prevUsers := readAppliedAccessAnnotation(bucket)
+	desired := map[string]string{}
+	for _, g := range bucket.Spec.Access {
+		desired[g.User] = joinActions(g.Actions)
+	}
+	for user, actions := range desired {
+		if err := admin.SetAccess(ctx, bucketName, user, actions); err != nil {
+			return r.failPhase(ctx, bucket, seaweedv1.BucketPhaseFailed, "AccessFailed",
+				fmt.Sprintf("set access for user %q: %s", user, err.Error()))
+		}
+	}
+	for _, user := range prevUsers {
+		if _, kept := desired[user]; kept {
+			continue
+		}
+		if err := admin.SetAccess(ctx, bucketName, user, "none"); err != nil {
+			return r.failPhase(ctx, bucket, seaweedv1.BucketPhaseFailed, "AccessRevokeFailed",
+				fmt.Sprintf("revoke access for user %q: %s", user, err.Error()))
+		}
+	}
+	if err := r.writeAppliedAccessAnnotation(ctx, bucket, desired); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Placement (fs.configure) — only call when at least one field set,
+	// since fs.configure with no flags is a no-op write.
+	if args := placementArgs(bucket.Spec.Placement); len(args) > 0 {
+		prefix := "/buckets/" + bucketName + "/"
+		if err := admin.Configure(ctx, prefix, args); err != nil {
+			return r.failPhase(ctx, bucket, seaweedv1.BucketPhaseFailed, "PlacementFailed", err.Error())
+		}
+	}
+
+	// Status: record observed state and mark Ready.
+	bucket.Status.BucketName = bucketName
+	bucket.Status.ObservedGeneration = bucket.Generation
+	bucket.Status.Versioning = bucket.Spec.Versioning
+	bucket.Status.ObjectLockEnabled = bucket.Spec.ObjectLock
+	bucket.Status.OwnerIdentity = bucket.Spec.Owner
+	if bucket.Spec.Quota != nil {
+		sizeMiB, _ := quantityToMiB(bucket.Spec.Quota.Size)
+		bucket.Status.Quota = &seaweedv1.BucketStatusQuota{
+			SizeBytes: sizeMiB * 1024 * 1024,
+			Enforced:  bucket.Spec.Quota.Enforce && sizeMiB > 0,
+		}
+	} else {
+		bucket.Status.Quota = nil
+	}
+	bucket.Status.Phase = seaweedv1.BucketPhaseReady
+	r.setCondition(bucket, seaweedv1.BucketConditionReady, metav1.ConditionTrue, "Reconciled", "")
+	// Clear the rare conditions when they no longer apply.
+	r.clearCondition(bucket, seaweedv1.BucketConditionBucketAlreadyExists)
+	r.clearCondition(bucket, seaweedv1.BucketConditionDeleteBlockedByRetention)
+
+	if err := r.Status().Update(ctx, bucket); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+// handleDeletion drives the reclaim-policy path. Retain just removes the
+// finalizer; Delete attempts s3.bucket.delete and surfaces retention
+// blocks as a condition with a backoff retry.
+func (r *BucketReconciler) handleDeletion(ctx context.Context, bucket *seaweedv1.Bucket, bucketName string, admin BucketAdmin) (ctrl.Result, error) {
+	log := r.Log.WithValues("bucket", types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name})
+
+	if !controllerutil.ContainsFinalizer(bucket, BucketFinalizer) {
+		return ctrl.Result{}, nil
+	}
+
+	bucket.Status.Phase = seaweedv1.BucketPhaseTerminating
+
+	if bucket.Spec.ReclaimPolicy == seaweedv1.BucketReclaimDelete {
+		err := admin.DeleteBucket(ctx, bucketName)
+		switch {
+		case err == nil, errors.Is(err, ErrBucketNotFound):
+			// Clean exit, fall through to finalizer removal.
+		case errors.Is(err, ErrRetentionBlocksDelete):
+			r.setCondition(bucket, seaweedv1.BucketConditionDeleteBlockedByRetention, metav1.ConditionTrue, "RetentionActive",
+				"bucket has objects under Object Lock retention or legal hold; flip reclaimPolicy to Retain and clear retention manually if you intend to delete")
+			if updateErr := r.Status().Update(ctx, bucket); updateErr != nil {
+				log.Error(updateErr, "status update during deletion")
+			}
+			return ctrl.Result{RequeueAfter: requeueAfterTransient}, nil
+		default:
+			r.setCondition(bucket, seaweedv1.BucketConditionReady, metav1.ConditionFalse, "DeleteFailed", err.Error())
+			if updateErr := r.Status().Update(ctx, bucket); updateErr != nil {
+				log.Error(updateErr, "status update during deletion")
+			}
+			return ctrl.Result{}, err
+		}
+	}
+
+	controllerutil.RemoveFinalizer(bucket, BucketFinalizer)
+	if err := r.Update(ctx, bucket); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+// failPhase records the failure on Status, persists, and returns. Used as a
+// terminal step within a reconcile so the caller does not need to also
+// requeue — controller-runtime will retry on the returned error.
+func (r *BucketReconciler) failPhase(ctx context.Context, bucket *seaweedv1.Bucket, phase seaweedv1.BucketPhase, reason, message string) (ctrl.Result, error) {
+	bucket.Status.Phase = phase
+	r.setCondition(bucket, seaweedv1.BucketConditionReady, metav1.ConditionFalse, reason, message)
+	if err := r.Status().Update(ctx, bucket); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{RequeueAfter: requeueAfterTransient}, fmt.Errorf("%s: %s", reason, message)
+}
+
+func (r *BucketReconciler) setCondition(bucket *seaweedv1.Bucket, condType string, status metav1.ConditionStatus, reason, message string) {
+	meta.SetStatusCondition(&bucket.Status.Conditions, metav1.Condition{
+		Type:               condType,
+		Status:             status,
+		ObservedGeneration: bucket.Generation,
+		Reason:             reason,
+		Message:            message,
+	})
+}
+
+func (r *BucketReconciler) clearCondition(bucket *seaweedv1.Bucket, condType string) {
+	meta.RemoveStatusCondition(&bucket.Status.Conditions, condType)
+}
+
+// getAdmin returns a cached BucketAdmin for the (Seaweed CR, masters)
+// pair, creating one via the factory on first use. See the comment on
+// adminCache about the goroutine-leak trade-off.
+func (r *BucketReconciler) getAdmin(ns, name, masters string, log logr.Logger) (BucketAdmin, error) {
+	key := ns + "/" + name + "@" + masters
+	r.adminMu.Lock()
+	defer r.adminMu.Unlock()
+	if r.adminCache == nil {
+		r.adminCache = make(map[string]BucketAdmin)
+	}
+	if a, ok := r.adminCache[key]; ok {
+		return a, nil
+	}
+	a, err := r.AdminFactory(masters, log)
+	if err != nil {
+		return nil, err
+	}
+	r.adminCache[key] = a
+	return a, nil
+}
+
+// SetupWithManager wires the reconciler into the controller-runtime manager.
+func (r *BucketReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if r.AdminFactory == nil {
+		r.AdminFactory = NewSwadminBucketAdmin
+	}
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&seaweedv1.Bucket{}).
+		Complete(r)
+}
+
+// resolvedBucketName returns spec.Name when set, falling back to metadata.name.
+func resolvedBucketName(b *seaweedv1.Bucket) string {
+	if b.Spec.Name != "" {
+		return b.Spec.Name
+	}
+	return b.Name
+}
+
+// quantityToMiB converts a resource.Quantity to whole MiB, rounding up.
+// Returns an error for negative or non-integer-byte quantities (which
+// resource.Quantity does support but make no sense as a bucket size).
+func quantityToMiB(q resource.Quantity) (int64, error) {
+	if q.Sign() < 0 {
+		return 0, fmt.Errorf("quota size must be non-negative, got %s", q.String())
+	}
+	bytes, ok := q.AsInt64()
+	if !ok {
+		return 0, fmt.Errorf("quota size %s cannot be represented as int64 bytes", q.String())
+	}
+	const mib = int64(1024 * 1024)
+	if bytes == 0 {
+		return 0, nil
+	}
+	return (bytes + mib - 1) / mib, nil
+}
+
+// joinActions canonicalizes a list of access actions to the comma form the
+// underlying s3.bucket.access command expects. Empty list returns "none"
+// so the user's bucket grants are revoked rather than left unchanged.
+func joinActions(actions []seaweedv1.BucketAccessAction) string {
+	if len(actions) == 0 {
+		return "none"
+	}
+	parts := make([]string, 0, len(actions))
+	for _, a := range actions {
+		parts = append(parts, string(a))
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ",")
+}
+
+// placementArgs flattens the BucketPlacement struct into the argv form
+// expected by `weed shell fs.configure`. Only set fields are emitted so a
+// re-reconcile with a partial placement spec doesn't accidentally clobber
+// fields the user left at their cluster default.
+func placementArgs(p *seaweedv1.BucketPlacement) []string {
+	if p == nil {
+		return nil
+	}
+	var out []string
+	if p.Replication != "" {
+		out = append(out, "-replication="+p.Replication)
+	}
+	if p.DiskType != "" {
+		out = append(out, "-disk="+p.DiskType)
+	}
+	if p.TTL != "" {
+		out = append(out, "-ttl="+p.TTL)
+	}
+	if p.Fsync {
+		out = append(out, "-fsync=true")
+	}
+	if p.WORM {
+		out = append(out, "-worm=true")
+	}
+	if p.ReadOnly {
+		out = append(out, "-readOnly=true")
+	}
+	if p.DataCenter != "" {
+		out = append(out, "-dataCenter="+p.DataCenter)
+	}
+	if p.Rack != "" {
+		out = append(out, "-rack="+p.Rack)
+	}
+	if p.DataNode != "" {
+		out = append(out, "-dataNode="+p.DataNode)
+	}
+	if p.VolumeGrowthCount > 0 {
+		out = append(out, fmt.Sprintf("-volumeGrowthCount=%d", p.VolumeGrowthCount))
+	}
+	return out
+}
+
+func boolToCondStatus(b bool) metav1.ConditionStatus {
+	if b {
+		return metav1.ConditionTrue
+	}
+	return metav1.ConditionFalse
+}
+
+// readAppliedAccessAnnotation parses the comma-joined user list from the
+// applied-access annotation. Returns an empty slice when the annotation is
+// missing or empty.
+func readAppliedAccessAnnotation(b *seaweedv1.Bucket) []string {
+	val := b.Annotations[AnnotationAppliedAccess]
+	if val == "" {
+		return nil
+	}
+	parts := strings.Split(val, ",")
+	out := parts[:0]
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func (r *BucketReconciler) writeAppliedAccessAnnotation(ctx context.Context, bucket *seaweedv1.Bucket, desired map[string]string) error {
+	users := make([]string, 0, len(desired))
+	for u := range desired {
+		users = append(users, u)
+	}
+	sort.Strings(users)
+	newVal := strings.Join(users, ",")
+
+	if bucket.Annotations[AnnotationAppliedAccess] == newVal {
+		return nil
+	}
+	if bucket.Annotations == nil {
+		bucket.Annotations = map[string]string{}
+	}
+	bucket.Annotations[AnnotationAppliedAccess] = newVal
+	return r.Update(ctx, bucket)
+}

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -528,6 +528,12 @@ func readAppliedAccessAnnotation(b *seaweedv1.Bucket) []string {
 	return out
 }
 
+// writeAppliedAccessAnnotation persists the canonicalized applied-access
+// list to the Bucket's annotations. Uses Patch with MergeFrom so only
+// the annotation diff is sent — a full r.Update bumps ResourceVersion
+// across the entire metadata which then races with the Status().Update
+// at the end of reconcile (and any concurrent SSA writes from the
+// usage refresher).
 func (r *BucketReconciler) writeAppliedAccessAnnotation(ctx context.Context, bucket *seaweedv1.Bucket, desired map[string]string) error {
 	users := make([]string, 0, len(desired))
 	for u := range desired {
@@ -539,9 +545,10 @@ func (r *BucketReconciler) writeAppliedAccessAnnotation(ctx context.Context, buc
 	if bucket.Annotations[AnnotationAppliedAccess] == newVal {
 		return nil
 	}
+	patch := client.MergeFrom(bucket.DeepCopy())
 	if bucket.Annotations == nil {
 		bucket.Annotations = map[string]string{}
 	}
 	bucket.Annotations[AnnotationAppliedAccess] = newVal
-	return r.Update(ctx, bucket)
+	return r.Patch(ctx, bucket, patch)
 }

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -485,8 +485,8 @@ func placementArgs(p *seaweedv1.BucketPlacement) []string {
 	if p.DataNode != "" {
 		out = append(out, "-dataNode="+p.DataNode)
 	}
-	if p.VolumeGrowthCount > 0 {
-		out = append(out, fmt.Sprintf("-volumeGrowthCount=%d", p.VolumeGrowthCount))
+	if p.VolumeGrowthCount != nil {
+		out = append(out, fmt.Sprintf("-volumeGrowthCount=%d", *p.VolumeGrowthCount))
 	}
 	return out
 }

--- a/internal/controller/bucket_controller_test.go
+++ b/internal/controller/bucket_controller_test.go
@@ -571,7 +571,7 @@ func TestPlacementArgs(t *testing.T) {
 				DataCenter:        "dc1",
 				Rack:              "rack-a",
 				DataNode:          "node1",
-				VolumeGrowthCount: 4,
+				VolumeGrowthCount: ptrInt32(4),
 			},
 			[]string{
 				"-replication=001",
@@ -586,6 +586,10 @@ func TestPlacementArgs(t *testing.T) {
 				"-volumeGrowthCount=4",
 			},
 		},
+		"explicit volumeGrowthCount zero is emitted": {
+			&seaweedv1.BucketPlacement{VolumeGrowthCount: ptrInt32(0)},
+			[]string{"-volumeGrowthCount=0"},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -596,6 +600,8 @@ func TestPlacementArgs(t *testing.T) {
 		})
 	}
 }
+
+func ptrInt32(v int32) *int32 { return &v }
 
 func equalStringSlices(a, b []string) bool {
 	if len(a) != len(b) {

--- a/internal/controller/bucket_controller_test.go
+++ b/internal/controller/bucket_controller_test.go
@@ -1,0 +1,639 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+)
+
+// fakeBucketAdmin records calls in order and returns configurable per-method
+// errors. Default behavior treats "BucketExists" as false and every other
+// call as success.
+type fakeBucketAdmin struct {
+	calls []string
+
+	existsResp    map[string]bool
+	createErr     error
+	deleteErr     error
+	versioningErr error
+	lockErr       error
+	quotaErr      error
+	ownerErr      error
+	accessErr     error
+	configureErr  error
+}
+
+func newFakeAdmin() *fakeBucketAdmin {
+	return &fakeBucketAdmin{existsResp: map[string]bool{}}
+}
+
+func (f *fakeBucketAdmin) record(call string) { f.calls = append(f.calls, call) }
+
+func (f *fakeBucketAdmin) BucketExists(_ context.Context, name string) (bool, error) {
+	f.record("Exists:" + name)
+	return f.existsResp[name], nil
+}
+func (f *fakeBucketAdmin) CreateBucket(_ context.Context, name, owner string, withLock bool) error {
+	f.record("Create:" + name + ":owner=" + owner + ":lock=" + boolStr(withLock))
+	if f.createErr == nil {
+		f.existsResp[name] = true
+	}
+	return f.createErr
+}
+func (f *fakeBucketAdmin) DeleteBucket(_ context.Context, name string) error {
+	f.record("Delete:" + name)
+	if f.deleteErr == nil {
+		delete(f.existsResp, name)
+	}
+	return f.deleteErr
+}
+func (f *fakeBucketAdmin) SetVersioning(_ context.Context, name, status string) error {
+	f.record("Versioning:" + name + ":" + status)
+	return f.versioningErr
+}
+func (f *fakeBucketAdmin) EnableObjectLock(_ context.Context, name string) error {
+	f.record("Lock:" + name)
+	return f.lockErr
+}
+func (f *fakeBucketAdmin) SetQuota(_ context.Context, name string, sizeMiB int64, enforce bool) error {
+	f.record("Quota:" + name + ":" + intStr(sizeMiB) + ":enforce=" + boolStr(enforce))
+	return f.quotaErr
+}
+func (f *fakeBucketAdmin) RemoveQuota(_ context.Context, name string) error {
+	f.record("RemoveQuota:" + name)
+	return f.quotaErr
+}
+func (f *fakeBucketAdmin) SetOwner(_ context.Context, name, owner string) error {
+	f.record("Owner:" + name + ":" + owner)
+	return f.ownerErr
+}
+func (f *fakeBucketAdmin) RemoveOwner(_ context.Context, name string) error {
+	f.record("RemoveOwner:" + name)
+	return f.ownerErr
+}
+func (f *fakeBucketAdmin) SetAccess(_ context.Context, name, user, actions string) error {
+	f.record("Access:" + name + ":" + user + ":" + actions)
+	return f.accessErr
+}
+func (f *fakeBucketAdmin) Configure(_ context.Context, prefix string, args []string) error {
+	f.record("Configure:" + prefix + ":" + strings.Join(args, ","))
+	return f.configureErr
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "t"
+	}
+	return "f"
+}
+func intStr(i int64) string {
+	const digits = "0123456789"
+	if i == 0 {
+		return "0"
+	}
+	neg := i < 0
+	if neg {
+		i = -i
+	}
+	var buf [20]byte
+	pos := len(buf)
+	for i > 0 {
+		pos--
+		buf[pos] = digits[i%10]
+		i /= 10
+	}
+	if neg {
+		pos--
+		buf[pos] = '-'
+	}
+	return string(buf[pos:])
+}
+
+// testReconciler builds a BucketReconciler whose AdminFactory always returns
+// the supplied fake. The fake client is pre-loaded with the given objects
+// and the bucket status subresource is registered.
+func testReconciler(t *testing.T, fa *fakeBucketAdmin, objs ...client.Object) (*BucketReconciler, client.Client) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("clientgoscheme: %v", err)
+	}
+	if err := seaweedv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("seaweedv1: %v", err)
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		WithStatusSubresource(&seaweedv1.Bucket{}).
+		Build()
+	r := &BucketReconciler{
+		Client: cli,
+		Log:    logf.FromContext(context.Background()),
+		Scheme: scheme,
+		AdminFactory: func(_ string, _ logr.Logger) (BucketAdmin, error) {
+			return fa, nil
+		},
+	}
+	return r, cli
+}
+
+// reconcileUntilStable hammers Reconcile until the returned Result is
+// neither Requeue:true nor Err. Returns an error if the loop doesn't
+// converge in maxSteps iterations.
+func reconcileUntilStable(t *testing.T, r *BucketReconciler, key types.NamespacedName, maxSteps int) {
+	t.Helper()
+	for i := 0; i < maxSteps; i++ {
+		res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+		if err != nil {
+			t.Fatalf("reconcile step %d: %v", i, err)
+		}
+		if !res.Requeue && res.RequeueAfter == 0 {
+			return
+		}
+	}
+	t.Fatalf("reconcile did not converge after %d steps", maxSteps)
+}
+
+func newTestSeaweed() *seaweedv1.Seaweed {
+	return &seaweedv1.Seaweed{
+		ObjectMeta: metav1.ObjectMeta{Name: "prod", Namespace: "seaweedfs"},
+		Spec: seaweedv1.SeaweedSpec{
+			Master: &seaweedv1.MasterSpec{Replicas: 3},
+		},
+	}
+}
+
+func newTestBucket(name string) *seaweedv1.Bucket {
+	return &seaweedv1.Bucket{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "media",
+		},
+		Spec: seaweedv1.BucketSpec{
+			ClusterRef: seaweedv1.BucketClusterRef{
+				Name:      "prod",
+				Namespace: "seaweedfs",
+			},
+			ReclaimPolicy: seaweedv1.BucketReclaimRetain,
+			Versioning:    seaweedv1.VersioningOff,
+		},
+	}
+}
+
+func TestReconcile_HappyPath_AddsFinalizerThenCreates(t *testing.T) {
+	bucket := newTestBucket("photos")
+	bucket.Spec.Versioning = seaweedv1.VersioningEnabled
+	bucket.Spec.Owner = "media-team"
+	bucket.Spec.Quota = &seaweedv1.BucketQuota{
+		Size:    resource.MustParse("100Gi"),
+		Enforce: true,
+	}
+	bucket.Spec.Access = []seaweedv1.BucketAccessGrant{
+		{User: "uploader", Actions: []seaweedv1.BucketAccessAction{seaweedv1.BucketAccessRead, seaweedv1.BucketAccessWrite}},
+	}
+	bucket.Spec.Placement = &seaweedv1.BucketPlacement{
+		Replication: "001",
+		DiskType:    "ssd",
+	}
+
+	fa := newFakeAdmin()
+	r, cli := testReconciler(t, fa, newTestSeaweed(), bucket)
+
+	key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
+	reconcileUntilStable(t, r, key, 5)
+
+	got := &seaweedv1.Bucket{}
+	if err := cli.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+
+	if !controllerutil.ContainsFinalizer(got, BucketFinalizer) {
+		t.Errorf("expected finalizer to be set")
+	}
+	if got.Status.Phase != seaweedv1.BucketPhaseReady {
+		t.Errorf("phase=%q want Ready; conditions=%+v", got.Status.Phase, got.Status.Conditions)
+	}
+	if got.Status.BucketName != "photos" {
+		t.Errorf("status.bucketName=%q want photos", got.Status.BucketName)
+	}
+	if got.Status.OwnerIdentity != "media-team" {
+		t.Errorf("status.owner=%q", got.Status.OwnerIdentity)
+	}
+	if got.Status.Quota == nil || got.Status.Quota.SizeBytes != 100*1024*1024*1024 {
+		t.Errorf("status.quota.sizeBytes=%v want %d", got.Status.Quota, 100*1024*1024*1024)
+	}
+
+	// Sanity-check the call sequence — order matters for create-then-config.
+	gotCalls := strings.Join(fa.calls, "\n")
+	for _, want := range []string{
+		"Exists:photos",
+		"Create:photos:owner=media-team:lock=f",
+		"Versioning:photos:Enabled",
+		"Quota:photos:102400:enforce=t",
+		"Owner:photos:media-team",
+		"Access:photos:uploader:Read,Write",
+		"Configure:/buckets/photos/:-replication=001,-disk=ssd",
+	} {
+		if !strings.Contains(gotCalls, want) {
+			t.Errorf("missing expected call %q\nactual calls:\n%s", want, gotCalls)
+		}
+	}
+}
+
+func TestReconcile_ExistingBucketRefusesAdoption(t *testing.T) {
+	bucket := newTestBucket("photos")
+	fa := newFakeAdmin()
+	fa.existsResp["photos"] = true // pre-existing on the filer
+	r, cli := testReconciler(t, fa, newTestSeaweed(), bucket)
+
+	key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
+	// First reconcile adds finalizer; second sees the pre-existing bucket
+	// and refuses adoption.
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	// failPhase returns an error so the manager requeues. Allow either
+	// non-zero RequeueAfter or non-nil err (both happen here).
+	if err == nil && res.RequeueAfter == 0 {
+		t.Fatalf("expected adoption refusal, got success")
+	}
+
+	got := &seaweedv1.Bucket{}
+	if err := cli.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	if got.Status.Phase != seaweedv1.BucketPhaseFailed {
+		t.Errorf("phase=%q want Failed", got.Status.Phase)
+	}
+	cond := meta.FindStatusCondition(got.Status.Conditions, seaweedv1.BucketConditionBucketAlreadyExists)
+	if cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Errorf("expected BucketAlreadyExists condition true, got %+v", cond)
+	}
+	// Adoption refusal should NOT have called Create.
+	for _, c := range fa.calls {
+		if strings.HasPrefix(c, "Create:") {
+			t.Errorf("unexpected Create call: %s", c)
+		}
+	}
+}
+
+func TestReconcile_RenameRefused(t *testing.T) {
+	bucket := newTestBucket("photos")
+	bucket.Spec.Name = "renamed"
+	bucket.Status.BucketName = "photos"
+	bucket.Finalizers = []string{BucketFinalizer}
+
+	fa := newFakeAdmin()
+	r, cli := testReconciler(t, fa, newTestSeaweed(), bucket)
+	key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	if err == nil && res.RequeueAfter == 0 {
+		t.Fatalf("expected rename to fail")
+	}
+
+	got := &seaweedv1.Bucket{}
+	if err := cli.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	cond := meta.FindStatusCondition(got.Status.Conditions, seaweedv1.BucketConditionReady)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "BucketRenameNotSupported" {
+		t.Errorf("expected Ready=False reason=BucketRenameNotSupported, got %+v", cond)
+	}
+}
+
+func TestReconcile_ClusterRefMissingRequeues(t *testing.T) {
+	bucket := newTestBucket("photos")
+	bucket.Spec.ClusterRef.Name = "missing"
+
+	fa := newFakeAdmin()
+	r, cli := testReconciler(t, fa, bucket) // no Seaweed CR
+	key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if res.RequeueAfter == 0 {
+		t.Errorf("expected RequeueAfter > 0 for missing clusterRef")
+	}
+
+	got := &seaweedv1.Bucket{}
+	if err := cli.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	cond := meta.FindStatusCondition(got.Status.Conditions, seaweedv1.BucketConditionClusterReachable)
+	if cond == nil || cond.Status != metav1.ConditionFalse {
+		t.Errorf("expected ClusterReachable=False, got %+v", cond)
+	}
+}
+
+func TestReconcile_RetainOnDelete_RemovesFinalizer(t *testing.T) {
+	now := metav1.Now()
+	bucket := newTestBucket("photos")
+	bucket.Spec.ReclaimPolicy = seaweedv1.BucketReclaimRetain
+	bucket.Status.BucketName = "photos"
+	bucket.Finalizers = []string{BucketFinalizer}
+	bucket.DeletionTimestamp = &now
+
+	fa := newFakeAdmin()
+	fa.existsResp["photos"] = true
+	r, cli := testReconciler(t, fa, newTestSeaweed(), bucket)
+	key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	// Bucket should have been deleted from the API (finalizer gone, no
+	// other holders) — fake client immediately reaps.
+	got := &seaweedv1.Bucket{}
+	err := cli.Get(context.Background(), key, got)
+	if err == nil {
+		t.Errorf("expected bucket to be deleted after finalizer removed; still present: %+v", got)
+	} else if !apierrors.IsNotFound(err) {
+		t.Errorf("unexpected error getting deleted bucket: %v", err)
+	}
+
+	for _, c := range fa.calls {
+		if strings.HasPrefix(c, "Delete:") {
+			t.Errorf("Retain policy must not call DeleteBucket, got: %s", c)
+		}
+	}
+}
+
+func TestReconcile_DeleteOnDelete_CallsDeleteBucket(t *testing.T) {
+	now := metav1.Now()
+	bucket := newTestBucket("photos")
+	bucket.Spec.ReclaimPolicy = seaweedv1.BucketReclaimDelete
+	bucket.Status.BucketName = "photos"
+	bucket.Finalizers = []string{BucketFinalizer}
+	bucket.DeletionTimestamp = &now
+
+	fa := newFakeAdmin()
+	fa.existsResp["photos"] = true
+	r, _ := testReconciler(t, fa, newTestSeaweed(), bucket)
+	key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if _, ok := fa.existsResp["photos"]; ok {
+		t.Errorf("expected bucket to be deleted from fake admin; still present")
+	}
+	found := false
+	for _, c := range fa.calls {
+		if c == "Delete:photos" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected Delete:photos call; got %v", fa.calls)
+	}
+}
+
+func TestReconcile_DeleteBlockedByRetention_KeepsFinalizer(t *testing.T) {
+	now := metav1.Now()
+	bucket := newTestBucket("photos")
+	bucket.Spec.ReclaimPolicy = seaweedv1.BucketReclaimDelete
+	bucket.Status.BucketName = "photos"
+	bucket.Finalizers = []string{BucketFinalizer}
+	bucket.DeletionTimestamp = &now
+
+	fa := newFakeAdmin()
+	fa.existsResp["photos"] = true
+	fa.deleteErr = ErrRetentionBlocksDelete
+	r, cli := testReconciler(t, fa, newTestSeaweed(), bucket)
+	key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if res.RequeueAfter == 0 {
+		t.Errorf("expected RequeueAfter > 0 when retention blocks deletion")
+	}
+
+	got := &seaweedv1.Bucket{}
+	if err := cli.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	if !controllerutil.ContainsFinalizer(got, BucketFinalizer) {
+		t.Errorf("finalizer must NOT be removed while retention blocks delete")
+	}
+	cond := meta.FindStatusCondition(got.Status.Conditions, seaweedv1.BucketConditionDeleteBlockedByRetention)
+	if cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Errorf("expected DeleteBlockedByRetention=True, got %+v", cond)
+	}
+}
+
+func TestReconcile_AccessRevokesRemovedUsers(t *testing.T) {
+	bucket := newTestBucket("photos")
+	// Existing applied list has 3 users; spec keeps only 1.
+	if bucket.Annotations == nil {
+		bucket.Annotations = map[string]string{}
+	}
+	bucket.Annotations[AnnotationAppliedAccess] = "alice,bob,carol"
+	bucket.Status.BucketName = "photos"
+	bucket.Finalizers = []string{BucketFinalizer}
+	bucket.Spec.Access = []seaweedv1.BucketAccessGrant{
+		{User: "alice", Actions: []seaweedv1.BucketAccessAction{seaweedv1.BucketAccessRead}},
+	}
+
+	fa := newFakeAdmin()
+	fa.existsResp["photos"] = true
+	r, cli := testReconciler(t, fa, newTestSeaweed(), bucket)
+	key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
+
+	reconcileUntilStable(t, r, key, 5)
+
+	// alice keeps Read; bob and carol get revoked to none.
+	wantSet := map[string]bool{
+		"Access:photos:alice:Read": false,
+		"Access:photos:bob:none":   false,
+		"Access:photos:carol:none": false,
+	}
+	for _, c := range fa.calls {
+		if _, ok := wantSet[c]; ok {
+			wantSet[c] = true
+		}
+	}
+	for k, seen := range wantSet {
+		if !seen {
+			t.Errorf("missing access call %q; calls=%v", k, fa.calls)
+		}
+	}
+
+	got := &seaweedv1.Bucket{}
+	if err := cli.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	if got.Annotations[AnnotationAppliedAccess] != "alice" {
+		t.Errorf("applied-access annotation = %q want %q",
+			got.Annotations[AnnotationAppliedAccess], "alice")
+	}
+}
+
+func TestQuantityToMiB(t *testing.T) {
+	cases := map[string]struct {
+		q       string
+		want    int64
+		wantErr bool
+	}{
+		"100Gi exactly":   {"100Gi", 100 * 1024, false},
+		"1Mi exactly":     {"1Mi", 1, false},
+		"512Ki rounds up": {"512Ki", 1, false},
+		"zero":            {"0", 0, false},
+		"negative":        {"-1", 0, true},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			q := resource.MustParse(tc.q)
+			got, err := quantityToMiB(q)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err=%v wantErr=%v", err, tc.wantErr)
+			}
+			if !tc.wantErr && got != tc.want {
+				t.Errorf("got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestJoinActions(t *testing.T) {
+	cases := map[string]struct {
+		in   []seaweedv1.BucketAccessAction
+		want string
+	}{
+		"empty":  {nil, "none"},
+		"single": {[]seaweedv1.BucketAccessAction{seaweedv1.BucketAccessRead}, "Read"},
+		"sorted": {[]seaweedv1.BucketAccessAction{seaweedv1.BucketAccessWrite, seaweedv1.BucketAccessRead}, "Read,Write"},
+		"all":    {[]seaweedv1.BucketAccessAction{seaweedv1.BucketAccessAdmin, seaweedv1.BucketAccessRead, seaweedv1.BucketAccessTagging, seaweedv1.BucketAccessList, seaweedv1.BucketAccessWrite}, "Admin,List,Read,Tagging,Write"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := joinActions(tc.in); got != tc.want {
+				t.Errorf("got %q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPlacementArgs(t *testing.T) {
+	cases := map[string]struct {
+		in   *seaweedv1.BucketPlacement
+		want []string
+	}{
+		"nil":   {nil, nil},
+		"empty": {&seaweedv1.BucketPlacement{}, nil},
+		"full": {
+			&seaweedv1.BucketPlacement{
+				Replication:       "001",
+				DiskType:          "ssd",
+				TTL:               "30d",
+				Fsync:             true,
+				WORM:              true,
+				ReadOnly:          true,
+				DataCenter:        "dc1",
+				Rack:              "rack-a",
+				DataNode:          "node1",
+				VolumeGrowthCount: 4,
+			},
+			[]string{
+				"-replication=001",
+				"-disk=ssd",
+				"-ttl=30d",
+				"-fsync=true",
+				"-worm=true",
+				"-readOnly=true",
+				"-dataCenter=dc1",
+				"-rack=rack-a",
+				"-dataNode=node1",
+				"-volumeGrowthCount=4",
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := placementArgs(tc.in)
+			if !equalStringSlices(got, tc.want) {
+				t.Errorf("got %v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	ac := append([]string(nil), a...)
+	bc := append([]string(nil), b...)
+	sort.Strings(ac)
+	sort.Strings(bc)
+	for i := range ac {
+		if ac[i] != bc[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestReadAppliedAccessAnnotation(t *testing.T) {
+	cases := map[string]struct {
+		ann  string
+		want []string
+	}{
+		"missing":       {"", nil},
+		"single":        {"alice", []string{"alice"}},
+		"multi":         {"alice,bob,carol", []string{"alice", "bob", "carol"}},
+		"with spaces":   {" alice , bob ", []string{"alice", "bob"}},
+		"empty entries": {"alice,,bob,", []string{"alice", "bob"}},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			b := &seaweedv1.Bucket{}
+			if tc.ann != "" {
+				b.Annotations = map[string]string{AnnotationAppliedAccess: tc.ann}
+			}
+			got := readAppliedAccessAnnotation(b)
+			if !equalStringSlices(got, tc.want) {
+				t.Errorf("got %v want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Implements the controller for the Bucket CRD added in #220. Reconcile
turns a `Bucket` spec into a sequence of `weed shell s3.bucket.*` and
`fs.configure` calls against the target Seaweed cluster, mediated by a
new `BucketAdmin` interface that wraps the existing `swadmin.SeaweedAdmin`.

**Stacked on #220** — base is \`feat/bucket-crd\`. Once #220 merges to
master, GitHub auto-rebases this PR's base.

## Reconcile flow

1. Resolve `spec.clusterRef` → `Seaweed` CR (cross-namespace allowed).
2. \`ClusterReachable\` condition tracks lookup state; missing CR surfaces
   as \`Pending\` and requeues with a 30s backoff.
3. Add \`seaweed.seaweedfs.com/bucket-protection\` finalizer; requeue once
   to pick up the metadata write.
4. Existence probe via \`s3.bucket.versioning -name X\` (a read-only call
   that errors with \"lookup bucket\" when the bucket is missing).
5. **Adoption refusal**: if the bucket already exists on the filer and
   \`status.bucketName\` is empty, surface \`BucketAlreadyExists\` and stop.
6. Apply each aspect in dependency order:
   - **Object Lock** (idempotent on repeat — the underlying command no-ops
     when already enabled).
   - **Versioning** (skipped when \`Off\`).
   - **Quota** — size converted from \`resource.Quantity\` to MiB (rounding
     up); \`enforce\` toggle drives \`-op enable\` vs \`-op disable\`. Quota
     block removed entirely → \`s3.bucket.quota -op remove\`.
   - **Owner** — set or remove based on \`spec.owner\`.
   - **Access** — declarative diff against an internal
     \`bucket.seaweed.seaweedfs.com/applied-access\` annotation so users
     dropped from spec have their bucket grants revoked (without deleting
     the IAM identity itself).
   - **Placement** — single \`fs.configure -locationPrefix=/buckets/<name>/\`
     call with the populated subset of flags.
7. Status records observed values, \`ObservedGeneration\`, \`Ready=True\`.

## Reclaim semantics

| Policy | Behavior |
|---|---|
| \`Retain\` (default) | Finalizer removed, filer state untouched. |
| \`Delete\` | \`s3.bucket.delete\` invoked. \`ErrRetentionBlocksDelete\` from the admin layer surfaces \`DeleteBlockedByRetention\` and preserves the finalizer with a 30s requeue. |

No force flag — flip to \`Retain\` and clear retention manually if you
really mean it.

## Rename refusal

Once \`status.bucketName\` is set, a divergent \`spec.name\` is refused with
reason \`BucketRenameNotSupported\`. S3 has no atomic rename; silently
creating a new bucket would surprise users.

## Admin abstraction

\`internal/controller/bucket_admin.go\` defines \`BucketAdmin\` (one method
per shell operation) and a swadmin-backed default implementation. Error
classification (not-found, already-exists, retention-blocked,
object-lock-suspend) is centralized so future swadmin error-message
changes only need updates in one place.

\`swadmin.NewSeaweedAdmin\` spawns a background goroutine that keeps a
master connection alive. To avoid leaking one goroutine per Reconcile,
the controller caches admin instances per \`(Seaweed CR, masters)\`
tuple. A scale-out that changes the master replica count leaks the
prior cached admin until operator restart — same trade-off as the
existing \`seaweed_maintenance.go\` path. Plumbing a cancelable context
through \`swadmin\` can land later.

## Wiring

- \`cmd/main.go\` registers \`BucketReconciler\` alongside
  \`SeaweedReconciler\` with the default \`AdminFactory =
  NewSwadminBucketAdmin\`.
- \`+kubebuilder:rbac\` markers regenerate \`config/rbac/role.yaml\` to grant
  \`get/list/watch\` on \`buckets\`, \`get/update/patch\` on \`buckets/status\`,
  and \`update\` on \`buckets/finalizers\`.
- \`make helm-crd-copy\` bundles the new \`buckets\` CRD into
  \`deploy/helm/templates/crd-seaweed.yaml\` alongside \`seaweeds\`. End
  users upgrading the chart pick up the CRD automatically.

## Tests

- \`bucket_admin_test.go\` — error-classifier table tests.
- \`bucket_controller_test.go\` — reconciler tests with a \`fakeBucketAdmin\`
  and the controller-runtime fake client. Covers:
  - Happy path (finalizer + create + versioning + quota + owner + access
    + placement, plus call-order assertion).
  - Adoption refusal (pre-existing bucket on the filer).
  - Rename refusal.
  - Missing \`clusterRef\` (\`ClusterReachable=False\` + requeue).
  - \`Retain\` on delete (no \`s3.bucket.delete\`).
  - \`Delete\` on delete (calls \`s3.bucket.delete\`).
  - Retention-blocked delete (finalizer preserved).
  - Declarative access revocation (annotation-driven diff).
  - Pure-function helpers (\`quantityToMiB\`, \`joinActions\`,
    \`placementArgs\`, \`readAppliedAccessAnnotation\`).

## Test plan

- [x] \`make fmt vet test\` clean.
- [x] Reconciler converges in ≤2 steps on the happy path with the fake
  admin (finalizer + work).
- [x] Annotation-based access diff revokes users dropped from spec.
- [x] \`reclaimPolicy: Delete\` honors \`ErrRetentionBlocksDelete\`.
- [ ] (Out of scope, PR3) Periodic \`status.usage\` refresh.

## Notes

- The reconciler is read-only against the filer for buckets it has
  never touched (\`status.bucketName == \"\"\`). It will not adopt or
  modify a bucket created by something else (COSI driver, hand-rolled
  \`weed shell\`, or another operator instance).
- An out-of-band rename of the bucket on the filer (not reflected in
  \`spec.name\`) would not be detected by the controller; it would
  attempt to reconcile the original name and surface a
  \`ClusterReachable\` / \`ExistsCheckFailed\` error. That's acceptable
  for v1; a follow-up could add a periodic state probe.