### PR TITLE
Add Helm install smoke test (closes the gap that hid #223 + servicemonitor RBAC)

### DIFF
--- a/.github/workflows/helm-install-test.yml
+++ b/.github/workflows/helm-install-test.yml
@@ -12,6 +12,7 @@ on:
       - labeled
       - synchronize
     paths:
+      - '.github/workflows/helm-install-test.yml'
       - 'deploy/helm/**'
       - 'config/rbac/**'
       - 'config/samples/**'

--- a/.github/workflows/helm-install-test.yml
+++ b/.github/workflows/helm-install-test.yml
@@ -3,8 +3,8 @@
 # Complements make-test-e2e.yaml (kustomize-based) by exercising the
 # `helm install` path users actually run. Catches RBAC drift, packaging
 # bugs, conditional gates, and helm-template render errors that the
-# kustomize deployment never sees. See test/helm/install_smoke.sh and
-# issues #223 + the servicemonitor RBAC follow-up for context.
+# kustomize deployment never sees. See test/helm/install_smoke.sh for
+# the assertion logic.
 on:
   pull_request:
     types:

--- a/.github/workflows/helm-install-test.yml
+++ b/.github/workflows/helm-install-test.yml
@@ -1,0 +1,61 @@
+#name: Helm install smoke test
+#
+# Complements make-test-e2e.yaml (kustomize-based) by exercising the
+# `helm install` path users actually run. Catches RBAC drift, packaging
+# bugs, conditional gates, and helm-template render errors that the
+# kustomize deployment never sees. See test/helm/install_smoke.sh and
+# issues #223 + the servicemonitor RBAC follow-up for context.
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+      - synchronize
+    paths:
+      - 'deploy/helm/**'
+      - 'config/rbac/**'
+      - 'config/samples/**'
+      - 'test/helm/**'
+      - 'Makefile'
+      - 'Dockerfile'
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+#
+jobs:
+  helm-install-smoke:
+    name: helm install smoke on k8s ${{ matrix.k8s.attribute }} version
+    # Same gating as make-test-e2e: requires 'ok-to-test' label or
+    # collaborator-and-up association so external PRs don't auto-burn
+    # CI minutes on a slow integration test.
+    if: contains(github.event.pull_request.labels.*.name, 'ok-to-test') || contains(fromJSON('["COLLABORATOR", "MEMBER", "OWNER"]'), github.event.pull_request.author_association)
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s:
+          - version: v1.28.0
+            attribute: penultimate
+          - version: v1.29.0
+            attribute: previous
+          - version: default
+            attribute: latest
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4.1.7
+      - uses: actions/setup-go@v5.0.1
+        with:
+          go-version: '1.24'
+      - uses: docker/setup-buildx-action@v3.3.0
+      - uses: azure/setup-helm@v4.2.0
+        with:
+          version: v3.16.2
+      - uses: tale/kubectl-action@v1.4.0
+        with:
+          kubectl-version: v1.30.0
+          base64-kube-config: "YXBpVmVyc2lvbjogdjEKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQo="
+      - run: |
+          if [ "${{ matrix.k8s.version }}" = "default" ]; then
+            make test-helm-install
+          else
+            K8S_VERSION=${{ matrix.k8s.version }} make test-helm-install
+          fi

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ test-e2e:
 # suite.
 .PHONY: test-helm-install
 test-helm-install: kind-prepare kind-load
-	test/helm/install_smoke.sh
+	IMAGE_TAG=$(VERSION) test/helm/install_smoke.sh
 
 # Build manager binary
 manager: generate fmt vet

--- a/Makefile
+++ b/Makefile
@@ -56,10 +56,8 @@ test-e2e:
 # parity test in test/helm/rbac_drift_test.go (which only inspects
 # rendered YAML) by also catching helm-template syntax bugs, missing
 # CRD includes, broken ServiceAccount bindings, and conditional gates
-# the static test isn't aware of. See issues #223 and the
-# servicemonitor RBAC follow-up — both of those would have failed
-# this test on master and were missed by the kustomize-based e2e
-# suite.
+# the static test isn't aware of — failure modes invisible to the
+# kustomize-based test-e2e suite, which never deploys the chart.
 .PHONY: test-helm-install
 test-helm-install: kind-prepare kind-load
 	IMAGE_TAG=$(VERSION) test/helm/install_smoke.sh

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,20 @@ test: manifests generate fmt vet envtest ## Run tests.
 test-e2e:
 	go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter='!integration' -timeout 20m
 
+# test-helm-install validates the chart's default-values rendering by
+# actually installing it into a Kind cluster and asserting the
+# operator emits no RBAC permission errors. Complements the static
+# parity test in test/helm/rbac_drift_test.go (which only inspects
+# rendered YAML) by also catching helm-template syntax bugs, missing
+# CRD includes, broken ServiceAccount bindings, and conditional gates
+# the static test isn't aware of. See issues #223 and the
+# servicemonitor RBAC follow-up — both of those would have failed
+# this test on master and were missed by the kustomize-based e2e
+# suite.
+.PHONY: test-helm-install
+test-helm-install: kind-prepare kind-load
+	test/helm/install_smoke.sh
+
 # Build manager binary
 manager: generate fmt vet
 	go build -ldflags="-s -w" -o bin/manager main.go

--- a/test/helm/install_smoke.sh
+++ b/test/helm/install_smoke.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# Helm-install smoke test: deploys the operator from the chart at
+# deploy/helm/ with **default values** (i.e., what a real user gets from
+# `helm install seaweedfs/seaweedfs-operator`), applies a Seaweed CR
+# and a Bucket CR to exercise both controllers, then asserts the
+# operator emits no RBAC permission errors during reconcile.
+#
+# Why this exists: the existing test-e2e suite deploys via `make deploy`
+# (kustomize-based, uses config/rbac/role.yaml — the kubebuilder-generated
+# unconditional ClusterRole), so it never observes the chart's
+# hand-maintained RBAC. Issue #223 (missing bucket RBAC) and the
+# follow-up servicemonitor RBAC gate were both invisible to the
+# existing e2e tests for that reason — both manifested only at
+# `helm install` time. The static parity test in test/helm/rbac_drift_test.go
+# catches obvious drift at compile-time, but a full install lap also
+# catches packaging bugs (missing CRD include, broken ServiceAccount
+# binding, helm template syntax errors that only manifest at apply
+# time, conditional gates the static parity test doesn't render).
+#
+# Pre-conditions assumed:
+#   - kubectl points at a Kind cluster created via `make kind-prepare`
+#     (which installs Prometheus Operator and cert-manager already).
+#   - Operator image is present in the cluster as ghcr.io/seaweedfs/seaweedfs-operator:v0.0.1
+#     (loaded via `make kind-load`).
+#
+# Override points:
+#   NAMESPACE          (default: seaweedfs-operator-system)
+#   RELEASE            (default: seaweedfs-operator)
+#   CHART_DIR          (default: deploy/helm relative to repo root)
+#   IMAGE_REPOSITORY   (default: ghcr.io/seaweedfs/seaweedfs-operator)
+#   IMAGE_TAG          (default: v0.0.1)
+#   RECONCILE_WAIT     (default: 30 — seconds to wait between applying
+#                      sample CRs and inspecting operator logs)
+
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-seaweedfs-operator-system}"
+RELEASE="${RELEASE:-seaweedfs-operator}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." >/dev/null 2>&1 && pwd -P)"
+CHART_DIR="${CHART_DIR:-$REPO_ROOT/deploy/helm}"
+IMAGE_REPOSITORY="${IMAGE_REPOSITORY:-ghcr.io/seaweedfs/seaweedfs-operator}"
+IMAGE_TAG="${IMAGE_TAG:-v0.0.1}"
+RECONCILE_WAIT="${RECONCILE_WAIT:-30}"
+
+log() { printf '[smoke] %s\n' "$*"; }
+fail() { printf '[smoke] FAIL: %s\n' "$*" >&2; exit 1; }
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || fail "$1 not found in PATH"
+}
+
+require helm
+require kubectl
+
+log "deploying operator via Helm with chart defaults"
+# Override only the image registry/tag so the locally-loaded image is
+# used; everything else stays at chart defaults so the test reflects
+# what `helm install seaweedfs/seaweedfs-operator` produces for a real
+# user.
+helm upgrade --install "$RELEASE" "$CHART_DIR" \
+  --namespace "$NAMESPACE" --create-namespace \
+  --set "image.registry=$(dirname "$IMAGE_REPOSITORY")" \
+  --set "image.repository=$(basename "$IMAGE_REPOSITORY")" \
+  --set "image.tag=$IMAGE_TAG" \
+  --wait --timeout 5m
+
+log "waiting for operator deployment Available"
+kubectl wait deployment.apps/"${RELEASE}-seaweedfs-operator" \
+  --for=condition=Available --namespace "$NAMESPACE" --timeout 5m
+
+# Apply a basic Seaweed CR. This drives the SeaweedReconciler which,
+# among other things, attempts to upsert ServiceMonitors for the
+# master/volume/filer/admin/worker components — that's the path that
+# trips the missing servicemonitor RBAC reported in TsengSR's follow-up
+# on issue #223.
+log "applying sample Seaweed CR"
+kubectl apply -f "$REPO_ROOT/config/samples/seaweed_v1_seaweed.yaml"
+
+# Apply a basic Bucket CR. This drives the BucketReconciler which
+# requires List/Watch on buckets.seaweed.seaweedfs.com — the original
+# permission gap reported in #223.
+log "applying sample Bucket CR"
+kubectl apply -f "$REPO_ROOT/config/samples/seaweed_v1_bucket.yaml" || \
+  log "  (bucket sample apply failed — likely missing media namespace; not fatal — bucket-CR List still tries on every reconcile)"
+
+log "sleeping ${RECONCILE_WAIT}s for reconcile cycles to run"
+sleep "$RECONCILE_WAIT"
+
+log "scraping operator logs for RBAC permission errors"
+LOGS="$(kubectl -n "$NAMESPACE" logs deployment.apps/"${RELEASE}-seaweedfs-operator" --tail=-1 2>/dev/null || true)"
+if [ -z "$LOGS" ]; then
+  fail "no operator logs found — deployment may not be running"
+fi
+
+# Grep for the family of error fragments controller-runtime emits when
+# RBAC is missing. Both the apiserver-formatted phrase and the typed
+# error message can show up depending on which client wrote the log:
+#   - "is forbidden: User \"...\" cannot list resource \"buckets\""
+#   - "failed to watch *v1.Bucket" / "failed to list *v1.Bucket"
+#   - controller-runtime reflector errors carrying "forbidden"
+PATTERN='is forbidden|cannot list|cannot watch|cannot get|cannot create|cannot update|cannot patch|cannot delete|failed to list|failed to watch'
+if printf '%s\n' "$LOGS" | grep -E -- "$PATTERN" >/tmp/smoke-rbac-errors 2>/dev/null; then
+  log "operator logs contain RBAC errors:"
+  sed 's/^/  /' /tmp/smoke-rbac-errors >&2
+  fail "operator emitted RBAC permission errors after Helm install with default values; see lines above"
+fi
+
+log "PASS — operator reconciled cleanly with chart-default RBAC"

