### PR TITLE
fix(admin): forward credentialsSecret as flags so auth actually enables

### DIFF
--- a/internal/controller/controller_admin_statefulset.go
+++ b/internal/controller/controller_admin_statefulset.go
@@ -12,54 +12,20 @@ import (
 	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
 )
 
-// adminCredentialEnvMappings maps each well-known key in the admin
-// CredentialsSecret to the env var that weed admin reads for it. weed admin
-// accepts credentials via env vars (see upstream weed/command/admin.go);
-// using them avoids a shell preamble and lets secret values contain any
-// bytes (spaces, newlines, quotes) without escaping concerns.
-// adminUser/adminPassword enable the login flow; readOnlyUser and
-// readOnlyPassword are optional view-only accounts.
-var adminCredentialEnvMappings = []struct {
-	secretKey string
-	envName   string
-}{
-	{"adminUser", "WEED_ADMIN_USER"},
-	{"adminPassword", "WEED_ADMIN_PASSWORD"},
-	{"readOnlyUser", "WEED_ADMIN_READONLY_USER"},
-	{"readOnlyPassword", "WEED_ADMIN_READONLY_PASSWORD"},
-}
+// adminCredentialsMountPath is the in-pod directory where the admin
+// CredentialsSecret is projected by createAdminStatefulSet; each key in
+// the secret becomes a file named after the key.
+const adminCredentialsMountPath = "/etc/sw/admin"
 
-// adminCredentialEnvVars projects the configured CredentialsSecret into the
-// env vars weed admin reads. Each mapping is marked optional so users can
-// supply only adminUser/adminPassword (or additionally the read-only pair)
-// without tripping pod startup on missing keys.
-func adminCredentialEnvVars(m *seaweedv1.Seaweed) []corev1.EnvVar {
-	if m.Spec.Admin.CredentialsSecret == nil || m.Spec.Admin.CredentialsSecret.Name == "" {
-		return nil
-	}
-	optional := true
-	envs := make([]corev1.EnvVar, 0, len(adminCredentialEnvMappings))
-	for _, mapping := range adminCredentialEnvMappings {
-		envs = append(envs, corev1.EnvVar{
-			Name: mapping.envName,
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: m.Spec.Admin.CredentialsSecret.Name,
-					},
-					Key:      mapping.secretKey,
-					Optional: &optional,
-				},
-			},
-		})
-	}
-	return envs
-}
+// adminCredentialKeys are the well-known keys in the admin CredentialsSecret
+// that weed admin accepts as `-<key>=<value>` flags. adminUser/adminPassword
+// enable the login flow; readOnlyUser/readOnlyPassword are optional view-only
+// accounts. We pass these as flags rather than env vars because older weed
+// builds do not bind WEED_ADMIN_* env vars to the admin command (see #239).
+var adminCredentialKeys = []string{"adminUser", "adminPassword", "readOnlyUser", "readOnlyPassword"}
 
 func buildAdminStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string {
-	// `exec` replaces the /bin/sh wrapper with weed so SIGTERM from the
-	// kubelet reaches weed directly and termination stays prompt.
-	commands := []string{"exec", "weed", "-logtostderr=true"}
+	commands := []string{"weed", "-logtostderr=true"}
 	if arg := tlsConfigDirArg(m); arg != "" {
 		commands = append(commands, arg)
 	}
@@ -71,7 +37,25 @@ func buildAdminStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string {
 	}
 	commands = append(commands, extraArgs...)
 
-	return strings.Join(commands, " ")
+	weedCmd := strings.Join(commands, " ")
+
+	// When a CredentialsSecret is mounted, resolve each well-known key from
+	// the projected files into `-<key>=<value>` flags at container start, so
+	// weed admin boots with authentication enabled. Keys with no file on disk
+	// are skipped, keeping readOnlyUser/readOnlyPassword optional. `set --`
+	// builds positional parameters so values containing spaces or special
+	// characters expand safely through `"$@"`. `exec` replaces the /bin/sh
+	// wrapper with weed so SIGTERM from the kubelet reaches weed directly.
+	if m.Spec.Admin.CredentialsSecret != nil && m.Spec.Admin.CredentialsSecret.Name != "" {
+		preamble := "set --; " +
+			"for key in " + strings.Join(adminCredentialKeys, " ") + "; do " +
+			`f="` + adminCredentialsMountPath + `/$key"; ` +
+			`[ -f "$f" ] && set -- "$@" "-$key=$(cat "$f")"; ` +
+			"done; "
+		return preamble + "exec " + weedCmd + ` "$@"`
+	}
+
+	return "exec " + weedCmd
 }
 
 // adminURLPrefix scans weed admin ExtraArgs for a -urlPrefix flag and returns
@@ -166,11 +150,26 @@ func (r *SeaweedReconciler) createAdminStatefulSet(m *seaweedv1.Seaweed) *appsv1
 	extraArgs := m.BaseAdminSpec().ExtraArgs()
 	healthPath := adminRoutePath(extraArgs, "/health")
 
