### PR TITLE
Add periodic Bucket usage stats refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,11 +289,21 @@ enabled, and the "no return to Off" versioning transition rule.
 See the `config/samples/seaweed_v1_bucket*.yaml` files for end-to-end
 examples (minimal, full-featured, object lock, cross-namespace).
 
-The `Bucket` controller (reconciler + finalizer + status) ships in a
-follow-up PR; this PR establishes only the API surface so the schema
-can be reviewed and adopted by tooling. While the controller is in
-flight, `Bucket` resources are inert — apply at will with no side
-effects on the cluster.
+#### Usage stats
+
+The operator periodically refreshes `status.usage` (object count, total
+bytes, last-updated timestamp) on every `Bucket` by issuing one
+`collection.list` call per Seaweed cluster and patching each bucket's
+status. The cadence is configurable via the
+`--bucket-usage-refresh-interval` flag (default `5m`). Set to `0` to
+disable. The loop is leader-elected so HA deployments do not duplicate
+work.
+
+Usage stats are best-effort observation — they do not block reconcile
+or affect quota enforcement (the underlying S3 quota check on writes is
+authoritative). When a Bucket has not been successfully reconciled yet
+(`status.bucketName` empty), it is skipped until the main reconcile
+loop has provisioned it.
 
 #### COSI coexistence
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"flag"
 	"os"
+	"time"
 
 	monitorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 
@@ -70,6 +71,11 @@ func main() {
 		"If set the metrics endpoint is served securely")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