--- a/test/helm/install_smoke.sh
+++ b/test/helm/install_smoke.sh
@@ -78,12 +78,15 @@ kubectl wait deployment.apps/"${RELEASE}-seaweedfs-operator" \
 log "applying sample Seaweed CR"
 kubectl apply -f "$REPO_ROOT/config/samples/seaweed_v1_seaweed.yaml"
 
-# Apply a basic Bucket CR. This drives the BucketReconciler which
-# requires List/Watch on buckets.seaweed.seaweedfs.com — the original
-# permission gap reported in #223.
+# Apply a basic Bucket CR. This drives the BucketReconciler all the
+# way through its full reconcile sequence (List, Get, finalizer
+# Update, Status Patch), not just the initial List. The bucket
+# sample is in the `media` namespace, so create it first — without
+# the namespace the apply errors before any RBAC verb beyond List
+# gets exercised.
 log "applying sample Bucket CR"
-kubectl apply -f "$REPO_ROOT/config/samples/seaweed_v1_bucket.yaml" || \
-  log "  (bucket sample apply failed — likely missing media namespace; not fatal — bucket-CR List still tries on every reconcile)"
+kubectl create namespace media --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -f "$REPO_ROOT/config/samples/seaweed_v1_bucket.yaml"
 
 log "sleeping ${RECONCILE_WAIT}s for reconcile cycles to run"
 sleep "$RECONCILE_WAIT"