-	// Credentials from spec.admin.credentialsSecret are projected as env vars
-	// (WEED_ADMIN_USER / WEED_ADMIN_PASSWORD / WEED_ADMIN_READONLY_USER /
-	// WEED_ADMIN_READONLY_PASSWORD) which weed admin reads natively.
+	// Project the configured CredentialsSecret as a read-only volume; the
+	// startup script in buildAdminStartupScript reads each well-known key
+	// from this directory and forwards it to weed admin as a flag.
+	if m.Spec.Admin.CredentialsSecret != nil && m.Spec.Admin.CredentialsSecret.Name != "" {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      "admin-credentials",
+			ReadOnly:  true,
+			MountPath: adminCredentialsMountPath,
+		})
+		adminPodSpec.Volumes = append(adminPodSpec.Volumes, corev1.Volume{
+			Name: "admin-credentials",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: m.Spec.Admin.CredentialsSecret.Name,
+				},
+			},
+		})
+	}
+
 	env := append(m.BaseAdminSpec().Env(), kubernetesEnvVars...)
-	env = append(env, adminCredentialEnvVars(m)...)
 
 	adminPodSpec.EnableServiceLinks = &enableServiceLinks
 	adminPodSpec.Containers = []corev1.Container{{

--- a/internal/controller/controller_admin_statefulset_test.go
+++ b/internal/controller/controller_admin_statefulset_test.go
@@ -46,78 +46,75 @@ func TestAdminRoutePath(t *testing.T) {
 }
 
 func TestBuildAdminStartupScript(t *testing.T) {
-	m := &seaweedv1.Seaweed{
-		ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
-		Spec: seaweedv1.SeaweedSpec{
-			Master: &seaweedv1.MasterSpec{Replicas: 1},
-			Admin:  &seaweedv1.AdminSpec{},
-		},
-	}
-	got := buildAdminStartupScript(m, "-urlPrefix=/admin")
-	// `exec` must prefix weed so SIGTERM from the kubelet reaches weed
-	// instead of the /bin/sh wrapper.
-	if !strings.HasPrefix(got, "exec weed -logtostderr=true admin ") {
-		t.Fatalf("expected exec'd weed command, got %q", got)
-	}
-	if !strings.Contains(got, "-urlPrefix=/admin") {
-		t.Fatalf("expected extra args to be included, got %q", got)
-	}
-}
-
-func TestAdminCredentialEnvVars(t *testing.T) {
-	baseSpec := func() *seaweedv1.Seaweed {
-		return &seaweedv1.Seaweed{
+	t.Run("no credentials secret execs weed directly", func(t *testing.T) {
+		m := &seaweedv1.Seaweed{
 			ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
 			Spec: seaweedv1.SeaweedSpec{
 				Master: &seaweedv1.MasterSpec{Replicas: 1},
 				Admin:  &seaweedv1.AdminSpec{},
 			},
 		}
-	}
-
-	t.Run("no credentials secret yields no env vars", func(t *testing.T) {
-		if got := adminCredentialEnvVars(baseSpec()); got != nil {
-			t.Fatalf("expected nil env vars, got %+v", got)
+		got := buildAdminStartupScript(m, "-urlPrefix=/admin")
+		// `exec` must prefix weed so SIGTERM from the kubelet reaches weed
+		// instead of the /bin/sh wrapper.
+		if !strings.HasPrefix(got, "exec weed -logtostderr=true admin ") {
+			t.Fatalf("expected exec'd weed command, got %q", got)
+		}
+		if !strings.Contains(got, "-urlPrefix=/admin") {
+			t.Fatalf("expected extra args to be included, got %q", got)
+		}
+		if strings.Contains(got, adminCredentialsMountPath) {
+			t.Fatalf("expected no credentials preamble, got %q", got)
 		}
 	})
 
-	t.Run("empty secret name yields no env vars", func(t *testing.T) {
-		m := baseSpec()
-		m.Spec.Admin.CredentialsSecret = &corev1.LocalObjectReference{Name: ""}
-		if got := adminCredentialEnvVars(m); got != nil {
-			t.Fatalf("expected nil env vars, got %+v", got)
+	t.Run("credentials secret emits flag-forwarding preamble", func(t *testing.T) {
+		m := &seaweedv1.Seaweed{
+			ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
+			Spec: seaweedv1.SeaweedSpec{
+				Master: &seaweedv1.MasterSpec{Replicas: 1},
+				Admin: &seaweedv1.AdminSpec{
+					CredentialsSecret: &corev1.LocalObjectReference{Name: "admin-creds"},
+				},
+			},
+		}
+		got := buildAdminStartupScript(m)
+
+		// The preamble must read each well-known key from the mount path and
+		// forward it as `-<key>=<value>` via `"$@"` so values with spaces or
+		// special characters survive shell expansion.
+		for _, key := range adminCredentialKeys {
+			if !strings.Contains(got, key) {
+				t.Errorf("expected preamble to reference key %q, got %q", key, got)
+			}
+		}
+		if !strings.Contains(got, adminCredentialsMountPath) {
+			t.Errorf("expected preamble to reference mount path %q, got %q", adminCredentialsMountPath, got)
+		}
+		if !strings.Contains(got, `set -- "$@" "-$key=$(cat "$f")"`) {
+			t.Errorf("expected preamble to append flags via positional parameters, got %q", got)
+		}
+		if !strings.Contains(got, `exec weed -logtostderr=true admin`) {
+			t.Errorf("expected weed to be exec'd after preamble, got %q", got)
+		}
+		if !strings.HasSuffix(got, ` "$@"`) {
+			t.Errorf("expected weed command to expand positional parameters at the end, got %q", got)
 		}
 	})
 
-	t.Run("credentials secret projects every key as optional secretKeyRef", func(t *testing.T) {
-		m := baseSpec()
-		m.Spec.Admin.CredentialsSecret = &corev1.LocalObjectReference{Name: "admin-creds"}
-
-		got := adminCredentialEnvVars(m)
-		if len(got) != len(adminCredentialEnvMappings) {
-			t.Fatalf("expected %d env vars, got %d: %+v", len(adminCredentialEnvMappings), len(got), got)
+	t.Run("empty credentials secret name skips preamble", func(t *testing.T) {
+		m := &seaweedv1.Seaweed{
+			ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
+			Spec: seaweedv1.SeaweedSpec{
+				Master: &seaweedv1.MasterSpec{Replicas: 1},
+				Admin: &seaweedv1.AdminSpec{
+					CredentialsSecret: &corev1.LocalObjectReference{Name: ""},
+				},
+			},
 		}
-		for i, mapping := range adminCredentialEnvMappings {
-			ev := got[i]
-			if ev.Name != mapping.envName {
-				t.Errorf("env[%d]: got name %q, want %q", i, ev.Name, mapping.envName)
-			}
-			if ev.ValueFrom == nil || ev.ValueFrom.SecretKeyRef == nil {
-				t.Fatalf("env[%d] (%s): missing SecretKeyRef", i, mapping.envName)
-			}
-			ref := ev.ValueFrom.SecretKeyRef
-			if ref.Name != "admin-creds" {
-				t.Errorf("env[%d]: secret name %q, want %q", i, ref.Name, "admin-creds")
-			}
-			if ref.Key != mapping.secretKey {
-				t.Errorf("env[%d]: secret key %q, want %q", i, ref.Key, mapping.secretKey)
-			}
-			// Every mapping is optional so users can supply only
-			// adminUser/adminPassword without pod startup failing on the
-			// missing read-only keys.
-			if ref.Optional == nil || !*ref.Optional {
-				t.Errorf("env[%d] (%s): SecretKeyRef.Optional must be true", i, mapping.envName)
-			}
+		got := buildAdminStartupScript(m)
+		if strings.Contains(got, adminCredentialsMountPath) {
+			t.Fatalf("expected no credentials preamble for empty secret name, got %q", got)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- Restore flag-based admin credential propagation (the path PR #216 originally landed before being changed to env vars)
- Project `spec.admin.credentialsSecret` as a read-only volume at `/etc/sw/admin`; a shell preamble reads each well-known key from disk and forwards it to `weed admin` as `-<key>=<value>` via positional parameters

## Why
PR #216 switched to setting `WEED_ADMIN_USER` / `WEED_ADMIN_PASSWORD` / `WEED_ADMIN_READONLY_USER` / `WEED_ADMIN_READONLY_PASSWORD` env vars on the assumption that `weed admin` would read them natively. In practice, the env vars are not picked up by the deployed `weed` binary — the admin pod still boots with `Authentication: Disabled` despite the secret being mounted and the env vars being present in the pod definition.

## Approach
- `buildAdminStartupScript` now emits a `set --` / `for key in ... done` preamble that walks the four well-known credential keys, reads each present file, and appends `-key=value` to `"$@"`. Keys with no file are skipped, so `readOnlyUser`/`readOnlyPassword` remain optional. `exec` is preserved so SIGTERM still reaches `weed` directly.
- `createAdminStatefulSet` projects the secret as a `Secret` volume at `/etc/sw/admin` instead of injecting `WEED_ADMIN_*` env vars.
- `set --` plus `"$@"` keeps values that contain spaces, quotes, or other shell metacharacters safely quoted through expansion.

Fixes #239

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/controller/...` (all unit tests pass, including new sub-tests in `TestBuildAdminStartupScript` covering: no secret, configured secret emits the preamble + flag-forwarding, empty secret name skips preamble)
- [ ] Deploy a Seaweed CR with `spec.admin.credentialsSecret` and confirm the admin pod logs `Authentication: Enabled`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated admin credentials delivery mechanism. Credentials from the configured secret are now mounted as read-only volumes rather than injected as environment variables, with values passed as command-line flags to the admin service.

* **Tests**
  * Comprehensive testing of admin startup script behavior across various credential secret configuration states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->