### PR TITLE
Throttle Reconcile requeue cadence based on readiness

### DIFF
--- a/internal/controller/seaweed_controller.go
+++ b/internal/controller/seaweed_controller.go
@@ -388,10 +388,13 @@ func (r *SeaweedReconciler) updateStatus(ctx context.Context, seaweedCR *seaweed
 		if errors.IsConflict(err) {
 			log.V(2).Info("Conflict while updating Seaweed status; will retry on next reconciliation")
 			// Do not treat conflict as a hard error to avoid unnecessary requeues.
-			// Return the readiness we computed so the caller still picks
-			// the right cadence — the conflict means our snapshot was
-			// stale, not that readiness flipped.
-			return isReady, nil
+			// Force the fast cadence: the persisted status was NOT updated
+			// (the conflict aborted our write), so as far as any observer
+			// is concerned the CR may still report stale NotReady values.
+			// Returning isReady=true here would defer the retry by up to
+			// a minute. Return false so the next reconcile fires within
+			// requeueWhileReconciling and the status catches up promptly.
+			return false, nil
 		}
 		return false, err
 	}

--- a/internal/controller/seaweed_controller.go
+++ b/internal/controller/seaweed_controller.go
@@ -51,6 +51,40 @@ const (
 	ComponentWorker = "worker"
 )
 