--- a/test/helm/install_smoke.sh
+++ b/test/helm/install_smoke.sh
@@ -9,14 +9,15 @@
 # Why this exists: the existing test-e2e suite deploys via `make deploy`
 # (kustomize-based, uses config/rbac/role.yaml — the kubebuilder-generated
 # unconditional ClusterRole), so it never observes the chart's
-# hand-maintained RBAC. Issue #223 (missing bucket RBAC) and the
-# follow-up servicemonitor RBAC gate were both invisible to the
-# existing e2e tests for that reason — both manifested only at
-# `helm install` time. The static parity test in test/helm/rbac_drift_test.go
-# catches obvious drift at compile-time, but a full install lap also
-# catches packaging bugs (missing CRD include, broken ServiceAccount
-# binding, helm template syntax errors that only manifest at apply
-# time, conditional gates the static parity test doesn't render).
+# hand-maintained RBAC. Past chart-RBAC drift (missing bucket RBAC,
+# servicemonitor RBAC gated behind a Helm value the operator binary
+# can't read) was invisible to the existing e2e tests for that reason —
+# both classes of bug only manifested at `helm install` time. The
+# static parity test in test/helm/rbac_drift_test.go catches obvious
+# drift at compile-time, but a full install lap also catches packaging
+# bugs (missing CRD include, broken ServiceAccount binding, helm
+# template syntax errors that only manifest at apply time, conditional
+# gates the static parity test doesn't render).
 #
 # Pre-conditions assumed:
 #   - kubectl points at a Kind cluster created via `make kind-prepare`
