### PR TITLE
Stop spurious VolumeClaimTemplates drift on every reconcile (fixes #224)

### DIFF
--- a/internal/controller/seaweed_controller.go
+++ b/internal/controller/seaweed_controller.go
@@ -35,7 +35,6 @@ import (
 
 	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
 	corev1 "k8s.io/api/core/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 )
 
 // ErrStatefulSetDeleted is a sentinel error returned when a StatefulSet is
@@ -451,7 +450,7 @@ func (r *SeaweedReconciler) getVolumeStatus(ctx context.Context, seaweedCR *seaw
 }
 
 func (r *SeaweedReconciler) reconcileVolumeClaimTemplates(ctx context.Context, seaweedCR *seaweedv1.Seaweed, existing, desired *appsv1.StatefulSet) error {
-	if apiequality.Semantic.DeepEqual(existing.Spec.VolumeClaimTemplates, desired.Spec.VolumeClaimTemplates) {
+	if vctSemanticallyEqual(existing.Spec.VolumeClaimTemplates, desired.Spec.VolumeClaimTemplates) {
 		return nil
 	}
 

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -16,84 +16,111 @@ limitations under the License.
 
 package controller
 
-//import (
-//	"path/filepath"
-//	"testing"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	goruntime "runtime"
+	"testing"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+)
+
+// Shared test environment populated by TestMain. Individual tests that
+// need a real apiserver call mustEnvtest() to fetch the config + client
+// or get a clean Skip when the suite couldn't start (e.g., the
+// kubebuilder envtest binaries weren't downloaded). Pure-Go tests in
+// this package don't depend on these globals and run regardless.
+var (
+	envtestEnv    *envtest.Environment
+	envtestCfg    *rest.Config
+	envtestClient client.Client
+)
+
+// TestMain bootstraps an in-process kube-apiserver via envtest and
+// installs the operator's CRDs so tests can exercise round-trip
+// behaviors that the controller-runtime fake client doesn't reproduce
+// (apiserver-side defaulting, CEL admission, ResourceVersion semantics).
 //
-//	. "github.com/onsi/ginkgo"
-//	. "github.com/onsi/gomega"
-//	"k8s.io/client-go/kubernetes/scheme"
-//	"k8s.io/client-go/rest"
-//	ctrl "sigs.k8s.io/controller-runtime"
-//	"sigs.k8s.io/controller-runtime/pkg/client"
-//	"sigs.k8s.io/controller-runtime/pkg/envtest"
-//	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
-//	logf "sigs.k8s.io/controller-runtime/pkg/log"
-//	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-//
-//	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
-//	// +kubebuilder:scaffold:imports
-//)
-//
-//// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-//// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
-//
-//var cfg *rest.Config
-//var k8sClient client.Client
-//var testEnv *envtest.Environment
-//
-//func TestAPIs(t *testing.T) {
-//	RegisterFailHandler(Fail)
-//
-//	RunSpecsWithDefaultAndCustomReporters(t,
-//		"Controller Suite",
-//		[]Reporter{printer.NewlineReporter{}})
-//}
-//
-//var _ = BeforeSuite(func(done Done) {
-//	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-//
-//	By("bootstrapping test environment")
-//	testEnv = &envtest.Environment{
-//		CRDDirectoryPaths: []string{filepath.Join("..", "config", "crd", "bases")},
-//	}
-//
-//	var err error
-//	cfg, err = testEnv.Start()
-//	Expect(err).ToNot(HaveOccurred())
-//	Expect(cfg).ToNot(BeNil())
-//
-//	err = seaweedv1.AddToScheme(scheme.Scheme)
-//	Expect(err).NotTo(HaveOccurred())
-//
-//	// +kubebuilder:scaffold:scheme
-//
-//	k8sClient, _ = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-//	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
-//		Scheme: scheme.Scheme,
-//	})
-//	Expect(err).ToNot(HaveOccurred())
-//
-//	err = (&SeaweedReconciler{
-//		Client: k8sManager.GetClient(),
-//		Log:    ctrl.Log.WithName("controller").WithName("Seaweed"),
-//		Scheme: k8sManager.GetScheme(),
-//	}).SetupWithManager(k8sManager)
-//	Expect(err).ToNot(HaveOccurred())
-//
-//	go func() {
-//		err = k8sManager.Start(ctrl.SetupSignalHandler())
-//		Expect(err).ToNot(HaveOccurred())
-//	}()
-//
-//	Expect(err).ToNot(HaveOccurred())
-//	Expect(k8sClient).ToNot(BeNil())
-//
-//	close(done)
-//}, 60)
-//
-//var _ = AfterSuite(func() {
-//	By("tearing down the test environment")
-//	err := testEnv.Stop()
-//	Expect(err).ToNot(HaveOccurred())
-//})
+// If KUBEBUILDER_ASSETS is unset or envtest fails to start, m.Run()
+// proceeds anyway — envtest-only tests Skip via mustEnvtest while pure
+// unit tests stay green. This means `go test ./...` works on a
+// developer machine that has not run setup-envtest, and `make test`
+// (which sets KUBEBUILDER_ASSETS) exercises the full suite.
+func TestMain(m *testing.M) {
+	if err := startEnvtest(); err != nil {
+		fmt.Fprintf(os.Stderr, "envtest unavailable, envtest-tagged tests will Skip: %v\n", err)
+	}
+	code := m.Run()
+	if envtestEnv != nil {
+		_ = envtestEnv.Stop()
+	}
+	os.Exit(code)
+}
+
+func startEnvtest() error {
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		return fmt.Errorf("KUBEBUILDER_ASSETS unset; run `make test` or set the env var to a setup-envtest assets dir")
+	}
+
+	envtestEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join(projectRoot(), "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+	cfg, err := envtestEnv.Start()
+	if err != nil {
+		envtestEnv = nil
+		return fmt.Errorf("start envtest: %w", err)
+	}
+	envtestCfg = cfg
+
+	scheme := clientgoscheme.Scheme
+	utilruntime.Must(seaweedv1.AddToScheme(scheme))
+
+	cli, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		_ = envtestEnv.Stop()
+		envtestEnv = nil
+		envtestCfg = nil
+		return fmt.Errorf("build envtest client: %w", err)
+	}
+	envtestClient = cli
+	return nil
+}
+
+// mustEnvtest returns the running test environment's config+client, or
+// Skips the calling test when envtest didn't start. Use as the first
+// line in any test that creates real apiserver objects.
+func mustEnvtest(t *testing.T) (*rest.Config, client.Client) {
+	t.Helper()
+	if envtestCfg == nil || envtestClient == nil {
+		t.Skip("envtest not running; set KUBEBUILDER_ASSETS or run via `make test`")
+	}
+	return envtestCfg, envtestClient
+}
+
+// projectRoot resolves the operator repo root by walking up from this
+// file's location until it sees a go.mod. Lets tests run from any cwd.
+func projectRoot() string {
+	_, thisFile, _, ok := goruntime.Caller(0)
+	if !ok {
+		panic("runtime.Caller(0) failed")
+	}
+	dir := filepath.Dir(thisFile)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			panic(fmt.Sprintf("could not find project root from %s", filepath.Dir(thisFile)))
+		}
+		dir = parent
+	}
+}

