### PR TITLE
swadmin: set default empty FilerGroup so NewCommandEnv doesn't nil-deref

### DIFF
--- a/internal/controller/swadmin/seaweed_admin.go
+++ b/internal/controller/swadmin/seaweed_admin.go
@@ -23,6 +23,13 @@ func NewSeaweedAdmin(masters string, output io.Writer) *SeaweedAdmin {
 	var shellOptions shell.ShellOptions
 	shellOptions.GrpcDialOption = grpc.WithTransportCredentials(insecure.NewCredentials())
 	shellOptions.Masters = &masters
+	// `shell.NewCommandEnv` dereferences `*options.FilerGroup` (commands.go:46)
+	// when constructing the MasterClient. The operator does not configure a
+	// filer group, so leaving it nil panics every reconcile — the same root
+	// cause as #101 / #120 keeps recurring after upstream refactors (#233).
+	// Default to an empty string so the deref produces "" without crashing.
+	emptyFilerGroup := ""
+	shellOptions.FilerGroup = &emptyFilerGroup
 
 	commandEnv := shell.NewCommandEnv(&shellOptions)
 	reg, _ := regexp.Compile(`'.*?'|".*?"|\S+`)


### PR DESCRIPTION
Fixes #233.

`shell.NewCommandEnv` (upstream seaweedfs commands.go:46) dereferences `*options.FilerGroup` when constructing the MasterClient. The operator did not configure a filer group, so the nil pointer panicked every reconcile. Same root cause as #101 / #120 — the upstream refactor keeps reintroducing the deref. Default `FilerGroup` to an empty string so the deref produces `""` without crashing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash in admin command execution that occurred during initialization of shell options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->