### PR TITLE
Always grant servicemonitor RBAC in Helm chart (follow-up to #223)

### DIFF
--- a/deploy/helm/templates/rbac/role.yaml
+++ b/deploy/helm/templates/rbac/role.yaml
@@ -99,7 +99,6 @@ rules:
   - get
   - patch
   - update
-{{- if .Values.serviceMonitor.enabled }}
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -112,4 +111,3 @@ rules:
   - patch
   - update
   - watch
-{{- end }}

--- a/test/helm/rbac_drift_test.go
+++ b/test/helm/rbac_drift_test.go
@@ -110,16 +110,23 @@ func flattenRules(rules []rbacv1.PolicyRule) map[ruleTriple]bool {
 
 func helmManagerRules(t *testing.T, chartDir string) []rbacv1.PolicyRule {
 	t.Helper()
-	// Render with every feature toggle enabled so the chart's
-	// rendered RBAC reflects the union of all conditional rules.
-	// The kustomize source-of-truth role.yaml is unconditional, so a
-	// fair parity comparison must compare against the chart's
-	// maximum-RBAC rendering. New conditional toggles that gate RBAC
-	// must be added here, otherwise this test will start failing
-	// when a kubebuilder marker references the gated resource.
-	cmd := exec.Command("helm", "template", "drift-test", chartDir,
-		"--set", "serviceMonitor.enabled=true",
-	)
+	// Render with the chart's default values — exactly what
+	// `helm install seaweedfs/seaweedfs-operator` produces for a
+	// fresh user. The previous version of this test rendered with
+	// every feature toggle enabled (e.g., serviceMonitor.enabled=true)
+	// to compare against the unconditional kustomize role; that
+	// masked the bug behind the comment on issue #223 — users hit
+	// the operator running with default-Helm RBAC, and any rule
+	// gated behind a values flag is missing for them. The kustomize
+	// role represents what the operator's controller code might
+	// actually request at runtime; the chart's default render must
+	// be a superset of that, regardless of which optional features
+	// the operator is using locally. RBAC scoped to "only granted
+	// when feature X is enabled" is fine in principle, but it has
+	// to be tied to a runtime signal the operator code itself
+	// observes — not a Helm value the operator binary knows nothing
+	// about.
+	cmd := exec.Command("helm", "template", "drift-test", chartDir)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr


### PR DESCRIPTION
## Summary

Follow-up to issue #223. After PR #225 fixed the bucket RBAC drift,
TsengSR reported on the [same issue](https://github.com/seaweedfs/seaweedfs-operator/issues/223#issuecomment-4360667109)
that fresh \`helm upgrade -i seaweedfs-operator seaweedfs/seaweedfs-operator\`
installs still hit a permission error — this time on
\`monitoring.coreos.com/servicemonitors\`.

Root cause: \`deploy/helm/templates/rbac/role.yaml\` gated the
servicemonitor RBAC behind \`{{- if .Values.serviceMonitor.enabled }}\`,
which defaults to \`false\`. The operator binary upserts SeaweedFS-
component ServiceMonitors based on whether the
\`monitoring.coreos.com\` **CRD** is installed (see
\`CreateOrUpdateServiceMonitor\` in \`controller_util.go\`) — it has no
way to read a Helm value. So in any cluster that has Prometheus
Operator installed but where the chart was deployed with default
values, the operator hits \`is forbidden\` on every reconcile that
needs to upsert a ServiceMonitor.

## What's in the PR

Two commits:

1. **\`Render Helm chart with default values in RBAC parity test\`**
   The original parity test (added in #225) rendered the chart with
   \`--set serviceMonitor.enabled=true\` so the comparison was against
   the union of all conditional rules. That masked exactly this bug
   class: a real user runs \`helm install\` with default values, and
   any rule gated behind a values flag is missing for them. Switch
   to rendering with chart defaults so the test reflects what users
   actually get. This commit fails on master with the 7 missing
   servicemonitor verbs that TsengSR's cluster hit.

2. **\`Always grant servicemonitor RBAC in Helm chart manager-role\`**
   Drop the \`{{- if .Values.serviceMonitor.enabled }}\` gate around
   the servicemonitor RBAC. RBAC must reflect what the operator
   binary might request at runtime, not which optional features the
   Helm user toggled.

## Why keep \`serviceMonitor.enabled\` at all

The values flag legitimately gates \`templates/servicemonitor.yaml\`,
which creates a ServiceMonitor for the **operator's own metrics
endpoint** (its \`/metrics\` Service, scraped by Prometheus). That's
optional per-cluster — if you don't run Prometheus Operator, you
don't want that ServiceMonitor created. Keep that gate.

What this PR removes is the *RBAC* gate, which was incorrectly
sharing the same flag. RBAC scoped to "only granted when feature X
is enabled" is fine in principle, but it has to be tied to a runtime
signal the operator code itself observes (e.g., CRD discovery), not
a Helm value the operator binary knows nothing about.

## Test plan

- [x] On master: parity test fails with \"7 missing servicemonitor
  verbs.\" (Confirmed by reverting the chart fix locally.)
- [x] With both commits: \`make test\` clean across the controller
  package and \`test/helm\`.