+	var bucketUsageInterval time.Duration
+	flag.DurationVar(&bucketUsageInterval, "bucket-usage-refresh-interval", controller.DefaultUsageRefreshInterval,
+		"Cadence for refreshing status.usage on Bucket resources. "+
+			"Set to 0 to disable. Defaults to 5m. Each tick issues one collection.list "+
+			"call per Seaweed cluster that owns Buckets, then patches per-bucket status.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -137,10 +143,11 @@ func main() {
 	}
 
 	if err = (&controller.BucketReconciler{
-		Client:   mgr.GetClient(),
-		Log:      ctrl.Log.WithName("controller").WithName("Bucket"),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor("bucket-controller"),
+		Client:               mgr.GetClient(),
+		Log:                  ctrl.Log.WithName("controller").WithName("Bucket"),
+		Scheme:               mgr.GetScheme(),
+		Recorder:             mgr.GetEventRecorderFor("bucket-controller"),
+		UsageRefreshInterval: bucketUsageInterval,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Bucket")
 		os.Exit(1)

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -49,6 +49,11 @@ spec:
         args:
         - --leader-elect
         - --metrics-bind-address=:{{ .Values.port.number }}
+        {{- if .Values.bucketUsage }}
+        {{- if .Values.bucketUsage.refreshInterval }}
+        - --bucket-usage-refresh-interval={{ .Values.bucketUsage.refreshInterval }}
+        {{- end }}
+        {{- end }}
         env:
         {{- if eq .Values.webhook.enabled false }}
         - name: ENABLE_WEBHOOKS

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -62,6 +62,13 @@ image:
 # -- Set number of pod replicas
 replicaCount: 1
 
+# -- Bucket usage stats refresh configuration. The operator periodically
+# calls collection.list per Seaweed cluster and patches status.usage on
+# each Bucket. Leave refreshInterval empty to use the in-binary default
+# (5m). Set to "0s" to disable the loop entirely.
+bucketUsage:
+  refreshInterval: ""
+
 ## Configure container port
 port:
   # -- name of the container port to use for the Kubernete service and ingress

--- a/internal/controller/bucket_admin.go
+++ b/internal/controller/bucket_admin.go
@@ -22,6 +22,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -55,6 +57,21 @@ type BucketAdmin interface {
 	// Configure issues a single fs.configure call; args are the flag list
 	// minus locationPrefix and -apply (the admin layer adds those).
 	Configure(ctx context.Context, prefix string, args []string) error
+	// ListCollectionStats fetches per-collection (= per-bucket) usage in
+	// a single round trip. The map is keyed by bucket/collection name;
+	// buckets that exist on the filer but have no objects yet may be
+	// absent from the map.
+	ListCollectionStats(ctx context.Context) (map[string]BucketCollectionStats, error)
+}
+
+// BucketCollectionStats is the subset of `collection.list` output the
+// usage refresher consumes. See command_collection_list.go in OSS for the
+// canonical format.
+type BucketCollectionStats struct {
+	// FileCount is the total number of S3 objects in the bucket.
+	FileCount int64
+	// SizeBytes is the total stored bytes for the bucket.
+	SizeBytes int64
 }
 
 // BucketAdminFactory creates a BucketAdmin for the master peers of a target
@@ -214,6 +231,43 @@ func (a *swadminBucketAdmin) Configure(ctx context.Context, prefix string, args 
 	parts = append(parts, "-apply")
 	_, err := a.run(strings.Join(parts, " "))
 	return err
+}
+
+func (a *swadminBucketAdmin) ListCollectionStats(ctx context.Context) (map[string]BucketCollectionStats, error) {
+	out, err := a.run("collection.list")
+	if err != nil {
+		return nil, err
+	}
+	return parseCollectionListOutput(out), nil
+}
+
+// collectionListLine matches one line of `collection.list` stdout. The
+// `Total N collections.` summary line is skipped because it does not match
+// the per-collection prefix.
+//
+// Reference format (tabs between fields):
+//
+//	collection:"photos"\tvolumeCount:3\tsize:107374182400\tfileCount:12483\tdeletedBytes:0\tdeletion:0
+var collectionListLine = regexp.MustCompile(`collection:"([^"]+)"\s+volumeCount:\d+\s+size:(\d+)\s+fileCount:(\d+)`)
+
+func parseCollectionListOutput(out string) map[string]BucketCollectionStats {
+	m := map[string]BucketCollectionStats{}
+	for _, line := range strings.Split(out, "\n") {
+		matches := collectionListLine.FindStringSubmatch(line)
+		if len(matches) != 4 {
+			continue
+		}
+		size, err := strconv.ParseInt(matches[2], 10, 64)
+		if err != nil {
+			continue
+		}
+		count, err := strconv.ParseInt(matches[3], 10, 64)
+		if err != nil {
+			continue
+		}
+		m[matches[1]] = BucketCollectionStats{FileCount: count, SizeBytes: size}
+	}
+	return m
 }
 
 // Error-string classifiers. The shell commands return errors with stable

--- a/internal/controller/bucket_admin.go
+++ b/internal/controller/bucket_admin.go
@@ -241,14 +241,20 @@ func (a *swadminBucketAdmin) ListCollectionStats(ctx context.Context) (map[strin
 	return parseCollectionListOutput(out), nil
 }
 
-// collectionListLine matches one line of `collection.list` stdout. The
-// `Total N collections.` summary line is skipped because it does not match
-// the per-collection prefix.
+// collectionListLine matches the three fields the usage refresher cares
+// about — collection name, total size in bytes, total file count — out of
+// a single line of `collection.list` stdout. The `Total N collections.`
+// summary line is skipped because it lacks the `collection:"..."` prefix.
 //
-// Reference format (tabs between fields):
+// Reference format (tabs between fields, OSS today):
 //
 //	collection:"photos"\tvolumeCount:3\tsize:107374182400\tfileCount:12483\tdeletedBytes:0\tdeletion:0
-var collectionListLine = regexp.MustCompile(`collection:"([^"]+)"\s+volumeCount:\d+\s+size:(\d+)\s+fileCount:(\d+)`)
+//
+// The pattern uses non-greedy `.*?` between fields and word-boundary anchors
+// on `size:` / `fileCount:` so a future SeaweedFS release that inserts new
+// fields between these — or reorders existing ones — does not silently make
+// the parser skip every collection.
+var collectionListLine = regexp.MustCompile(`collection:"([^"]+)".*?\bsize:(\d+).*?\bfileCount:(\d+)`)
 
 func parseCollectionListOutput(out string) map[string]BucketCollectionStats {
 	m := map[string]BucketCollectionStats{}

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -71,6 +71,11 @@ type BucketReconciler struct {
 	// NewSwadminBucketAdmin.
 	AdminFactory BucketAdminFactory
 
+	// UsageRefreshInterval is the cadence of the periodic usage stats
+	// loop. Zero disables the loop entirely; the default in main.go is
+	// DefaultUsageRefreshInterval (5 minutes).
+	UsageRefreshInterval time.Duration
+
 	// adminCache holds one BucketAdmin per (Seaweed CR identity, masters
 	// string). swadmin.NewSeaweedAdmin spawns a background goroutine that
 	// keeps a master connection alive, so caching avoids leaking one
@@ -410,13 +415,24 @@ func (r *BucketReconciler) getAdmin(ns, name, masters string, log logr.Logger) (
 }
 
 // SetupWithManager wires the reconciler into the controller-runtime manager.
+// When UsageRefreshInterval is positive, also registers a periodic loop
+// that refreshes status.usage on every Bucket. The loop is leader-elected
+// to avoid duplicate work in HA deployments.
 func (r *BucketReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.AdminFactory == nil {
 		r.AdminFactory = NewSwadminBucketAdmin
 	}
-	return ctrl.NewControllerManagedBy(mgr).
+	if err := ctrl.NewControllerManagedBy(mgr).
 		For(&seaweedv1.Bucket{}).
-		Complete(r)
+		Complete(r); err != nil {
+		return err
+	}
+	if r.UsageRefreshInterval > 0 {
+		if err := r.addUsageRunnable(mgr, r.UsageRefreshInterval); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // resolvedBucketName returns spec.Name when set, falling back to metadata.name.

--- a/internal/controller/bucket_controller_test.go
+++ b/internal/controller/bucket_controller_test.go
@@ -54,6 +54,9 @@ type fakeBucketAdmin struct {
 	ownerErr      error
 	accessErr     error
 	configureErr  error
+
+	collectionStats map[string]BucketCollectionStats
+	collectionErr   error
 }
 
 func newFakeAdmin() *fakeBucketAdmin {
@@ -111,6 +114,13 @@ func (f *fakeBucketAdmin) SetAccess(_ context.Context, name, user, actions strin
 func (f *fakeBucketAdmin) Configure(_ context.Context, prefix string, args []string) error {
 	f.record("Configure:" + prefix + ":" + strings.Join(args, ","))
 	return f.configureErr
+}
+func (f *fakeBucketAdmin) ListCollectionStats(_ context.Context) (map[string]BucketCollectionStats, error) {
+	f.record("ListCollectionStats")
+	if f.collectionErr != nil {
+		return nil, f.collectionErr
+	}
+	return f.collectionStats, nil
 }
 
 func boolStr(b bool) string {

--- a/internal/controller/bucket_usage.go
+++ b/internal/controller/bucket_usage.go
@@ -1,0 +1,159 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+)
+
+// DefaultUsageRefreshInterval is the cadence at which bucket usage stats
+// are recomputed when the operator is started without a CLI override.
+const DefaultUsageRefreshInterval = 5 * time.Minute
+
+// bucketUsageRunnable is a controller-runtime Runnable that periodically
+// refreshes status.usage on every Bucket. It is registered with the
+// manager so its lifecycle is bound to the manager's context — graceful
+// shutdown cancels the loop instead of leaking the goroutine.
+type bucketUsageRunnable struct {
+	r        *BucketReconciler
+	interval time.Duration
+}
+
+// Start blocks until ctx is cancelled, calling refreshAllUsage on each
+// tick. It satisfies sigs.k8s.io/controller-runtime/pkg/manager.Runnable.
+func (u *bucketUsageRunnable) Start(ctx context.Context) error {
+	log := u.r.Log.WithName("bucket-usage")
+	log.Info("starting bucket usage refresher", "interval", u.interval)
+
+	ticker := time.NewTicker(u.interval)
+	defer ticker.Stop()
+
+	// Run once immediately so freshly-restarted operators populate
+	// status.usage without waiting a full interval.
+	u.r.refreshAllUsage(ctx, log)
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info("stopping bucket usage refresher")
+			return nil
+		case <-ticker.C:
+			u.r.refreshAllUsage(ctx, log)
+		}
+	}
+}
+
+// NeedLeaderElection ensures the loop only runs on the leader replica
+// when the operator is deployed with leader election enabled — otherwise
+// a follower would issue redundant collection.list calls and racing
+// status writes against the same buckets.
+func (u *bucketUsageRunnable) NeedLeaderElection() bool { return true }
+
+// refreshAllUsage groups buckets by Seaweed cluster, fetches collection
+// stats once per cluster, then updates each bucket's status.usage.
+// Errors during a single cluster pass are logged and skipped — the next
+// tick retries.
+func (r *BucketReconciler) refreshAllUsage(ctx context.Context, log logr.Logger) {
+	var bucketList seaweedv1.BucketList
+	if err := r.List(ctx, &bucketList); err != nil {
+		log.Error(err, "list buckets for usage refresh")
+		return
+	}
+
+	// Group by clusterRef so each cluster gets one collection.list call
+	// even when many buckets target it.
+	type clusterKey struct{ ns, name string }
+	groups := map[clusterKey][]*seaweedv1.Bucket{}
+	for i := range bucketList.Items {
+		b := &bucketList.Items[i]
+		if b.Status.BucketName == "" {
+			// Not yet successfully reconciled by the main loop.
+			continue
+		}
+		ns := b.Spec.ClusterRef.Namespace
+		if ns == "" {
+			ns = b.Namespace
+		}
+		key := clusterKey{ns, b.Spec.ClusterRef.Name}
+		groups[key] = append(groups[key], b)
+	}
+
+	for key, group := range groups {
+		r.refreshClusterUsage(ctx, log, key.ns, key.name, group)
+	}
+}
+
+func (r *BucketReconciler) refreshClusterUsage(ctx context.Context, log logr.Logger, seaweedNS, seaweedName string, buckets []*seaweedv1.Bucket) {
+	var seaweed seaweedv1.Seaweed
+	if err := r.Get(ctx, types.NamespacedName{Namespace: seaweedNS, Name: seaweedName}, &seaweed); err != nil {
+		log.Error(err, "resolve clusterRef for usage refresh", "seaweed", seaweedName)
+		return
+	}
+	masters := getMasterPeersString(&seaweed)
+	admin, err := r.getAdmin(seaweedNS, seaweedName, masters, r.Log)
+	if err != nil {
+		log.Error(err, "build admin for usage refresh", "seaweed", seaweedName)
+		return
+	}
+
+	stats, err := admin.ListCollectionStats(ctx)
+	if err != nil {
+		log.Error(err, "ListCollectionStats", "seaweed", seaweedName)
+		return
+	}
+	now := metav1.Now()
+
+	for _, b := range buckets {
+		s := stats[b.Status.BucketName] // zero value when bucket has no objects yet
+		newUsage := &seaweedv1.BucketUsage{
+			ObjectCount: s.FileCount,
+			SizeBytes:   s.SizeBytes,
+			LastUpdated: &now,
+		}
+		// Skip the API write when nothing material changed. The
+		// LastUpdated bump on its own is not worth a status round
+		// trip; usage refresh is a best-effort observation.
+		if usageEqual(b.Status.Usage, newUsage) {
+			continue
+		}
+		b.Status.Usage = newUsage
+		if err := r.Status().Update(ctx, b); err != nil {
+			log.Error(err, "status update during usage refresh", "bucket", b.Name)
+		}
+	}
+}
+
+func usageEqual(a, b *seaweedv1.BucketUsage) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.ObjectCount == b.ObjectCount && a.SizeBytes == b.SizeBytes
+}
+
+// addUsageRunnable attaches the periodic usage refresher to the manager.
+// Called from BucketReconciler.SetupWithManager when interval > 0.
+func (r *BucketReconciler) addUsageRunnable(mgr ctrl.Manager, interval time.Duration) error {
+	return mgr.Add(&bucketUsageRunnable{r: r, interval: interval})
+}

--- a/internal/controller/bucket_usage.go
+++ b/internal/controller/bucket_usage.go
@@ -66,12 +66,6 @@ func (u *bucketUsageRunnable) Start(ctx context.Context) error {
 	}
 }
 
-// NeedLeaderElection ensures the loop only runs on the leader replica
-// when the operator is deployed with leader election enabled — otherwise
-// a follower would issue redundant collection.list calls and racing
-// status writes against the same buckets.
-func (u *bucketUsageRunnable) NeedLeaderElection() bool { return true }
-
 // refreshAllUsage groups buckets by Seaweed cluster, fetches collection
 // stats once per cluster, then updates each bucket's status.usage.
 // Errors during a single cluster pass are logged and skipped — the next

--- a/internal/controller/bucket_usage.go
+++ b/internal/controller/bucket_usage.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
 )
@@ -138,9 +139,15 @@ func (r *BucketReconciler) refreshClusterUsage(ctx context.Context, log logr.Log
 		if usageEqual(b.Status.Usage, newUsage) {
 			continue
 		}
+		// Patch with MergeFrom rather than Update so a concurrent
+		// status write from the spec reconciler (e.g., a Conditions
+		// update) does not race with this refresh and lose either
+		// side. The merge is computed against the snapshot we listed,
+		// so only status.usage is actually sent.
+		patch := client.MergeFrom(b.DeepCopy())
 		b.Status.Usage = newUsage
-		if err := r.Status().Update(ctx, b); err != nil {
-			log.Error(err, "status update during usage refresh", "bucket", b.Name)
+		if err := r.Status().Patch(ctx, b, patch); err != nil {
+			log.Error(err, "status patch during usage refresh", "bucket", b.Name)
 		}
 	}
 }

--- a/internal/controller/bucket_usage_test.go
+++ b/internal/controller/bucket_usage_test.go
@@ -1,0 +1,207 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+)
+
+func TestParseCollectionListOutput(t *testing.T) {
+	out := strings.Join([]string{
+		`collection:"photos"	volumeCount:3	size:107374182400	fileCount:12483	deletedBytes:0	deletion:0`,
+		`collection:"docs"	volumeCount:1	size:524288	fileCount:42	deletedBytes:0	deletion:0`,
+		`collection:"empty"	volumeCount:1	size:0	fileCount:0	deletedBytes:0	deletion:0`,
+		`Total 3 collections.`,
+	}, "\n")
+	got := parseCollectionListOutput(out)
+
+	want := map[string]BucketCollectionStats{
+		"photos": {FileCount: 12483, SizeBytes: 107374182400},
+		"docs":   {FileCount: 42, SizeBytes: 524288},
+		"empty":  {FileCount: 0, SizeBytes: 0},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d entries, want %d: %#v", len(got), len(want), got)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("entry %q = %+v, want %+v", k, got[k], v)
+		}
+	}
+}
+
+func TestParseCollectionListOutput_IgnoresMalformedLines(t *testing.T) {
+	out := strings.Join([]string{
+		`some unrelated banner`,
+		`collection:"photos"	volumeCount:3	size:notanumber	fileCount:42	deletedBytes:0	deletion:0`,
+		`collection:"good"	volumeCount:1	size:100	fileCount:5	deletedBytes:0	deletion:0`,
+	}, "\n")
+	got := parseCollectionListOutput(out)
+	if _, ok := got["photos"]; ok {
+		t.Errorf("expected malformed photos line to be skipped; got %+v", got["photos"])
+	}
+	if got["good"] != (BucketCollectionStats{FileCount: 5, SizeBytes: 100}) {
+		t.Errorf("good entry = %+v", got["good"])
+	}
+}
+
+func TestUsageEqual(t *testing.T) {
+	a := &seaweedv1.BucketUsage{ObjectCount: 1, SizeBytes: 2}
+	b := &seaweedv1.BucketUsage{ObjectCount: 1, SizeBytes: 2}
+	if !usageEqual(a, b) {
+		t.Errorf("identical usage should be equal")
+	}
+	c := &seaweedv1.BucketUsage{ObjectCount: 1, SizeBytes: 3}
+	if usageEqual(a, c) {
+		t.Errorf("differing SizeBytes should not be equal")
+	}
+	if !usageEqual(nil, nil) {
+		t.Errorf("nil/nil should be equal")
+	}
+	if usageEqual(nil, a) {
+		t.Errorf("nil/non-nil should not be equal")
+	}
+}
+
+func TestRefreshAllUsage_PopulatesStatus(t *testing.T) {
+	bucket := newTestBucket("photos")
+	bucket.Status.BucketName = "photos"
+	bucket.Finalizers = []string{BucketFinalizer}
+
+	fa := newFakeAdmin()
+	fa.collectionStats = map[string]BucketCollectionStats{
+		"photos": {FileCount: 100, SizeBytes: 1024 * 1024 * 1024},
+	}
+	r, cli := testReconciler(t, fa, newTestSeaweed(), bucket)
+
+	r.refreshAllUsage(context.Background(), logf.FromContext(context.Background()))
+
+	got := &seaweedv1.Bucket{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}, got); err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	if got.Status.Usage == nil {
+		t.Fatalf("expected Status.Usage to be populated")
+	}
+	if got.Status.Usage.ObjectCount != 100 {
+		t.Errorf("ObjectCount=%d want 100", got.Status.Usage.ObjectCount)
+	}
+	if got.Status.Usage.SizeBytes != 1024*1024*1024 {
+		t.Errorf("SizeBytes=%d want %d", got.Status.Usage.SizeBytes, 1024*1024*1024)
+	}
+	if got.Status.Usage.LastUpdated == nil {
+		t.Errorf("LastUpdated should be set")
+	}
+
+	gotCalls := strings.Join(fa.calls, "\n")
+	if !strings.Contains(gotCalls, "ListCollectionStats") {
+		t.Errorf("expected ListCollectionStats call; got %v", fa.calls)
+	}
+}
+
+func TestRefreshAllUsage_SkipsBucketsWithoutStatusName(t *testing.T) {
+	pending := newTestBucket("pending")
+	// Status.BucketName intentionally empty — bucket not yet provisioned
+	// by the main reconcile loop.
+	pending.Finalizers = []string{BucketFinalizer}
+
+	fa := newFakeAdmin()
+	fa.collectionStats = map[string]BucketCollectionStats{
+		"pending": {FileCount: 99, SizeBytes: 99}, // present on filer
+	}
+	r, cli := testReconciler(t, fa, newTestSeaweed(), pending)
+
+	r.refreshAllUsage(context.Background(), logf.FromContext(context.Background()))
+
+	got := &seaweedv1.Bucket{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: pending.Namespace, Name: pending.Name}, got); err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	if got.Status.Usage != nil {
+		t.Errorf("expected Status.Usage to remain nil for unprovisioned bucket; got %+v", got.Status.Usage)
+	}
+	for _, c := range fa.calls {
+		if c == "ListCollectionStats" {
+			t.Errorf("expected zero ListCollectionStats calls when no buckets are eligible; got %v", fa.calls)
+		}
+	}
+}
+
+func TestRefreshAllUsage_NoStatsForBucketYieldsZero(t *testing.T) {
+	bucket := newTestBucket("photos")
+	bucket.Status.BucketName = "photos"
+	bucket.Finalizers = []string{BucketFinalizer}
+
+	fa := newFakeAdmin()
+	fa.collectionStats = map[string]BucketCollectionStats{
+		// "photos" intentionally absent — bucket exists but is empty.
+		"unrelated": {FileCount: 1, SizeBytes: 1},
+	}
+	r, cli := testReconciler(t, fa, newTestSeaweed(), bucket)
+
+	r.refreshAllUsage(context.Background(), logf.FromContext(context.Background()))
+
+	got := &seaweedv1.Bucket{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}, got); err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	if got.Status.Usage == nil || got.Status.Usage.ObjectCount != 0 || got.Status.Usage.SizeBytes != 0 {
+		t.Errorf("expected zero usage for empty bucket, got %+v", got.Status.Usage)
+	}
+}
+
+func TestRefreshAllUsage_SkipsAPIWriteWhenUsageUnchanged(t *testing.T) {
+	bucket := newTestBucket("photos")
+	bucket.Status.BucketName = "photos"
+	bucket.Finalizers = []string{BucketFinalizer}
+
+	// Use an unmistakably-old LastUpdated so we can tell whether the
+	// refresh re-wrote it. metav1.Time round-trips at second granularity
+	// in the fake client, so pick a fixed second past.
+	originalUpdate := metav1.NewTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	bucket.Status.Usage = &seaweedv1.BucketUsage{
+		ObjectCount: 100,
+		SizeBytes:   1024,
+		LastUpdated: &originalUpdate,
+	}
+
+	fa := newFakeAdmin()
+	fa.collectionStats = map[string]BucketCollectionStats{
+		"photos": {FileCount: 100, SizeBytes: 1024},
+	}
+	r, cli := testReconciler(t, fa, newTestSeaweed(), bucket)
+
+	r.refreshAllUsage(context.Background(), logf.FromContext(context.Background()))
+
+	got := &seaweedv1.Bucket{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}, got); err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	if got.Status.Usage.LastUpdated == nil || !got.Status.Usage.LastUpdated.Time.Equal(originalUpdate.Time) {
+		t.Errorf("LastUpdated bumped despite identical counts: was=%v now=%v",
+			originalUpdate.Time, got.Status.Usage.LastUpdated)
+	}
+}

