### PR TITLE
feat(crd): add per-component serviceAccountName (closes #244)

### DIFF
--- a/api/v1/component_accessor.go
+++ b/api/v1/component_accessor.go
@@ -247,9 +247,19 @@ func (s *Seaweed) BaseFilerSpec() ComponentAccessor {
 	return buildSeaweedComponentAccessor(&s.Spec, &s.Spec.Filer.ComponentSpec)
 }
 
-// BaseVolumeSpec provides merged spec of volumes
+// BaseVolumeSpec provides merged spec of volumes. Volume is optional —
+// topology-only deployments (spec.volumeTopology set, spec.volume omitted)
+// still call this accessor for cluster-level fallbacks like labels, so
+// nil-guard the dereference. Returning an accessor over an empty
+// ComponentSpec collapses the volume tier of inheritance to a no-op,
+// which matches the controller's expectation that topology entries fully
+// describe their pods when spec.volume is absent.
 func (s *Seaweed) BaseVolumeSpec() ComponentAccessor {
-	return buildSeaweedComponentAccessor(&s.Spec, &s.Spec.Volume.ComponentSpec)
+	cs := &ComponentSpec{}
+	if s.Spec.Volume != nil {
+		cs = &s.Spec.Volume.ComponentSpec
+	}
+	return buildSeaweedComponentAccessor(&s.Spec, cs)
 }
 
 // BaseAdminSpec provides merged spec of admin

--- a/api/v1/component_accessor.go
+++ b/api/v1/component_accessor.go
@@ -15,6 +15,7 @@ type ComponentAccessor interface {
 	HostNetwork() bool
 	Affinity() *corev1.Affinity
 	PriorityClassName() *string
+	ServiceAccountName() string
 	NodeSelector() map[string]string
 	Annotations() map[string]string
 	Tolerations() []corev1.Toleration
@@ -103,6 +104,14 @@ func (a *componentAccessorImpl) PriorityClassName() *string {
 	return pcn
 }
 
+func (a *componentAccessorImpl) ServiceAccountName() string {
+	san := a.ComponentSpec.ServiceAccountName
+	if san == nil {
+		return ""
+	}
+	return *san
+}
+
 func (a *componentAccessorImpl) SchedulerName() string {
 	pcn := a.ComponentSpec.SchedulerName
 	if pcn == nil {
@@ -165,6 +174,9 @@ func (a *componentAccessorImpl) BuildPodSpec() corev1.PodSpec {
 	}
 	if a.PriorityClassName() != nil {
 		spec.PriorityClassName = *a.PriorityClassName()
+	}
+	if san := a.ServiceAccountName(); san != "" {
+		spec.ServiceAccountName = san
 	}
 	if a.ImagePullSecrets() != nil {
 		spec.ImagePullSecrets = a.ImagePullSecrets()

--- a/api/v1/component_accessor_test.go
+++ b/api/v1/component_accessor_test.go
@@ -44,6 +44,27 @@ func TestBuildPodSpecServiceAccountName(t *testing.T) {
 	}
 }
 
+// TestBaseVolumeSpecNilVolume guards against the panic that surfaced on
+// the post-merge CI when spec.volumeTopology is set without spec.volume:
+// BaseVolumeSpec() previously deref'd s.Spec.Volume.ComponentSpec
+// unconditionally, crashing topology-only deployments through any
+// caller that reached for cluster-level fallbacks (Labels, etc.).
+func TestBaseVolumeSpecNilVolume(t *testing.T) {
+	s := &Seaweed{
+		Spec: SeaweedSpec{
+			Labels: map[string]string{"team": "platform"},
+			// Volume intentionally nil — topology-only deployment.
+		},
+	}
+	acc := s.BaseVolumeSpec()
+	got := acc.Labels()
+	if got["team"] != "platform" {
+		t.Fatalf("expected cluster label to pass through, got %v", got)
+	}
+	// BuildPodSpec must also be safe to call.
+	_ = acc.BuildPodSpec()
+}
+
 // TestComponentAccessorLabels pins the cluster+component label merge for
 // issue #243: component-level labels override cluster-level keys, and both
 // flow through unchanged when one side is empty.

--- a/api/v1/component_accessor_test.go
+++ b/api/v1/component_accessor_test.go
@@ -1,0 +1,35 @@
+package v1
+
+import "testing"
+
+// Verifies pod.spec.serviceAccountName is rendered per-component when
+// ComponentSpec.ServiceAccountName is set, and is omitted otherwise so
+// pods continue to fall back to the namespace's default SA.
+func TestBuildPodSpecServiceAccountName(t *testing.T) {
+	sa := "seaweedfs-master"
+	cases := []struct {
+		name     string
+		set      *string
+		expected string
+	}{
+		{"unset preserves default SA fallback", nil, ""},
+		{"explicit value is propagated", &sa, sa},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Seaweed{
+				Spec: SeaweedSpec{
+					Master: &MasterSpec{
+						ComponentSpec: ComponentSpec{ServiceAccountName: tc.set},
+						Replicas:      1,
+					},
+				},
+			}
+			got := s.BaseMasterSpec().BuildPodSpec().ServiceAccountName
+			if got != tc.expected {
+				t.Fatalf("ServiceAccountName = %q, want %q", got, tc.expected)
+			}
+		})
+	}
+}

--- a/api/v1/seaweed_types.go
+++ b/api/v1/seaweed_types.go
@@ -612,6 +612,16 @@ type ComponentSpec struct {
 	// PriorityClassName of the component. Override the cluster-level one if present
 	PriorityClassName *string `json:"priorityClassName,omitempty"`
 
+	// ServiceAccountName of the component's pods. When set, the operator
+	// renders pod.spec.serviceAccountName so the component runs under a
+	// dedicated ServiceAccount instead of the namespace's default SA. The
+	// operator does not create the ServiceAccount — it must already exist
+	// in the same namespace as the Seaweed CR. Required on clusters that
+	// bind SCCs or PSA-restricted privileges per-SA (e.g. OpenShift) and
+	// want to avoid granting elevated permissions to the default SA.
+	// +optional
+	ServiceAccountName *string `json:"serviceAccountName,omitempty"`
+
 	// SchedulerName of the component. Override the cluster-level one if present
 	SchedulerName *string `json:"schedulerName,omitempty"`
 

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -325,6 +325,11 @@ func (in *ComponentSpec) DeepCopyInto(out *ComponentSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ServiceAccountName != nil {
+		in, out := &in.ServiceAccountName, &out.ServiceAccountName
+		*out = new(string)
+		**out = **in
+	}
 	if in.SchedulerName != nil {
 		in, out := &in.SchedulerName, &out.SchedulerName
 		*out = new(string)

--- a/config/crd/bases/seaweed.seaweedfs.com_seaweeds.yaml
+++ b/config/crd/bases/seaweed.seaweedfs.com_seaweeds.yaml
@@ -637,6 +637,8 @@ spec:
                       type:
                         type: string
                     type: object
+                  serviceAccountName:
+                    type: string
                   sidecars:
                     x-kubernetes-preserve-unknown-fields: true
                   statefulSetUpdateStrategy:
@@ -2633,6 +2635,8 @@ spec:
                       type:
                         type: string
                     type: object
+                  serviceAccountName:
+                    type: string
                   sidecars:
                     x-kubernetes-preserve-unknown-fields: true
                   statefulSetUpdateStrategy:
@@ -4066,6 +4070,8 @@ spec:
                       type:
                         type: string
                     type: object
+                  serviceAccountName:
+                    type: string
                   sidecars:
                     x-kubernetes-preserve-unknown-fields: true
                   statefulSetUpdateStrategy:
@@ -5505,6 +5511,8 @@ spec:
                       type:
                         type: string
                     type: object
+                  serviceAccountName:
+                    type: string
                   sidecars:
                     x-kubernetes-preserve-unknown-fields: true
                   statefulSetUpdateStrategy:
@@ -6930,6 +6938,8 @@ spec:
                       type:
                         type: string
                     type: object
+                  serviceAccountName:
+                    type: string
                   sidecars:
                     x-kubernetes-preserve-unknown-fields: true
                   statefulSetUpdateStrategy:
@@ -8405,6 +8415,8 @@ spec:
                       type:
                         type: string
                     type: object
+                  serviceAccountName:
+                    type: string
                   sidecars:
                     x-kubernetes-preserve-unknown-fields: true
                   statefulSetUpdateStrategy:
@@ -9805,6 +9817,8 @@ spec:
                         type:
                           type: string
                       type: object
+                    serviceAccountName:
+                      type: string
                     sidecars:
                       x-kubernetes-preserve-unknown-fields: true
                     statefulSetUpdateStrategy:
@@ -11272,6 +11286,8 @@ spec:
                       x-kubernetes-int-or-string: true
                     type: object
                   schedulerName:
+                    type: string
+                  serviceAccountName:
                     type: string
                   sidecars:
                     x-kubernetes-preserve-unknown-fields: true

--- a/deploy/helm/templates/crd-seaweed.yaml
+++ b/deploy/helm/templates/crd-seaweed.yaml
@@ -911,6 +911,8 @@ spec:
                         type:
                           type: string
                       type: object
+                    serviceAccountName:
+                      type: string
                     sidecars:
                       x-kubernetes-preserve-unknown-fields: true
                     statefulSetUpdateStrategy:
@@ -2907,6 +2909,8 @@ spec:
                         type:
                           type: string
                       type: object
+                    serviceAccountName:
+                      type: string
                     sidecars:
                       x-kubernetes-preserve-unknown-fields: true
                     statefulSetUpdateStrategy:
@@ -4340,6 +4344,8 @@ spec:
                         type:
                           type: string
                       type: object
+                    serviceAccountName:
+                      type: string
                     sidecars:
                       x-kubernetes-preserve-unknown-fields: true
                     statefulSetUpdateStrategy:
@@ -5779,6 +5785,8 @@ spec:
                         type:
                           type: string
                       type: object
+                    serviceAccountName:
+                      type: string
                     sidecars:
                       x-kubernetes-preserve-unknown-fields: true
                     statefulSetUpdateStrategy:
@@ -7204,6 +7212,8 @@ spec:
                         type:
                           type: string
                       type: object
+                    serviceAccountName:
+                      type: string
                     sidecars:
                       x-kubernetes-preserve-unknown-fields: true
                     statefulSetUpdateStrategy:
@@ -8679,6 +8689,8 @@ spec:
                         type:
                           type: string
                       type: object
+                    serviceAccountName:
+                      type: string
                     sidecars:
                       x-kubernetes-preserve-unknown-fields: true
                     statefulSetUpdateStrategy:
@@ -10079,6 +10091,8 @@ spec:
                           type:
                             type: string
                         type: object
+                      serviceAccountName:
+                        type: string
                       sidecars:
                         x-kubernetes-preserve-unknown-fields: true
                       statefulSetUpdateStrategy:
@@ -11546,6 +11560,8 @@ spec:
                         x-kubernetes-int-or-string: true
                       type: object
                     schedulerName:
+                      type: string
+                    serviceAccountName:
                       type: string
                     sidecars:
                       x-kubernetes-preserve-unknown-fields: true

--- a/internal/controller/controller_volume_statefulset.go
+++ b/internal/controller/controller_volume_statefulset.go
@@ -13,6 +13,15 @@ import (
 )
 
 func buildVolumeServerStartupScriptWithTopology(m *seaweedv1.Seaweed, dirs []string, topologyName string, topologySpec *seaweedv1.VolumeTopologySpec) string {
+	// In topology-only deployments spec.volume is omitted (the operator
+	// skips the flat -volume StatefulSet entirely), so all flat-Volume
+	// fallbacks below must be nil-safe — reading m.Spec.Volume.<field>
+	// directly panics otherwise.
+	var fallback seaweedv1.VolumeServerConfig
+	if m.Spec.Volume != nil {
+		fallback = m.Spec.Volume.VolumeServerConfig
+	}
+
 	commands := []string{"weed", "-logtostderr=true"}
 	if arg := tlsConfigDirArg(m); arg != "" {
 		commands = append(commands, arg)
@@ -21,7 +30,7 @@ func buildVolumeServerStartupScriptWithTopology(m *seaweedv1.Seaweed, dirs []str
 	commands = append(commands, fmt.Sprintf("-port=%d", seaweedv1.VolumeHTTPPort))
 
 	// Configure max volume counts with fallback
-	maxVolumeCounts := getVolumeServerConfigValue(topologySpec.MaxVolumeCounts, m.Spec.Volume.MaxVolumeCounts)
+	maxVolumeCounts := getVolumeServerConfigValue(topologySpec.MaxVolumeCounts, fallback.MaxVolumeCounts)
 	if maxVolumeCounts != nil {
 		commands = append(commands, fmt.Sprintf("-max=%d", *maxVolumeCounts))
 	} else {
@@ -46,23 +55,23 @@ func buildVolumeServerStartupScriptWithTopology(m *seaweedv1.Seaweed, dirs []str
 	commands = append(commands, fmt.Sprintf("-dataCenter=%s", topologySpec.DataCenter))
 
 	// Add volume server configuration parameters with fallback
-	compactionMBps := getVolumeServerConfigValue(topologySpec.CompactionMBps, m.Spec.Volume.CompactionMBps)
+	compactionMBps := getVolumeServerConfigValue(topologySpec.CompactionMBps, fallback.CompactionMBps)
 	if compactionMBps != nil {
 		commands = append(commands, fmt.Sprintf("-compactionMBps=%d", *compactionMBps))
 	}
-	fileSizeLimitMB := getVolumeServerConfigValue(topologySpec.FileSizeLimitMB, m.Spec.Volume.FileSizeLimitMB)
+	fileSizeLimitMB := getVolumeServerConfigValue(topologySpec.FileSizeLimitMB, fallback.FileSizeLimitMB)
 	if fileSizeLimitMB != nil {
 		commands = append(commands, fmt.Sprintf("-fileSizeLimitMB=%d", *fileSizeLimitMB))
 	}
-	fixJpgOrientation := getVolumeServerConfigValue(topologySpec.FixJpgOrientation, m.Spec.Volume.FixJpgOrientation)
+	fixJpgOrientation := getVolumeServerConfigValue(topologySpec.FixJpgOrientation, fallback.FixJpgOrientation)
 	if fixJpgOrientation != nil {
 		commands = append(commands, fmt.Sprintf("-fixJpgOrientation=%t", *fixJpgOrientation))
 	}
-	idleTimeout := getVolumeServerConfigValue(topologySpec.IdleTimeout, m.Spec.Volume.IdleTimeout)
+	idleTimeout := getVolumeServerConfigValue(topologySpec.IdleTimeout, fallback.IdleTimeout)
 	if idleTimeout != nil {
 		commands = append(commands, fmt.Sprintf("-idleTimeout=%d", *idleTimeout))
 	}
-	minFreeSpacePercent := getVolumeServerConfigValue(topologySpec.MinFreeSpacePercent, m.Spec.Volume.MinFreeSpacePercent)
+	minFreeSpacePercent := getVolumeServerConfigValue(topologySpec.MinFreeSpacePercent, fallback.MinFreeSpacePercent)
 	if minFreeSpacePercent != nil {
 		commands = append(commands, fmt.Sprintf("-minFreeSpacePercent=%d", *minFreeSpacePercent))
 	}

--- a/internal/controller/controller_volume_statefulset.go
+++ b/internal/controller/controller_volume_statefulset.go
@@ -461,6 +461,10 @@ func buildTopologyPodSpec(m *seaweedv1.Seaweed, topologySpec *seaweedv1.VolumeTo
 		podSpec.PriorityClassName = *topologySpec.PriorityClassName
 	}
 
+	if topologySpec.ServiceAccountName != nil {
+		podSpec.ServiceAccountName = *topologySpec.ServiceAccountName
+	}
+
 	if topologySpec.SchedulerName != nil {
 		podSpec.SchedulerName = *topologySpec.SchedulerName
 	} else if m.Spec.SchedulerName != "" {

--- a/internal/controller/helper_test.go
+++ b/internal/controller/helper_test.go
@@ -77,6 +77,30 @@ func TestFilterContainerResourcesEmpty(t *testing.T) {
 	}
 }
 
+// TestBuildVolumeServerStartupScriptWithTopologyNilVolume guards against
+// the panic surfaced by issue #244 once VolumeTopology was exercised
+// without a flat spec.volume: the builder previously dereferenced
+// m.Spec.Volume.<field> unconditionally, crashing the reconciler on
+// topology-only deployments.
+func TestBuildVolumeServerStartupScriptWithTopologyNilVolume(t *testing.T) {
+	m := &seaweedv1.Seaweed{
+		ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
+		Spec: seaweedv1.SeaweedSpec{
+			Master: &seaweedv1.MasterSpec{Replicas: 1},
+		},
+	}
+	topo := &seaweedv1.VolumeTopologySpec{
+		VolumeServerConfig: seaweedv1.VolumeServerConfig{},
+		Rack:               "rack1",
+		DataCenter:         "dc1",
+	}
+	// Must not panic.
+	got := buildVolumeServerStartupScriptWithTopology(m, []string{"/data0"}, "rack1", topo)
+	if got == "" {
+		t.Fatal("expected non-empty startup script")
+	}
+}
+
 // TestBuildTopologyPodSpecServiceAccountName locks in that the
 // VolumeTopology pod-spec builder (which constructs PodSpec manually
 // rather than via ComponentAccessor.BuildPodSpec) also propagates

--- a/internal/controller/helper_test.go
+++ b/internal/controller/helper_test.go
@@ -77,6 +77,40 @@ func TestFilterContainerResourcesEmpty(t *testing.T) {
 	}
 }
 
+// TestBuildTopologyPodSpecServiceAccountName locks in that the
+// VolumeTopology pod-spec builder (which constructs PodSpec manually
+// rather than via ComponentAccessor.BuildPodSpec) also propagates
+// serviceAccountName — see issue #244.
+func TestBuildTopologyPodSpecServiceAccountName(t *testing.T) {
+	sa := "seaweedfs-volume-rack1"
+	cases := []struct {
+		name     string
+		set      *string
+		expected string
+	}{
+		{"unset preserves default SA fallback", nil, ""},
+		{"explicit value is propagated", &sa, sa},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &seaweedv1.Seaweed{
+				ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
+			}
+			topo := &seaweedv1.VolumeTopologySpec{
+				VolumeServerConfig: seaweedv1.VolumeServerConfig{
+					ComponentSpec: seaweedv1.ComponentSpec{ServiceAccountName: tc.set},
+				},
+				Rack:       "rack1",
+				DataCenter: "dc1",
+			}
+			got := buildTopologyPodSpec(m, topo).ServiceAccountName
+			if got != tc.expected {
+				t.Fatalf("ServiceAccountName = %q, want %q", got, tc.expected)
+			}
+		})
+	}
+}
+
 // TestGetFilerAddress pins the filer address format; a regression here
 // resurfaces issue #237.
 func TestGetFilerAddress(t *testing.T) {

--- a/test/e2e/service_account_integration_test.go
+++ b/test/e2e/service_account_integration_test.go
@@ -22,6 +22,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
@@ -70,9 +72,15 @@ var _ = Describe("ServiceAccountName Integration", Ordered, func() {
 		filerSA := "seaweedfs-filer"
 		topologySA := "seaweedfs-volume-rack1"
 
-		BeforeEach(func() {
+		// buildBase returns a Seaweed CR with master and filer wired up,
+		// each pinned to its own ServiceAccount. The volume side is
+		// intentionally absent so each spec can choose between the flat
+		// VolumeSpec and the topology-aware VolumeTopology map — they
+		// flow through different pod-spec builders and Seaweed treats
+		// VolumeTopology as a replacement for VolumeSpec, not an addition.
+		buildBase := func() *seaweedv1.Seaweed {
 			concurrentStart := true
-			seaweed = &seaweedv1.Seaweed{
+			return &seaweedv1.Seaweed{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      seaweedName,
 					Namespace: testNamespace,
@@ -86,40 +94,32 @@ var _ = Describe("ServiceAccountName Integration", Ordered, func() {
 							ServiceAccountName: &masterSA,
 						},
 					},
-					Volume: &seaweedv1.VolumeSpec{
-						Replicas: 1,
-						VolumeServerConfig: seaweedv1.VolumeServerConfig{
-							ComponentSpec: seaweedv1.ComponentSpec{
-								ServiceAccountName: &volumeSA,
-							},
-						},
-					},
 					Filer: &seaweedv1.FilerSpec{
 						Replicas: 1,
 						ComponentSpec: seaweedv1.ComponentSpec{
 							ServiceAccountName: &filerSA,
 						},
 					},
-					// VolumeTopology has its own pod-spec builder
-					// (buildTopologyPodSpec) separate from the shared
-					// ComponentAccessor path — covered here to lock in
-					// that the field flows through both code paths.
-					VolumeTopology: map[string]*seaweedv1.VolumeTopologySpec{
-						"rack1": {
-							VolumeServerConfig: seaweedv1.VolumeServerConfig{
-								ComponentSpec: seaweedv1.ComponentSpec{
-									ServiceAccountName: &topologySA,
-								},
-							},
-							Replicas:   1,
-							Rack:       "rack1",
-							DataCenter: "dc1",
-						},
-					},
 					VolumeServerDiskCount: func() *int32 { v := int32(1); return &v }(),
 				},
 			}
-		})
+		}
+
+		assertSAs := func(expected map[string]string) {
+			clientset, err := utils.GetClientset(restCfg)
+			Expect(err).NotTo(HaveOccurred())
+			for stsName, wantSA := range expected {
+				stsName, wantSA := stsName, wantSA
+				Eventually(func() (string, error) {
+					sts, err := clientset.AppsV1().StatefulSets(testNamespace).Get(ctx, stsName, metav1.GetOptions{})
+					if err != nil {
+						return "", err
+					}
+					return sts.Spec.Template.Spec.ServiceAccountName, nil
+				}, time.Minute*2, time.Second*10).Should(Equal(wantSA),
+					"StatefulSet %s should pin pods to %s, not the namespace default SA", stsName, wantSA)
+			}
+		}
 
 		AfterEach(func() {
 			if seaweed != nil {
@@ -133,29 +133,61 @@ var _ = Describe("ServiceAccountName Integration", Ordered, func() {
 			}
 		})
 
-		It("should set serviceAccountName on master, volume, filer, and topology volume StatefulSets", func() {
+		It("should set serviceAccountName on master, volume, and filer StatefulSets", func() {
+			seaweed = buildBase()
+			seaweed.Spec.Volume = &seaweedv1.VolumeSpec{
+				Replicas: 1,
+				VolumeServerConfig: seaweedv1.VolumeServerConfig{
+					ComponentSpec: seaweedv1.ComponentSpec{
+						ServiceAccountName: &volumeSA,
+					},
+					ResourceRequirements: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("1Gi"),
+						},
+					},
+				},
+			}
 			Expect(k8sClient.Create(ctx, seaweed)).To(Succeed())
 
-			clientset, err := utils.GetClientset(restCfg)
-			Expect(err).NotTo(HaveOccurred())
+			assertSAs(map[string]string{
+				seaweedName + "-master": masterSA,
+				seaweedName + "-volume": volumeSA,
+				seaweedName + "-filer":  filerSA,
+			})
+		})
 
-			expected := map[string]string{
+		// VolumeTopology renders pods through buildTopologyPodSpec, not
+		// ComponentAccessor.BuildPodSpec — the field needs to flow through
+		// both code paths. Note that setting VolumeTopology causes the
+		// operator to skip the flat -volume StatefulSet entirely, so this
+		// spec verifies only the topology-suffixed StatefulSet.
+		It("should set serviceAccountName on the topology volume StatefulSet", func() {
+			seaweed = buildBase()
+			seaweed.Spec.VolumeTopology = map[string]*seaweedv1.VolumeTopologySpec{
+				"rack1": {
+					VolumeServerConfig: seaweedv1.VolumeServerConfig{
+						ComponentSpec: seaweedv1.ComponentSpec{
+							ServiceAccountName: &topologySA,
+						},
+						ResourceRequirements: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("1Gi"),
+							},
+						},
+					},
+					Replicas:   1,
+					Rack:       "rack1",
+					DataCenter: "dc1",
+				},
+			}
+			Expect(k8sClient.Create(ctx, seaweed)).To(Succeed())
+
+			assertSAs(map[string]string{
 				seaweedName + "-master":       masterSA,
-				seaweedName + "-volume":       volumeSA,
 				seaweedName + "-filer":        filerSA,
 				seaweedName + "-volume-rack1": topologySA,
-			}
-
-			for stsName, wantSA := range expected {
-				stsName, wantSA := stsName, wantSA
-				Eventually(func() (string, error) {
-					sts, err := clientset.AppsV1().StatefulSets(testNamespace).Get(ctx, stsName, metav1.GetOptions{})
-					if err != nil {
-						return "", err
-					}
-					return sts.Spec.Template.Spec.ServiceAccountName, nil
-				}, time.Minute*2, time.Second*10).Should(Equal(wantSA), "StatefulSet %s should pin pods to %s, not the namespace default SA", stsName, wantSA)
-			}
+			})
 		})
 	})
 })

--- a/test/e2e/service_account_integration_test.go
+++ b/test/e2e/service_account_integration_test.go
@@ -68,6 +68,7 @@ var _ = Describe("ServiceAccountName Integration", Ordered, func() {
 		masterSA := "seaweedfs-master"
 		volumeSA := "seaweedfs-volume"
 		filerSA := "seaweedfs-filer"
+		topologySA := "seaweedfs-volume-rack1"
 
 		BeforeEach(func() {
 			concurrentStart := true
@@ -99,6 +100,22 @@ var _ = Describe("ServiceAccountName Integration", Ordered, func() {
 							ServiceAccountName: &filerSA,
 						},
 					},
+					// VolumeTopology has its own pod-spec builder
+					// (buildTopologyPodSpec) separate from the shared
+					// ComponentAccessor path — covered here to lock in
+					// that the field flows through both code paths.
+					VolumeTopology: map[string]*seaweedv1.VolumeTopologySpec{
+						"rack1": {
+							VolumeServerConfig: seaweedv1.VolumeServerConfig{
+								ComponentSpec: seaweedv1.ComponentSpec{
+									ServiceAccountName: &topologySA,
+								},
+							},
+							Replicas:   1,
+							Rack:       "rack1",
+							DataCenter: "dc1",
+						},
+					},
 					VolumeServerDiskCount: func() *int32 { v := int32(1); return &v }(),
 				},
 			}
@@ -116,16 +133,17 @@ var _ = Describe("ServiceAccountName Integration", Ordered, func() {
 			}
 		})
 
-		It("should set serviceAccountName on master, volume, and filer StatefulSets", func() {
+		It("should set serviceAccountName on master, volume, filer, and topology volume StatefulSets", func() {
 			Expect(k8sClient.Create(ctx, seaweed)).To(Succeed())
 
 			clientset, err := utils.GetClientset(restCfg)
 			Expect(err).NotTo(HaveOccurred())
 
 			expected := map[string]string{
-				seaweedName + "-master": masterSA,
-				seaweedName + "-volume": volumeSA,
-				seaweedName + "-filer":  filerSA,
+				seaweedName + "-master":       masterSA,
+				seaweedName + "-volume":       volumeSA,
+				seaweedName + "-filer":        filerSA,
+				seaweedName + "-volume-rack1": topologySA,
 			}
 
 			for stsName, wantSA := range expected {

--- a/test/e2e/service_account_integration_test.go
+++ b/test/e2e/service_account_integration_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+	"github.com/seaweedfs/seaweedfs-operator/test/utils"
+)
+
+// Covers issue #244: without spec.<component>.serviceAccountName the
+// operator-managed StatefulSets render an empty SA and pods fall back to
+// the namespace's default SA, which forces OpenShift / PSA-restricted
+// clusters to bind elevated SCCs to that default SA. Verifies the field
+// flows through to the rendered StatefulSet pod template for each
+// component. The referenced ServiceAccounts are intentionally not
+// created — this test asserts manifest rendering, not pod scheduling.
+var _ = Describe("ServiceAccountName Integration", Ordered, func() {
+	var (
+		ctx           context.Context
+		k8sClient     client.Client
+		restCfg       *rest.Config
+		testNamespace = "test-service-accounts"
+		seaweedName   = "test-seaweed-sa"
+	)
+
+	BeforeAll(func() {
+		ctx = context.Background()
+		k8sClient, restCfg = utils.NewE2EClient()
+		utils.EnsureNamespace(ctx, k8sClient, testNamespace)
+	})
+
+	BeforeEach(func() {
+		DeferCleanup(func() {
+			utils.CollectDiagnostics(ctx, k8sClient, restCfg, testNamespace)
+		})
+	})
+
+	AfterAll(func() {
+		utils.DeleteNamespace(ctx, k8sClient, testNamespace)
+	})
+
+	Context("When deploying Seaweed with per-component serviceAccountName set", func() {
+		var seaweed *seaweedv1.Seaweed
+		masterSA := "seaweedfs-master"
+		volumeSA := "seaweedfs-volume"
+		filerSA := "seaweedfs-filer"
+
+		BeforeEach(func() {
+			concurrentStart := true
+			seaweed = &seaweedv1.Seaweed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      seaweedName,
+					Namespace: testNamespace,
+				},
+				Spec: seaweedv1.SeaweedSpec{
+					Image: "chrislusf/seaweedfs:latest",
+					Master: &seaweedv1.MasterSpec{
+						Replicas:        1,
+						ConcurrentStart: &concurrentStart,
+						ComponentSpec: seaweedv1.ComponentSpec{
+							ServiceAccountName: &masterSA,
+						},
+					},
+					Volume: &seaweedv1.VolumeSpec{
+						Replicas: 1,
+						VolumeServerConfig: seaweedv1.VolumeServerConfig{
+							ComponentSpec: seaweedv1.ComponentSpec{
+								ServiceAccountName: &volumeSA,
+							},
+						},
+					},
+					Filer: &seaweedv1.FilerSpec{
+						Replicas: 1,
+						ComponentSpec: seaweedv1.ComponentSpec{
+							ServiceAccountName: &filerSA,
+						},
+					},
+					VolumeServerDiskCount: func() *int32 { v := int32(1); return &v }(),
+				},
+			}
+		})
+
+		AfterEach(func() {
+			if seaweed != nil {
+				_ = k8sClient.Delete(ctx, seaweed)
+				Eventually(func() error {
+					return k8sClient.Get(ctx, types.NamespacedName{
+						Name:      seaweedName,
+						Namespace: testNamespace,
+					}, seaweed)
+				}, time.Minute*2, time.Second*5).ShouldNot(Succeed())
+			}
+		})
+
+		It("should set serviceAccountName on master, volume, and filer StatefulSets", func() {
+			Expect(k8sClient.Create(ctx, seaweed)).To(Succeed())
+
+			clientset, err := utils.GetClientset(restCfg)
+			Expect(err).NotTo(HaveOccurred())
+
+			expected := map[string]string{
+				seaweedName + "-master": masterSA,
+				seaweedName + "-volume": volumeSA,
+				seaweedName + "-filer":  filerSA,
+			}
+
+			for stsName, wantSA := range expected {
+				stsName, wantSA := stsName, wantSA
+				Eventually(func() (string, error) {
+					sts, err := clientset.AppsV1().StatefulSets(testNamespace).Get(ctx, stsName, metav1.GetOptions{})
+					if err != nil {
+						return "", err
+					}
+					return sts.Spec.Template.Spec.ServiceAccountName, nil
+				}, time.Minute*2, time.Second*10).Should(Equal(wantSA), "StatefulSet %s should pin pods to %s, not the namespace default SA", stsName, wantSA)
+			}
+		})
+	})
+})


### PR DESCRIPTION
## Summary
- Add optional `serviceAccountName` to `ComponentSpec` so master/volume/filer/admin/worker/S3/SFTP pods can each run under a dedicated ServiceAccount instead of the namespace's default SA.
- Wire the field through `ComponentAccessor.BuildPodSpec()` — unset preserves the prior behavior (empty pod-spec field, default-SA fallback), so this is a pure additive change.
- Regenerate `zz_generated.deepcopy.go`, the base CRD, and the Helm-templated CRD via `make generate manifests helm-crd-copy`.

Closes #244.

### Why
On OpenShift / PSA-restricted clusters, the only way to make Seaweed pods schedulable today is to bind a SCC (e.g. `privileged`, `anyuid`) to `system:serviceaccount:<ns>:default`, which leaks those privileges to every unrelated workload in the namespace. With this field, operators can bind the SCC to just the SeaweedFS SAs they choose to create.

Example:
```yaml
spec:
  master:
    serviceAccountName: seaweedfs-master
  volume:
    serviceAccountName: seaweedfs-volume
  filer:
    serviceAccountName: seaweedfs-filer
```

The operator deliberately does not create the SA — it must already exist in the same namespace. That keeps the SCC binding under the cluster admin's control.

## Test plan
- [x] Unit test in `api/v1/component_accessor_test.go` — covers both unset (empty SA preserved) and set (value propagates to pod spec) cases.
- [x] Integration test in `test/e2e/service_account_integration_test.go` — creates a Seaweed CR with `serviceAccountName` on master, volume, and filer, then asserts each rendered StatefulSet's pod template has the SA pinned. The referenced SAs are intentionally not created — the test verifies manifest rendering, not pod scheduling.
- [x] `make generate manifests helm-crd-copy` — CRD diff shows a `serviceAccountName: { type: string }` slot under all eight component specs (master / volume / volumeTopology / filer / admin / worker / s3 / sftp).
- [x] `go build ./...`, `go vet ./...`, `go test ./api/v1/...` all pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-component ServiceAccount names supported in Seaweed CRs (admin, filer, master, worker, s3, sftp) and per-volume-topology entries.

* **Bug Fixes / Behavior**
  * Pod templates omit ServiceAccountName when unset and apply configured ServiceAccountName when provided.
  * Topology-only or missing volume configs no longer cause panics; startup and pod spec generation are nil-safe.

* **Tests**
  * Added unit and e2e tests validating ServiceAccountName propagation and topology nil-volume handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs-operator/pull/245)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->