--- a/internal/controller/volume_claim_templates.go
+++ b/internal/controller/volume_claim_templates.go
@@ -45,7 +45,7 @@ import (
 //   - Selector          Semantic.DeepEqual on *metav1.LabelSelector
 //   - VolumeName        exact string match
 //   - VolumeMode        nil-equivalent-to-Filesystem; Filesystem vs
-//                       Block etc. is still a real diff
+//     Block etc. is still a real diff
 //   - DataSource        Semantic.DeepEqual
 //
 // Fields the operator never sets and the apiserver may populate

--- a/internal/controller/volume_claim_templates.go
+++ b/internal/controller/volume_claim_templates.go
@@ -1,0 +1,111 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+)
+
+// vctSemanticallyEqual returns true when two VolumeClaimTemplates slices
+// describe the same intent over the fields the operator actually owns,
+// tolerating apiserver-side defaulting that round-trips a Created
+// StatefulSet's VCT entries differently from what the operator
+// constructed in memory.
+//
+// The original implementation (apiequality.Semantic.DeepEqual on the
+// whole slice) returns false on every reconcile because the apiserver
+// defaults Spec.VolumeMode to Filesystem when the operator leaves it
+// nil — see issue #224. The reconciler then logs
+// "VolumeClaimTemplates differ but cannot be auto-applied" every 5
+// seconds (the requeue cadence), spamming the events stream and
+// confusing operators into thinking their CR isn't taking effect.
+//
+// Comparison surface, per field the operator can set in any of the
+// component statefulset builders:
+//
+//   - Name              required, exact match
+//   - AccessModes       Semantic.DeepEqual
+//   - Resources.Requests Semantic.DeepEqual (resource.Quantity comparison)
+//   - StorageClassName  pointer-aware: nil == nil, both set must match
+//   - Selector          Semantic.DeepEqual on *metav1.LabelSelector
+//   - VolumeName        exact string match
+//   - VolumeMode        nil-equivalent-to-Filesystem; Filesystem vs
+//                       Block etc. is still a real diff
+//   - DataSource        Semantic.DeepEqual
+//
+// Fields the operator never sets and the apiserver may populate
+// (DataSourceRef pre-CSI-snapshots-graduation, status, etc.) are
+// intentionally not compared. If a future operator change starts
+// setting one of those, add it here and to the unit tests.
+func vctSemanticallyEqual(a, b []corev1.PersistentVolumeClaim) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !pvcSemanticallyEqual(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func pvcSemanticallyEqual(a, b corev1.PersistentVolumeClaim) bool {
+	if a.Name != b.Name {
+		return false
+	}
+	if !apiequality.Semantic.DeepEqual(a.Spec.AccessModes, b.Spec.AccessModes) {
+		return false
+	}
+	if !apiequality.Semantic.DeepEqual(a.Spec.Resources.Requests, b.Spec.Resources.Requests) {
+		return false
+	}
+	if !apiequality.Semantic.DeepEqual(a.Spec.StorageClassName, b.Spec.StorageClassName) {
+		return false
+	}
+	if !apiequality.Semantic.DeepEqual(a.Spec.Selector, b.Spec.Selector) {
+		return false
+	}
+	if a.Spec.VolumeName != b.Spec.VolumeName {
+		return false
+	}
+	if !volumeModeSemanticallyEqual(a.Spec.VolumeMode, b.Spec.VolumeMode) {
+		return false
+	}
+	if !apiequality.Semantic.DeepEqual(a.Spec.DataSource, b.Spec.DataSource) {
+		return false
+	}
+	return true
+}
+
+// volumeModeSemanticallyEqual treats nil VolumeMode as Filesystem,
+// matching apiserver behavior on Create. With this normalization, the
+// "operator left it nil → apiserver stored &Filesystem → re-read
+// returns &Filesystem" flow no longer trips a false-positive diff.
+// Real differences (Filesystem vs Block, set vs explicit Block, etc.)
+// still propagate.
+func volumeModeSemanticallyEqual(a, b *corev1.PersistentVolumeMode) bool {
+	aMode := corev1.PersistentVolumeFilesystem
+	bMode := corev1.PersistentVolumeFilesystem
+	if a != nil {
+		aMode = *a
+	}
+	if b != nil {
+		bMode = *b
+	}
+	return aMode == bMode
+}

--- a/internal/controller/volume_claim_templates_envtest_test.go
+++ b/internal/controller/volume_claim_templates_envtest_test.go
@@ -1,0 +1,146 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+)
+
+// TestReconcileVolumeClaimTemplates_RoundTripWithApiserverDefaults is the
+// end-to-end version of the regression test for issue #224. It builds a
+// volume-server StatefulSet exactly the way the controller does in
+// production, hands it to a real apiserver, reads it back (now carrying
+// the apiserver's defaulted PVC fields), and asserts that
+// reconcileVolumeClaimTemplates does NOT report drift.
+//
+// On master with apiequality.Semantic.DeepEqual, this test fails: the
+// apiserver writes &Filesystem into Spec.VolumeMode and the in-memory
+// desired still has nil, so DeepEqual returns false. With the
+// vctSemanticallyEqual comparator introduced in this PR, it passes.
+//
+// The unit test in volume_claim_templates_test.go covers the comparator
+// in isolation; this test catches the case where the operator and
+// apiserver disagree about a default that the unit test author didn't
+// foresee — any future apiserver-side default that lands on a PVC field
+// the comparator doesn't already handle would surface here.
+func TestReconcileVolumeClaimTemplates_RoundTripWithApiserverDefaults(t *testing.T) {
+	_, cli := mustEnvtest(t)
+	ctx := context.Background()
+
+	ns := newTestNamespace(t, ctx, cli, "vct-roundtrip")
+	t.Cleanup(func() {
+		_ = cli.Delete(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	})
+
+	cr := minimalVolumeSeaweedCR(ns)
+
+	r := &SeaweedReconciler{
+		Client: cli,
+		Log:    logf.FromContext(ctx),
+		Scheme: cli.Scheme(),
+	}
+
+	// Build the desired SS the exact way the controller does, then
+	// realize it on the apiserver. The apiserver will fill in defaults
+	// on the PVC templates (notably Spec.VolumeMode).
+	desired := r.createVolumeServerStatefulSet(cr)
+	desired.Namespace = ns
+	if err := cli.Create(ctx, desired); err != nil {
+		t.Fatalf("create StatefulSet: %v", err)
+	}
+
+	// Read it back — this is the version reconcileVolumeClaimTemplates
+	// would compare against on a follow-up reconcile.
+	var existing appsv1.StatefulSet
+	key := types.NamespacedName{Namespace: ns, Name: desired.Name}
+	if err := cli.Get(ctx, key, &existing); err != nil {
+		t.Fatalf("get StatefulSet: %v", err)
+	}
+
+	// Sanity: apiserver actually injected a non-nil VolumeMode. Without
+	// that the test isn't proving anything beyond the unit test.
+	if len(existing.Spec.VolumeClaimTemplates) == 0 {
+		t.Fatalf("expected at least one VCT, got 0")
+	}
+	if existing.Spec.VolumeClaimTemplates[0].Spec.VolumeMode == nil {
+		t.Fatalf("expected apiserver to default Spec.VolumeMode after Create; got nil — apiserver behavior may have changed")
+	}
+
+	// The actual fix property: rebuild the desired (operator's
+	// in-memory view) and ask whether reconcile would think it
+	// differs from what's on the apiserver.
+	freshDesired := r.createVolumeServerStatefulSet(cr)
+	if !vctSemanticallyEqual(existing.Spec.VolumeClaimTemplates, freshDesired.Spec.VolumeClaimTemplates) {
+		t.Errorf("vctSemanticallyEqual reports drift after apiserver round-trip; reconciler would log a Warning event every reconcile")
+		t.Errorf("  existing VCTs:  %+v", existing.Spec.VolumeClaimTemplates)
+		t.Errorf("  desired  VCTs:  %+v", freshDesired.Spec.VolumeClaimTemplates)
+	}
+}
+
+// minimalVolumeSeaweedCR builds the smallest Seaweed CR that still
+// drives createVolumeServerStatefulSet through the persistence path
+// (volumeCount > 0, with a real storage request). Anything else the
+// helper reads off the spec uses defaults via component_accessor.go.
+func minimalVolumeSeaweedCR(namespace string) *seaweedv1.Seaweed {
+	one := int32(1)
+	return &seaweedv1.Seaweed{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vct",
+			Namespace: namespace,
+		},
+		Spec: seaweedv1.SeaweedSpec{
+			Image:                 "chrislusf/seaweedfs:latest",
+			VolumeServerDiskCount: &one,
+			Master:                &seaweedv1.MasterSpec{Replicas: 1},
+			Volume: &seaweedv1.VolumeSpec{
+				Replicas: 1,
+				VolumeServerConfig: seaweedv1.VolumeServerConfig{
+					ResourceRequirements: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("1Gi"),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// newTestNamespace creates a uniquely-named Namespace so concurrent
+// envtest tests don't step on each other's StatefulSets/PVCs. Returns
+// the namespace name. Caller is responsible for cleanup via t.Cleanup.
+func newTestNamespace(t *testing.T, ctx context.Context, cli client.Client, prefix string) string {
+	t.Helper()
+	name := fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
+	if err := cli.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}); err != nil {
+		t.Fatalf("create namespace %s: %v", name, err)
+	}
+	return name
+}

--- a/internal/controller/volume_claim_templates_test.go
+++ b/internal/controller/volume_claim_templates_test.go
@@ -1,0 +1,145 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestVCTSemanticallyEqual_HandlesApiserverDefaultedVolumeMode is the
+// regression test for issue #224. The operator builds a desired PVC
+// template with VolumeMode unset (nil); the apiserver fills it with
+// &Filesystem on Create. apiequality.Semantic.DeepEqual on the two
+// returns false, which makes reconcileVolumeClaimTemplates think the
+// VCT differs on every reconcile, log a warning, and emit a Warning
+// event — every 5 seconds, forever.
+//
+// The test constructs the two states by hand so it's fast and doesn't
+// need envtest. The end-to-end version (envtest_volume_claim_templates_test.go)
+// proves the same property against a real apiserver round-trip.
+func TestVCTSemanticallyEqual_HandlesApiserverDefaultedVolumeMode(t *testing.T) {
+	desired := []corev1.PersistentVolumeClaim{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "data"},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("100Gi"),
+					},
+				},
+			},
+		},
+	}
+
+	// Mimic what the apiserver returns after Create: same fields plus
+	// VolumeMode defaulted to Filesystem, and a generated UID/CreationTimestamp
+	// that Semantic.DeepEqual would also have caught. Here we only inject
+	// the spec-level default, since metadata is excluded from the controller's
+	// comparison anyway.
+	filesystem := corev1.PersistentVolumeFilesystem
+	existing := []corev1.PersistentVolumeClaim{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "data"},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("100Gi"),
+					},
+				},
+				VolumeMode: &filesystem, // <-- the apiserver default
+			},
+		},
+	}
+
+	if !vctSemanticallyEqual(existing, desired) {
+		t.Errorf("expected vctSemanticallyEqual to treat nil VolumeMode and &Filesystem as equivalent (issue #224 regression)")
+	}
+}
+
+func TestVCTSemanticallyEqual_DetectsRealStorageDiff(t *testing.T) {
+	mk := func(size string) []corev1.PersistentVolumeClaim {
+		return []corev1.PersistentVolumeClaim{{
+			ObjectMeta: metav1.ObjectMeta{Name: "data"},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse(size),
+					},
+				},
+			},
+		}}
+	}
+	if vctSemanticallyEqual(mk("100Gi"), mk("200Gi")) {
+		t.Errorf("expected size diff to be detected — comparator must not be too lenient")
+	}
+}
+
+func TestVCTSemanticallyEqual_DetectsRealStorageClassDiff(t *testing.T) {
+	mk := func(class string) []corev1.PersistentVolumeClaim {
+		var sc *string
+		if class != "" {
+			sc = &class
+		}
+		return []corev1.PersistentVolumeClaim{{
+			ObjectMeta: metav1.ObjectMeta{Name: "data"},
+			Spec:       corev1.PersistentVolumeClaimSpec{StorageClassName: sc},
+		}}
+	}
+	if vctSemanticallyEqual(mk("fast"), mk("slow")) {
+		t.Errorf("expected StorageClassName diff to be detected")
+	}
+	if !vctSemanticallyEqual(mk(""), mk("")) {
+		t.Errorf("expected matching nil StorageClassName to be equal")
+	}
+	if vctSemanticallyEqual(mk(""), mk("fast")) {
+		t.Errorf("expected nil vs set StorageClassName to be detected")
+	}
+}
+
+func TestVCTSemanticallyEqual_DetectsLengthDiff(t *testing.T) {
+	one := []corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "a"}}}
+	two := []corev1.PersistentVolumeClaim{
+		{ObjectMeta: metav1.ObjectMeta{Name: "a"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "b"}},
+	}
+	if vctSemanticallyEqual(one, two) {
+		t.Errorf("expected length diff to be detected")
+	}
+}
+
+func TestVCTSemanticallyEqual_DetectsExplicitlyDifferentVolumeMode(t *testing.T) {
+	filesystem := corev1.PersistentVolumeFilesystem
+	block := corev1.PersistentVolumeBlock
+	a := []corev1.PersistentVolumeClaim{{
+		ObjectMeta: metav1.ObjectMeta{Name: "data"},
+		Spec:       corev1.PersistentVolumeClaimSpec{VolumeMode: &filesystem},
+	}}
+	b := []corev1.PersistentVolumeClaim{{
+		ObjectMeta: metav1.ObjectMeta{Name: "data"},
+		Spec:       corev1.PersistentVolumeClaimSpec{VolumeMode: &block},
+	}}
+	if vctSemanticallyEqual(a, b) {
+		t.Errorf("expected Filesystem vs Block VolumeMode to be detected — only the nil-vs-Filesystem case should be smoothed")
+	}
+}