@@ -73,8 +74,7 @@ kubectl wait deployment.apps/"${RELEASE}-seaweedfs-operator" \
 # Apply a basic Seaweed CR. This drives the SeaweedReconciler which,
 # among other things, attempts to upsert ServiceMonitors for the
 # master/volume/filer/admin/worker components — that's the path that
-# trips the missing servicemonitor RBAC reported in TsengSR's follow-up
-# on issue #223.
+# would trip a missing servicemonitor RBAC rule.
 log "applying sample Seaweed CR"
 kubectl apply -f "$REPO_ROOT/config/samples/seaweed_v1_seaweed.yaml"
 

--- a/test/helm/install_smoke.sh
+++ b/test/helm/install_smoke.sh
@@ -104,9 +104,10 @@ fi
 #   - "failed to watch *v1.Bucket" / "failed to list *v1.Bucket"
 #   - controller-runtime reflector errors carrying "forbidden"
 PATTERN='is forbidden|cannot list|cannot watch|cannot get|cannot create|cannot update|cannot patch|cannot delete|failed to list|failed to watch'
-if printf '%s\n' "$LOGS" | grep -E -- "$PATTERN" >/tmp/smoke-rbac-errors 2>/dev/null; then
+RBAC_ERRORS="$(printf '%s\n' "$LOGS" | grep -E -- "$PATTERN" || true)"
+if [ -n "$RBAC_ERRORS" ]; then
   log "operator logs contain RBAC errors:"
-  sed 's/^/  /' /tmp/smoke-rbac-errors >&2
+  printf '%s\n' "$RBAC_ERRORS" | sed 's/^/  /' >&2
   fail "operator emitted RBAC permission errors after Helm install with default values; see lines above"
 fi
 

--- a/test/helm/install_smoke.sh
+++ b/test/helm/install_smoke.sh
@@ -68,7 +68,20 @@ helm upgrade --install "$RELEASE" "$CHART_DIR" \
   --wait --timeout 5m
 
 log "waiting for operator deployment Available"
-kubectl wait deployment.apps/"${RELEASE}-seaweedfs-operator" \
+# Resolve the operator Deployment by Helm's standard
+# app.kubernetes.io/instance label rather than guessing the rendered
+# fullname. The chart's `_helpers.tpl` collapses
+# `<release>-<chart-name>` to just `<release>` when the release name
+# already contains the chart name, so a hardcoded `<release>-<chart>`
+# only works for some release names — use the label.
+DEPLOYMENT="$(kubectl -n "$NAMESPACE" get deployment \
+  -l app.kubernetes.io/instance="$RELEASE",app.kubernetes.io/name=seaweedfs-operator \
+  -o jsonpath='{.items[0].metadata.name}')"
+if [ -z "$DEPLOYMENT" ]; then
+  fail "no Deployment matching the operator labels in namespace $NAMESPACE"
+fi
+log "  resolved operator Deployment: $DEPLOYMENT"
+kubectl wait deployment.apps/"$DEPLOYMENT" \
   --for=condition=Available --namespace "$NAMESPACE" --timeout 5m
 
 # Apply a basic Seaweed CR. This drives the SeaweedReconciler which,
