### PR TITLE
Fix #237: set FilerAddress on swadmin so Bucket reconciler can reach the filer

### DIFF
--- a/internal/controller/bucket_admin.go
+++ b/internal/controller/bucket_admin.go
@@ -74,9 +74,9 @@ type BucketCollectionStats struct {
 	SizeBytes int64
 }
 
-// BucketAdminFactory creates a BucketAdmin for the master peers of a target
-// Seaweed cluster. Replaceable in tests.
-type BucketAdminFactory func(masters string, log logr.Logger) (BucketAdmin, error)
+// BucketAdminFactory creates a BucketAdmin for a target Seaweed cluster.
+// Replaceable in tests.
+type BucketAdminFactory func(masters, filer string, log logr.Logger) (BucketAdmin, error)
 
 // Sentinel errors returned by BucketAdmin implementations.
 var (
@@ -107,10 +107,9 @@ type swadminBucketAdmin struct {
 	mu  sync.Mutex
 }
 
-// NewSwadminBucketAdmin returns a BucketAdmin that runs `weed shell` commands
-// against the given comma-separated master peers list.
-func NewSwadminBucketAdmin(masters string, log logr.Logger) (BucketAdmin, error) {
-	sa := swadmin.NewSeaweedAdmin(masters, io.Discard)
+// NewSwadminBucketAdmin returns a BucketAdmin that runs `weed shell` commands.
+func NewSwadminBucketAdmin(masters, filer string, log logr.Logger) (BucketAdmin, error) {
+	sa := swadmin.NewSeaweedAdmin(masters, filer, io.Discard)
 	return &swadminBucketAdmin{sa: sa, log: log}, nil
 }
 

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -135,7 +135,8 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	r.setCondition(&bucket, seaweedv1.BucketConditionClusterReachable, metav1.ConditionTrue, "Reachable", "")
 
 	masters := getMasterPeersString(&seaweed)
-	admin, err := r.getAdmin(seaweedNS, seaweed.Name, masters, log)
+	filer := getFilerAddress(&seaweed)
+	admin, err := r.getAdmin(seaweedNS, seaweed.Name, masters, filer, log)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -393,11 +394,10 @@ func (r *BucketReconciler) clearCondition(bucket *seaweedv1.Bucket, condType str
 	meta.RemoveStatusCondition(&bucket.Status.Conditions, condType)
 }
 
-// getAdmin returns a cached BucketAdmin for the (Seaweed CR, masters)
-// pair, creating one via the factory on first use. See the comment on
-// adminCache about the goroutine-leak trade-off.
-func (r *BucketReconciler) getAdmin(ns, name, masters string, log logr.Logger) (BucketAdmin, error) {
-	key := ns + "/" + name + "@" + masters
+// getAdmin returns a cached BucketAdmin for the (Seaweed CR, masters, filer)
+// tuple. See the comment on adminCache about the goroutine-leak trade-off.
+func (r *BucketReconciler) getAdmin(ns, name, masters, filer string, log logr.Logger) (BucketAdmin, error) {
+	key := ns + "/" + name + "@" + masters + "|" + filer
 	r.adminMu.Lock()
 	defer r.adminMu.Unlock()
 	if r.adminCache == nil {
@@ -406,7 +406,7 @@ func (r *BucketReconciler) getAdmin(ns, name, masters string, log logr.Logger) (
 	if a, ok := r.adminCache[key]; ok {
 		return a, nil
 	}
-	a, err := r.AdminFactory(masters, log)
+	a, err := r.AdminFactory(masters, filer, log)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controller/bucket_controller_test.go
+++ b/internal/controller/bucket_controller_test.go
@@ -173,7 +173,7 @@ func testReconciler(t *testing.T, fa *fakeBucketAdmin, objs ...client.Object) (*
 		Client: cli,
 		Log:    logf.FromContext(context.Background()),
 		Scheme: scheme,
-		AdminFactory: func(_ string, _ logr.Logger) (BucketAdmin, error) {
+		AdminFactory: func(_, _ string, _ logr.Logger) (BucketAdmin, error) {
 			return fa, nil
 		},
 	}

--- a/internal/controller/bucket_usage.go
+++ b/internal/controller/bucket_usage.go
@@ -107,7 +107,8 @@ func (r *BucketReconciler) refreshClusterUsage(ctx context.Context, log logr.Log
 		return
 	}
 	masters := getMasterPeersString(&seaweed)
-	admin, err := r.getAdmin(seaweedNS, seaweedName, masters, r.Log)
+	filer := getFilerAddress(&seaweed)
+	admin, err := r.getAdmin(seaweedNS, seaweedName, masters, filer, r.Log)
 	if err != nil {
 		log.Error(err, "build admin for usage refresh", "seaweed", seaweedName)
 		return

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -62,6 +62,12 @@ func getMasterPeersString(m *seaweedv1.Seaweed) string {
 	return strings.Join(getMasterAddresses(m.Namespace, m.Name, m.Spec.Master.Replicas), ",")
 }
 
+// getFilerAddress returns the HTTP host:port for the Seaweed CR's filer Service.
+// Required for s3.bucket.* shell commands; seaweedfs adds GRPCPortDelta internally.
+func getFilerAddress(m *seaweedv1.Seaweed) string {
+	return fmt.Sprintf("%s-filer.%s:%d", m.Name, m.Namespace, seaweedv1.FilerHTTPPort)
+}
+
 // Note: IAM is now embedded in S3 by default (on the same port as S3: FilerS3Port).
 // The getIAMPort function has been removed since standalone IAM is no longer supported.
 

--- a/internal/controller/helper_test.go
+++ b/internal/controller/helper_test.go
@@ -5,6 +5,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
 )
 
 func TestFilterContainerResources(t *testing.T) {
@@ -71,5 +74,18 @@ func TestFilterContainerResourcesEmpty(t *testing.T) {
 	}
 	if filtered.Limits != nil {
 		t.Errorf("Expected empty limits to remain nil")
+	}
+}
+
+// TestGetFilerAddress pins the filer address format; a regression here
+// resurfaces issue #237.
+func TestGetFilerAddress(t *testing.T) {
+	m := &seaweedv1.Seaweed{
+		ObjectMeta: metav1.ObjectMeta{Name: "seaweed", Namespace: "seaweedfs"},
+	}
+	got := getFilerAddress(m)
+	want := "seaweed-filer.seaweedfs:8888"
+	if got != want {
+		t.Fatalf("getFilerAddress = %q, want %q", got, want)
 	}
 }

--- a/internal/controller/seaweed_maintenance.go
+++ b/internal/controller/seaweed_maintenance.go
@@ -16,7 +16,7 @@ func (r *SeaweedReconciler) maintenance(m *seaweedv1.Seaweed) (done bool, result
 	r.Log.V(0).Info("wait to connect to masters", "masters", masters)
 
 	// this step blocks since the operator can not access the masters when running from outside of the k8s cluster
-	sa := swadmin.NewSeaweedAdmin(masters, ioutil.Discard)
+	sa := swadmin.NewSeaweedAdmin(masters, "", ioutil.Discard)
 
 	// For now this is an example of the admin commands
 	// master by default has some maintenance commands already.

--- a/internal/controller/swadmin/seaweed_admin.go
+++ b/internal/controller/swadmin/seaweed_admin.go
@@ -9,6 +9,7 @@ import (
 
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/shell"
 	"github.com/seaweedfs/seaweedfs/weed/util/fla9"
 	"google.golang.org/grpc"
@@ -32,13 +33,16 @@ type SeaweedAdmin struct {
 	Output     io.Writer
 }
 
-func NewSeaweedAdmin(masters string, output io.Writer) *SeaweedAdmin {
+// NewSeaweedAdmin builds a SeaweedAdmin that mirrors `weed shell`. filer is
+// required for s3.bucket.* / fs.* callers; master-only callers (volume.list,
+// volume.balance) may pass "".
+func NewSeaweedAdmin(masters, filer string, output io.Writer) *SeaweedAdmin {
 	var shellOptions shell.ShellOptions
 	shellOptions.GrpcDialOption = grpc.WithTransportCredentials(insecure.NewCredentials())
 	shellOptions.Masters = &masters
+	shellOptions.FilerAddress = pb.ServerAddress(filer)
 	// shell.NewCommandEnv unconditionally dereferences FilerGroup; leaving
 	// it nil panics the reconciler the moment any Bucket is processed.
-	// Match the `weed shell` default of an empty filer group.
 	emptyFilerGroup := ""
 	shellOptions.FilerGroup = &emptyFilerGroup
 

--- a/internal/controller/swadmin/seaweed_admin_test.go
+++ b/internal/controller/swadmin/seaweed_admin_test.go
@@ -2,7 +2,10 @@ package swadmin
 
 import (
 	"io"
+	"strings"
 	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 )
 
 // TestNewSeaweedAdmin_DoesNotPanic guards against regressions like
@@ -10,11 +13,25 @@ import (
 // shell.ShellOptions.FilerGroup nil panicked inside shell.NewCommandEnv the
 // moment any Bucket reached the reconciler.
 func TestNewSeaweedAdmin_DoesNotPanic(t *testing.T) {
-	sa := NewSeaweedAdmin("seaweed-master.invalid:9333", io.Discard)
+	sa := NewSeaweedAdmin("seaweed-master.invalid:9333", "seaweed-filer.invalid:8888", io.Discard)
 	if sa == nil {
 		t.Fatal("NewSeaweedAdmin returned nil")
 	}
 	if sa.commandEnv == nil {
 		t.Fatal("commandEnv was not initialized")
+	}
+}
+
+// TestNewSeaweedAdmin_FilerAddressWired guards against regressing
+// https://github.com/seaweedfs/seaweedfs-operator/issues/237, where
+// ShellOptions.FilerAddress was never set so every s3.bucket.* command
+// dialed gRPC with an empty target.
+func TestNewSeaweedAdmin_FilerAddressWired(t *testing.T) {
+	sa := NewSeaweedAdmin("seaweed-master.invalid:9333", "seaweed-filer.invalid:8888", io.Discard)
+	err := sa.commandEnv.WithFilerClient(false, func(filer_pb.SeaweedFilerClient) error {
+		return nil
+	})
+	if err != nil && strings.Contains(err.Error(), "received empty target") {
+		t.Fatalf("regression of issue #237: empty target leaked through despite non-empty filer arg: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- Fixes #237. `swadmin.NewSeaweedAdmin` left `shell.ShellOptions.FilerAddress` unset, so every `s3.bucket.*` shell command (`BucketExists`, `CreateBucket`, `SetVersioning`, …) reached `WithFilerClient` with an empty gRPC target and failed with `passthrough: received empty target in Build()` — exactly the error in the bug report.
- Threads a `filer` arg through `swadmin.NewSeaweedAdmin`, `NewSwadminBucketAdmin`, `BucketAdminFactory`, and `BucketReconciler.getAdmin`. The reconciler derives the address from the Seaweed CR as `<name>-filer.<namespace>:8888` (HTTP form; seaweedfs adds `GRPCPortDelta` internally — same convention used in `controller_s3.go` / `controller_sftp.go`).
- `seaweed_maintenance.go` (`volume.list` / `volume.balance`) is master-only and passes `""`.

## Reproduction

Confirmed locally with a 12-line program calling `pb.WithGrpcFilerClient` directly:

```
BEFORE (FilerAddress=\"\"): getOrCreateConnection : fail to dial : failed to exit idle mode: failed to start resolver: passthrough: received empty target in Build()
AFTER  (FilerAddress=seaweed-filer.seaweedfs:8888): <nil>
```

## Why existing tests didn't catch this

- `bucket_controller_test.go` injects a fake `BucketAdmin` via `AdminFactory`, so the real `swadmin` path is never exercised.
- `swadmin/seaweed_admin_test.go` previously only asserted `NewSeaweedAdmin` doesn't panic — it never invoked any command, so the empty `FilerAddress` couldn't surface.
- `bucket_admin_test.go::TestBucketAdminCommandsRegistered` checks command names are registered in `shell.Commands` but never executes them.
- No integration test stands up master+filer to drive a Bucket reconcile end-to-end.

## Coverage added

- `TestNewSeaweedAdmin_FilerAddressWired` calls `WithFilerClient` with a no-op callback against a freshly-built `SeaweedAdmin` and asserts the error never contains `received empty target`. Verified to fire on the unfixed code via a negative-control run.
- `TestGetFilerAddress` pins the `<name>-filer.<ns>:8888` format the reconciler hands to swadmin.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/...` (all green)
- [x] Negative-control: regression test fires on the broken code path
- [ ] Manual verification on a Kind cluster with a real Seaweed CR + Bucket CR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved Seaweed cluster admin client management by incorporating filer service address into caching and initialization logic, ensuring better scoping of admin instances to complete cluster configurations.
  * Enhanced admin client creation to derive and use filer service addresses from cluster resources.

* **Bug Fixes**
  * Fixed potential nil dereference issue in shell options initialization during SeaweedAdmin creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->