### PR DESCRIPTION
## Summary

Issue #224: long-running clusters that upgrade to 1.0.15 emit

\`\`\`
VolumeClaimTemplates differ but cannot be auto-applied. Delete the
StatefulSet manually to apply changes.
\`\`\`

every 5 seconds for the master / volume / filer / topology
StatefulSets. Deleting the StatefulSet, recreating from scratch,
even fully recreating the Seaweed CR — none of it stops the spam.

Root cause: \`reconcileVolumeClaimTemplates\` uses
\`apiequality.Semantic.DeepEqual\` on the entire VCT slice. The
apiserver defaults \`Spec.VolumeMode\` to \`&Filesystem\` on Create when
the operator leaves it nil. The desired in-memory view still has
\`nil\`. DeepEqual returns false on every reconcile, the Warning event
fires, and the 5-second \`RequeueAfter\` cadence keeps it cycling.

## What's in the PR

Four commits, separated to keep each diff reviewable:

1. \`Revive envtest scaffold for the controller package\` — replaces the
   commented-out Ginkgo suite with a TestMain-based envtest harness.
   Pure-Go tests in the package run regardless; envtest tests Skip
   when KUBEBUILDER_ASSETS is unset (so \`go test ./...\` works on a
   developer machine without setup-envtest, and \`make test\` exercises
   the full path).
2. \`Introduce vctSemanticallyEqual ignoring apiserver-defaulted VolumeMode\` —
   new comparator + 5 unit tests covering the regression case and four
   real-diff cases (storage size, storage class, length, explicit
   VolumeMode change).
3. \`Use vctSemanticallyEqual in reconcileVolumeClaimTemplates (fixes #224)\` —
   one-line call-site swap in seaweed_controller.go, plus drop of the
   now-unused apiequality import. **The user-visible fix.**
4. \`Add envtest round-trip test for VolumeClaimTemplates comparison\` —
   end-to-end test that creates a real StatefulSet via envtest, reads
   it back with apiserver defaults applied, and asserts the comparator
   returns true. Catches future apiserver-side defaulting on PVC
   fields the unit-test author didn't foresee.

## Comparison surface

The new comparator scopes equality to fields the operator can set in
any of the \`createXxxStatefulSet\` helpers, with one normalization:

| Field | Comparison |
|---|---|
| \`Name\` | exact match |
| \`AccessModes\` | Semantic.DeepEqual |
| \`Resources.Requests\` | Semantic.DeepEqual (resource.Quantity) |
| \`StorageClassName\` | Semantic.DeepEqual on \`*string\` (nil-aware) |
| \`Selector\` | Semantic.DeepEqual on \`*metav1.LabelSelector\` |
| \`VolumeName\` | exact string match |
| **\`VolumeMode\`** | **nil-equivalent-to-Filesystem**; explicit Filesystem-vs-Block diff still propagates |
| \`DataSource\` | Semantic.DeepEqual |

Fields the operator never sets are intentionally omitted — that
includes status fields and (today) DataSourceRef, which apiserver may
auto-populate from DataSource in newer k8s versions. If a future
operator change starts setting one of those, both the comparator and
the unit tests need a corresponding line; the godoc on
\`vctSemanticallyEqual\` calls this out explicitly.

## Why both unit and envtest tests

The unit test (\`volume_claim_templates_test.go\`) handcrafts the
apiserver-defaulted VCT shape and is the regression test for the exact
field. It's fast and deterministic.

The envtest round-trip (\`volume_claim_templates_envtest_test.go\`)
catches the broader class: any future apiserver-side default that
lands on a PVC field the comparator didn't already know about would
surface here even if no one updated the unit test. Empirically
validated by running a one-shot demo that swapped the new comparator
back to \`apiequality.Semantic.DeepEqual\` — the same round-trip
reports drift, confirming the test exercises the bug path.

## Test plan

- [x] \`make test\` (with envtest) passes including the new envtest case.
- [x] \`go test ./internal/controller/\` (no KUBEBUILDER_ASSETS) — envtest
  test cleanly Skips, unit test passes.
- [x] Sanity check: temporarily reverted commit 3 to use
  apiequality.Semantic.DeepEqual; envtest round-trip test failed as
  expected; restored.
- [x] Existing controller_admin_statefulset_test, helper_test, bucket
  tests all still green.

## Notes

- Out of scope: the 5-second unconditional \`RequeueAfter\` in
  \`Reconcile\` (line 159 of seaweed_controller.go). With the VCT bug
  fixed the per-tick reconcile is a no-op semantically; the only
  visible effect is small-scale CPU/network for the periodic
  re-list. If you'd like that throttled too, happy to do a follow-up
  PR — but separately, since the change there has different blast
  radius (affects how quickly the controller catches drift the
  apiserver-side reflector hasn't notified about yet).
- \`test/helm/rbac_drift_test.go\` from #225 already runs in this PR's
  CI and stays green; no changes needed.