@@ -92,7 +105,7 @@ log "sleeping ${RECONCILE_WAIT}s for reconcile cycles to run"
 sleep "$RECONCILE_WAIT"
 
 log "scraping operator logs for RBAC permission errors"
-LOGS="$(kubectl -n "$NAMESPACE" logs deployment.apps/"${RELEASE}-seaweedfs-operator" --tail=-1 2>/dev/null || true)"
+LOGS="$(kubectl -n "$NAMESPACE" logs deployment.apps/"$DEPLOYMENT" --tail=-1 2>/dev/null || true)"
 if [ -z "$LOGS" ]; then
   fail "no operator logs found — deployment may not be running"
 fi


### PR DESCRIPTION
## Summary

The kustomize-based test-e2e suite never observed the chart's
hand-maintained RBAC. Both #223 and the servicemonitor RBAC follow-up
slipped through CI for the same reason — neither manifested under
\`make deploy\` (which uses \`config/rbac/role.yaml\`), only under
\`helm install\` (which uses \`deploy/helm/templates/rbac/role.yaml\`).

This PR closes that gap with a Helm-install smoke test:

- New \`test/helm/install_smoke.sh\`: \`helm upgrade --install\` with chart
  defaults, apply \`Seaweed\` + \`Bucket\` sample CRs, sleep one reconcile
  cycle, grep operator logs for any RBAC permission errors. Fails on
  \`is forbidden\`, \`cannot list/watch/get/...\`, \`failed to list/watch\`.
- \`make test-helm-install\` target wraps it with sane defaults
  (\`kind-prepare\` + \`kind-load\` deps so dev runs work the same as CI).
- New \`.github/workflows/helm-install-test.yml\`: same matrix as the
  existing kustomize e2e, same author-association gating, runs
  \`make test-helm-install\`.

**Stacked on #228** (\`fix/223-followup-servicemonitor-rbac\`). Without
that PR the smoke test fails on master because the servicemonitor
RBAC is still gated. Once #228 merges this PR's base auto-rebases to
master.

## Why both this and the static parity test

The static parity test in \`test/helm/rbac_drift_test.go\`
(\`TestHelmManagerRoleIsSupersetOfKustomize\`) catches drift between
the kubebuilder-generated kustomize role and the chart's role —
fast, deterministic, no cluster needed. After PR #228 it renders
with chart defaults, so it'll catch any future conditional-gate
regression too.

This smoke test is broader: it also catches packaging errors a static
test can't see, like:

- helm template syntax errors that only surface at \`helm install\` time
- A CRD missing from the chart's \`templates/\` (kustomize would still
  install it via \`config/crd\`)
- Broken ServiceAccount or RoleBinding refs
- Image registry/tag misconfigurations that prevent the operator pod
  from starting

Run cost: ~5 minutes per matrix entry, gated on \`ok-to-test\` so
external PRs don't burn it.

## Test plan

- [x] \`bash -n test/helm/install_smoke.sh\` clean.
- [x] \`make fmt vet test\` clean (the smoke script is shell, not Go).
- [ ] CI run on this PR validates the script end-to-end across the
  three k8s versions in matrix.
- [ ] Confirm the smoke script's grep would have caught both #223
  cases — by stashing the chart-fix commits from #225 and #228 and
  re-running locally. (Not blocking PR — the chart fixes are
  merged/queued; this PR's CI will produce the green signal directly.)

## After this PR lands

PR #228 merges with the parity test passing. This PR's CI demonstrates
the end-to-end install also passes. Issue #223 stays closed — anything
that re-introduces RBAC drift (kustomize, helm, or both) will fail
either the static or smoke test in the same PR that introduces it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive Helm chart installation validation across multiple Kubernetes versions (1.28.0, 1.29.0, and latest)
  * Enhanced RBAC configuration testing to validate permission configurations during deployment
  * Improved CI pipeline reliability with automated smoke tests and operator reconciliation checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->