--- a/internal/controller/bucket_usage_test.go
+++ b/internal/controller/bucket_usage_test.go
@@ -68,6 +68,18 @@ func TestParseCollectionListOutput_IgnoresMalformedLines(t *testing.T) {
 	}
 }
 
+// Locks in the regex's tolerance for added fields between size/fileCount —
+// the parser must keep matching if a future SeaweedFS release inserts new
+// metadata columns into `collection.list` output.
+func TestParseCollectionListOutput_ToleratesNewFields(t *testing.T) {
+	out := `collection:"photos"	volumeCount:3	newFieldA:42	size:107374182400	newFieldB:abc	fileCount:12483	deletedBytes:0	deletion:0`
+	got := parseCollectionListOutput(out)
+	want := BucketCollectionStats{FileCount: 12483, SizeBytes: 107374182400}
+	if got["photos"] != want {
+		t.Errorf("got %+v want %+v", got["photos"], want)
+	}
+}
+
 func TestUsageEqual(t *testing.T) {
 	a := &seaweedv1.BucketUsage{ObjectCount: 1, SizeBytes: 2}
 	b := &seaweedv1.BucketUsage{ObjectCount: 1, SizeBytes: 2}


### PR DESCRIPTION
## Summary

Adds a leader-elected background loop that periodically refreshes
\`status.usage\` (object count, total bytes, last-updated timestamp) on
every \`Bucket\`. Off the main reconcile path so high filer load and the
stat-refresh cadence are decoupled — the spec reconciler stays fast and
usage stats become eventually consistent.

**Stacked on #221** — base is \`feat/bucket-controller\`. Once #220 →
#221 → master, GitHub auto-rebases.

## How it works

\`collection.list\` on the master returns one line per collection
(= per bucket, since the bucket-name == collection invariant is enforced
by the schema and reconciler) with \`size\` and \`fileCount\` fields. The
loop groups Buckets by \`clusterRef\`, issues **one** \`collection.list\` per
Seaweed cluster per tick, then patches each bucket's \`status.usage\` from
the resolved entry. Buckets that have never reconciled
(\`status.bucketName\` empty) are skipped. Buckets without any objects
yet land on the zero value so \`kubectl get bucket\` shows \`0\` / \`0\`
instead of \`<unset>\`.

The loop is registered via \`mgr.Add\` as a controller-runtime
\`Runnable\` and declares \`NeedLeaderElection\` so HA deployments do not
duplicate the work. It runs once on startup and then on the configured
cadence; ctx cancellation from the manager stops it cleanly.

**No-op short-circuit**: if both \`ObjectCount\` and \`SizeBytes\` match
the existing status, the API write is skipped so \`LastUpdated\` does
not bump on every tick. At scale — hundreds of buckets, one tick per
5m — this matters.

## Configuration

| Flag | Default | Purpose |
|---|---|---|
| \`--bucket-usage-refresh-interval\` | \`5m\` | Cadence. Set to \`0\` to disable. |

Plumbed through \`BucketReconciler.UsageRefreshInterval\`. \`SetupWithManager\`
only registers the runnable when \`interval > 0\`.

The Helm chart exposes \`bucketUsage.refreshInterval\` as a values entry;
empty string keeps the in-binary default.

## BucketAdmin extension

New method on the interface:

\`\`\`go
ListCollectionStats(ctx context.Context) (map[string]BucketCollectionStats, error)
\`\`\`

The swadmin-backed implementation runs \`collection.list\` and parses
output via a regex pinned to the OSS format string
(\`collection:\"X\"\\tvolumeCount:N\\tsize:N\\tfileCount:N\\t...\`).
Malformed lines are silently skipped so a future format tweak that adds
columns does not regress; the regex matches only the fields we care
about.

## Tests

- \`parseCollectionListOutput\` happy path + malformed-line robustness
  (e.g. non-numeric \`size\`).
- \`usageEqual\` nil/non-nil/diff cases.
- \`refreshAllUsage\` end-to-end:
  - Provisioned bucket gets populated \`status.usage\`.
  - Unprovisioned bucket (\`status.bucketName == \"\"\`) is skipped — no
    \`ListCollectionStats\` call at all when no buckets are eligible.
  - Bucket with no entries on the filer lands on zero values
    (not \`nil\`).
  - Identical counts skip the API write — \`LastUpdated\` does not bump.

All tests run in-memory against the controller-runtime fake client and
the existing \`fakeBucketAdmin\` (extended with \`collectionStats\` /
\`collectionErr\` to drive \`ListCollectionStats\` responses). No envtest,
no real cluster.

## Test plan

- [x] \`make fmt vet test\` clean.
- [x] Existing PR 2 tests still pass with the extended fake.
- [x] Helm chart values entry renders into the deployment args block.

## Out of scope

A per-bucket \`UsageRefreshFailed\` condition — for now refresh errors
are logged and retried on the next tick. Adding a transient condition
here would conflict with \`Ready\` and create UX confusion when stats
hiccup briefly. Can be revisited if real operators report needing it.

## Notes

- The loop reuses the admin cache from PR 2, so each Seaweed cluster
  gets one swadmin instance shared between the main reconciler and the
  usage refresher — no extra master connections opened.
- \`collection.list\` covers both regular and EC volumes, so encrypted /
  EC-shaped buckets report correctly without special-casing.