+// Reconcile cadences. The reconciler pulls itself back periodically via
+// RequeueAfter rather than relying solely on watches, so transient
+// status changes the apiserver-side reflector might miss still get
+// caught. The interval depends on whether the cluster has converged:
+//
+//   - requeueWhileReconciling: status hasn't reached Ready yet — pods
+//     are still rolling out, components are coming up. Tight cadence
+//     so the user sees Replicas/ReadyReplicas catch up promptly.
+//   - requeueWhenReady: every owned component reports its desired
+//     replica count is fully ready. The reconciler is just refreshing
+//     status as a safety net; a slower cadence dramatically reduces
+//     the per-CR baseline load on the apiserver and the operator's
+//     log volume in steady state.
+//
+// At the previous unconditional 5s, a single Seaweed CR generated
+// ~17,280 reconcile passes / day even when nothing changed. With 1m
+// in steady state, ~1,440 / day — same convergence properties for
+// transitions, much less noise at rest.
+const (
+	requeueWhileReconciling = 5 * time.Second
+	requeueWhenReady        = 1 * time.Minute
+)
+
+// reconcileRequeueAfter returns the interval Reconcile should request
+// based on whether status reports the cluster is Ready. Extracted so
+// the cadence policy is unit-testable without driving a full
+// reconcile pass.
+func reconcileRequeueAfter(isReady bool) time.Duration {
+	if isReady {
+		return requeueWhenReady
+	}
+	return requeueWhileReconciling
+}
+
 // SeaweedReconciler reconciles a Seaweed object
 type SeaweedReconciler struct {
 	client.Client
@@ -150,13 +184,17 @@ func (r *SeaweedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 	}
 
-	// Update status
-	if err := r.updateStatus(ctx, seaweedCR); err != nil {
+	// Update status. The returned readiness flag chooses the requeue
+	// cadence: tight while the cluster is still rolling out, slower
+	// once everything reports Ready (the periodic loop is then just
+	// a safety net for events the watch might have missed).
+	isReady, err := r.updateStatus(ctx, seaweedCR)
+	if err != nil {
 		log.Error(err, "Failed to update Seaweed status")
 		return ctrl.Result{}, err
 	}
 
-	return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	return ctrl.Result{RequeueAfter: reconcileRequeueAfter(isReady)}, nil
 }
 
 func (r *SeaweedReconciler) findSeaweedCustomResourceInstance(ctx context.Context, log logr.Logger, req ctrl.Request) (*seaweedv1.Seaweed, bool, ctrl.Result, error) {
@@ -185,21 +223,27 @@ func (r *SeaweedReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (r *SeaweedReconciler) updateStatus(ctx context.Context, seaweedCR *seaweedv1.Seaweed) error {
+// updateStatus refreshes the Seaweed CR's status from the live state of
+// every owned component, then writes the result. It also returns the
+// readiness signal so Reconcile can decide how aggressively to requeue
+// itself: 5s while components are still rolling out (status converges
+// quickly), 1m once Ready=True (watches catch real changes; the periodic
+// loop is just a belt-and-suspenders safety net).
+func (r *SeaweedReconciler) updateStatus(ctx context.Context, seaweedCR *seaweedv1.Seaweed) (isReady bool, err error) {
 	log := r.Log.WithValues("seaweed", seaweedCR.Name)
 
 	// Get master statefulset status
 	masterStatus, err := r.getComponentStatus(ctx, seaweedCR, ComponentMaster)
 	if err != nil {
 		log.Error(err, "Failed to get master status")
-		return err
+		return false, err
 	}
 
 	// Get volume statefulset status
 	volumeStatus, err := r.getComponentStatus(ctx, seaweedCR, ComponentVolume)
 	if err != nil {
 		log.Error(err, "Failed to get volume status")
-		return err
+		return false, err
 	}
 
 	// Get filer statefulset status (if enabled)
@@ -208,7 +252,7 @@ func (r *SeaweedReconciler) updateStatus(ctx context.Context, seaweedCR *seaweed
 		filerStatus, err = r.getComponentStatus(ctx, seaweedCR, ComponentFiler)
 		if err != nil {
 			log.Error(err, "Failed to get filer status")
-			return err
+			return false, err
 		}
 	}
 
@@ -218,7 +262,7 @@ func (r *SeaweedReconciler) updateStatus(ctx context.Context, seaweedCR *seaweed
 		adminStatus, err = r.getComponentStatus(ctx, seaweedCR, ComponentAdmin)
 		if err != nil {
 			log.Error(err, "Failed to get admin status")
-			return err
+			return false, err
 		}
 	}
 
@@ -228,7 +272,7 @@ func (r *SeaweedReconciler) updateStatus(ctx context.Context, seaweedCR *seaweed
 		workerStatus, err = r.getComponentStatus(ctx, seaweedCR, ComponentWorker)
 		if err != nil {
 			log.Error(err, "Failed to get worker status")
-			return err
+			return false, err
 		}
 	}
 
@@ -236,19 +280,19 @@ func (r *SeaweedReconciler) updateStatus(ctx context.Context, seaweedCR *seaweed
 	s3Status, err := r.getS3Status(ctx, seaweedCR)
 	if err != nil {
 		log.Error(err, "Failed to get S3 gateway status")
-		return err
+		return false, err
 	}
 
 	// Get standalone SFTP gateway status (if enabled)
 	sftpStatus, err := r.getSFTPStatus(ctx, seaweedCR)
 	if err != nil {
 		log.Error(err, "Failed to get SFTP gateway status")
-		return err
+		return false, err
 	}
 
 	// Determine if cluster is ready
 	// Master must have replicas and all must be ready
-	isReady := masterStatus.Replicas > 0 && masterStatus.ReadyReplicas == masterStatus.Replicas
+	isReady = masterStatus.Replicas > 0 && masterStatus.ReadyReplicas == masterStatus.Replicas
 	// Volume is ready if disabled (0 replicas) or all configured replicas are ready
 	isReady = isReady && (volumeStatus.Replicas == 0 || volumeStatus.ReadyReplicas == volumeStatus.Replicas)
 
@@ -344,13 +388,16 @@ func (r *SeaweedReconciler) updateStatus(ctx context.Context, seaweedCR *seaweed
 		if errors.IsConflict(err) {
 			log.V(2).Info("Conflict while updating Seaweed status; will retry on next reconciliation")
 			// Do not treat conflict as a hard error to avoid unnecessary requeues.
-			return nil
+			// Return the readiness we computed so the caller still picks
+			// the right cadence — the conflict means our snapshot was
+			// stale, not that readiness flipped.
+			return isReady, nil
 		}
-		return err
+		return false, err
 	}
 
 	log.Info("Updated Seaweed status", "ready", isReady)
-	return nil
+	return isReady, nil
 }
 
 func (r *SeaweedReconciler) getComponentStatus(ctx context.Context, seaweedCR *seaweedv1.Seaweed, component string) (seaweedv1.ComponentStatus, error) {

--- a/internal/controller/seaweed_requeue_test.go
+++ b/internal/controller/seaweed_requeue_test.go
@@ -1,0 +1,45 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+)
+
+// TestReconcileRequeueAfter_ScalesWithReadiness locks in the policy
+// that drives the periodic safety-net requeue. It's the only behavior
+// difference between this PR's controller and master's — important
+// enough to cover with a focused unit test.
+func TestReconcileRequeueAfter_ScalesWithReadiness(t *testing.T) {
+	if got := reconcileRequeueAfter(false); got != requeueWhileReconciling {
+		t.Errorf("not-ready cadence = %s, want %s", got, requeueWhileReconciling)
+	}
+	if got := reconcileRequeueAfter(true); got != requeueWhenReady {
+		t.Errorf("ready cadence = %s, want %s", got, requeueWhenReady)
+	}
+}
+
+// TestReconcileRequeueAfter_ReadyIsLongerThanReconciling guards the
+// invariant that the steady-state interval cannot be tighter than the
+// rollout interval — flipping these accidentally would hide the
+// readiness signal from the cadence policy.
+func TestReconcileRequeueAfter_ReadyIsLongerThanReconciling(t *testing.T) {
+	if requeueWhenReady <= requeueWhileReconciling {
+		t.Errorf("requeueWhenReady (%s) must be longer than requeueWhileReconciling (%s)",
+			requeueWhenReady, requeueWhileReconciling)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #226 (the VolumeClaimTemplates fix for #224). The bug in
that PR was the comparator falsely reporting drift; this PR is about
the **cadence** that turned the false drift into a 5-second log
storm.

\`Reconcile\` previously ended with:

\`\`\`go
return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
\`\`\`

unconditionally. A single Seaweed CR generated ~17,280 reconcile
passes per day — most of them no-ops once the cluster reached Ready.
With the VCT warning fixed in #226 the noise is much quieter, but
it's still a constant baseline of \`start Reconcile ...\` /
\`Get master ...\` / \`Updated Seaweed status\` log lines and an
apiserver Get/Status-Update cycle every 5s for no functional benefit.

## What changed

- \`updateStatus\` now returns \`(isReady bool, err error)\` so the
  cadence decision can use the readiness signal it already computes
  internally. On \`Status().Update\` \`IsConflict\` it still returns the
  locally-computed \`isReady\` so the caller's cadence stays correct —
  the conflict means our snapshot was stale, not that readiness
  flipped.
- New \`reconcileRequeueAfter(isReady)\` helper picks between two
  intervals based on readiness. Extracted as a separate function so
  the cadence policy is unit-testable without spinning up a full
  reconcile pass.
- Two intervals as named constants:
    - \`requeueWhileReconciling = 5 * time.Second\` — preserved during
      rollout when status is moving and quick visibility matters.
    - \`requeueWhenReady = 1 * time.Minute\` — once every component
      reports its desired replicas fully ready. 12x less load at
      rest; watches still drive real-time response to actual changes.
- Two unit tests pin the policy:
    - \`TestReconcileRequeueAfter_ScalesWithReadiness\` — the value at
      each readiness state.
    - \`TestReconcileRequeueAfter_ReadyIsLongerThanReconciling\` —
      invariant guard so the relationship can't be flipped accidentally.

## Why a periodic requeue at all

Pure-watch controllers can miss events: apiserver flakes, watch
reconnects, cache invalidations. The convention is to keep a
periodic safety net at a long enough interval that it doesn't add
visible load but short enough that any missed event is reflected in
status within a bounded window. 1m at steady state is the
controller-runtime norm for this purpose; matching it keeps the
operator predictable for ops teams already familiar with the pattern.

## Test plan

- [x] \`make fmt vet test\` clean.
- [x] Unit tests for the cadence helper pass.
- [x] Existing controller tests unchanged (the only Reconcile signature
  change is the internal \`updateStatus\` return type).

## Stacking

Branched off master, not stacked on #226. The two PRs touch
seaweed_controller.go in different functions (\`reconcileVolumeClaimTemplates\`
vs \`Reconcile\`/\`updateStatus\`) so they merge independently in either
order. If both queue up I'm happy to rebase whichever lands second.

## Out of scope

Dropping the periodic requeue entirely. Switching to a pure-watch
model is a bigger architectural change and would need a thorough
review of which signals the controller depends on (e.g., status
transitions on owned StatefulSets that the cache might drop). 1m at
Ready is a measured, conservative step that captures most of the
benefit without that risk.