### PR TITLE
Add watch verb to pods RBAC rule

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -31,6 +31,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - apps
   resources:

--- a/deploy/helm/templates/rbac/role.yaml
+++ b/deploy/helm/templates/rbac/role.yaml
@@ -32,6 +32,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - apps
   resources:

--- a/internal/controller/seaweed_controller.go
+++ b/internal/controller/seaweed_controller.go
@@ -103,7 +103,7 @@ type SeaweedReconciler struct {
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cert-manager.io,resources=issuers;certificates,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 
 // Reconcile implements the reconciliation logic
 func (r *SeaweedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
## Summary
Adds the 'watch' verb to the RBAC rule for pods to enable the operator to properly monitor pod state changes.

## Changes
- Updated the RBAC rule in `internal/controller/seaweed_controller.go` annotation
- Updated `config/rbac/role.yaml` with the watch verb  
- Updated `deploy/helm/templates/rbac/role.yaml` with the watch verb

## Related
Fixes #223
Addresses comment: https://github.com/seaweedfs/seaweedfs-operator/issues/223#issuecomment-4361359432

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Extended pod monitoring capabilities by adding support for real-time watch operations. The system can now monitor pod status changes in addition to standard retrieval and listing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->