### PR TITLE
Name the drifted fields in VolumeClaimTemplatesMismatch event

### DIFF
--- a/internal/controller/seaweed_controller.go
+++ b/internal/controller/seaweed_controller.go
@@ -525,13 +525,21 @@ func (r *SeaweedReconciler) reconcileVolumeClaimTemplates(ctx context.Context, s
 	}
 
 	// Warn but don't fail reconciliation — this requires manual intervention.
+	// Name the specific fields that drifted so operators (and future bug
+	// reports) can tell whether this is a real user-intent change versus a
+	// spurious apiserver-defaulting artifact the comparator should have
+	// smoothed over.
+	diffs := vctDifferences(existing.Spec.VolumeClaimTemplates, desired.Spec.VolumeClaimTemplates)
+	diffSummary := strings.Join(diffs, "; ")
+
 	r.Log.Info("VolumeClaimTemplates differ but cannot be auto-applied. Delete the StatefulSet manually to apply changes.",
 		"statefulset", existing.Name,
-		"namespace", existing.Namespace)
+		"namespace", existing.Namespace,
+		"differences", diffSummary)
 
 	if r.Recorder != nil {
 		r.Recorder.Eventf(seaweedCR, corev1.EventTypeWarning, "VolumeClaimTemplatesMismatch",
-			"VolumeClaimTemplates on %s differ but cannot be auto-applied. Delete the StatefulSet manually to apply changes.", existing.Name)
+			"VolumeClaimTemplates on %s differ but cannot be auto-applied. Delete the StatefulSet manually to apply changes. Differences: %s", existing.Name, diffSummary)
 	}
 
 	return nil

--- a/internal/controller/volume_claim_templates.go
+++ b/internal/controller/volume_claim_templates.go
@@ -17,6 +17,9 @@ limitations under the License.
 package controller
 
 import (
+	"fmt"
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 )
@@ -90,6 +93,94 @@ func pvcSemanticallyEqual(a, b corev1.PersistentVolumeClaim) bool {
 		return false
 	}
 	return true
+}
+
+// vctDifferences returns a human-readable description of the first
+// few field-level differences between two VolumeClaimTemplates slices,
+// using the same comparison surface as vctSemanticallyEqual.
+//
+// It exists so that the "VolumeClaimTemplates differ" Warning event
+// can name what actually drifted, rather than forcing operators to
+// guess. If nothing drifted, the slice is empty (and vctSemanticallyEqual
+// will have already returned true). Output is capped to avoid producing
+// multi-kilobyte event messages when many fields differ at once.
+func vctDifferences(a, b []corev1.PersistentVolumeClaim) []string {
+	const maxDiffs = 5
+	var diffs []string
+
+	if len(a) != len(b) {
+		diffs = append(diffs, fmt.Sprintf("length: existing=%d desired=%d", len(a), len(b)))
+		return diffs
+	}
+
+	for i := range a {
+		diffs = append(diffs, pvcDifferences(a[i], b[i], i)...)
+		if len(diffs) >= maxDiffs {
+			diffs = diffs[:maxDiffs]
+			diffs = append(diffs, "...")
+			break
+		}
+	}
+	return diffs
+}
+
+func pvcDifferences(a, b corev1.PersistentVolumeClaim, index int) []string {
+	var diffs []string
+	prefix := fmt.Sprintf("template[%d]", index)
+	if a.Name != "" {
+		prefix = fmt.Sprintf("template[%d:%s]", index, a.Name)
+	}
+
+	if a.Name != b.Name {
+		diffs = append(diffs, fmt.Sprintf("%s.name: %q vs %q", prefix, a.Name, b.Name))
+	}
+	if !apiequality.Semantic.DeepEqual(a.Spec.AccessModes, b.Spec.AccessModes) {
+		diffs = append(diffs, fmt.Sprintf("%s.accessModes: %v vs %v", prefix, a.Spec.AccessModes, b.Spec.AccessModes))
+	}
+	if !apiequality.Semantic.DeepEqual(a.Spec.Resources.Requests, b.Spec.Resources.Requests) {
+		diffs = append(diffs, fmt.Sprintf("%s.resources.requests: %s vs %s", prefix, resourceListString(a.Spec.Resources.Requests), resourceListString(b.Spec.Resources.Requests)))
+	}
+	if !apiequality.Semantic.DeepEqual(a.Spec.StorageClassName, b.Spec.StorageClassName) {
+		diffs = append(diffs, fmt.Sprintf("%s.storageClassName: %s vs %s", prefix, stringPtr(a.Spec.StorageClassName), stringPtr(b.Spec.StorageClassName)))
+	}
+	if !apiequality.Semantic.DeepEqual(a.Spec.Selector, b.Spec.Selector) {
+		diffs = append(diffs, fmt.Sprintf("%s.selector differs", prefix))
+	}
+	if a.Spec.VolumeName != b.Spec.VolumeName {
+		diffs = append(diffs, fmt.Sprintf("%s.volumeName: %q vs %q", prefix, a.Spec.VolumeName, b.Spec.VolumeName))
+	}
+	if !volumeModeSemanticallyEqual(a.Spec.VolumeMode, b.Spec.VolumeMode) {
+		diffs = append(diffs, fmt.Sprintf("%s.volumeMode: %s vs %s", prefix, volumeModeString(a.Spec.VolumeMode), volumeModeString(b.Spec.VolumeMode)))
+	}
+	if !apiequality.Semantic.DeepEqual(a.Spec.DataSource, b.Spec.DataSource) {
+		diffs = append(diffs, fmt.Sprintf("%s.dataSource differs", prefix))
+	}
+	return diffs
+}
+
+func resourceListString(rl corev1.ResourceList) string {
+	if len(rl) == 0 {
+		return "{}"
+	}
+	parts := make([]string, 0, len(rl))
+	for name, q := range rl {
+		parts = append(parts, fmt.Sprintf("%s=%s", name, q.String()))
+	}
+	return "{" + strings.Join(parts, ",") + "}"
+}
+
+func stringPtr(p *string) string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%q", *p)
+}
+
+func volumeModeString(p *corev1.PersistentVolumeMode) string {
+	if p == nil {
+		return "<nil>"
+	}
+	return string(*p)
 }
 
 // volumeModeSemanticallyEqual treats nil VolumeMode as Filesystem,

--- a/internal/controller/volume_claim_templates.go
+++ b/internal/controller/volume_claim_templates.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -162,8 +163,14 @@ func resourceListString(rl corev1.ResourceList) string {
 	if len(rl) == 0 {
 		return "{}"
 	}
-	parts := make([]string, 0, len(rl))
-	for name, q := range rl {
+	names := make([]string, 0, len(rl))
+	for name := range rl {
+		names = append(names, string(name))
+	}
+	sort.Strings(names)
+	parts := make([]string, 0, len(names))
+	for _, name := range names {
+		q := rl[corev1.ResourceName(name)]
 		parts = append(parts, fmt.Sprintf("%s=%s", name, q.String()))
 	}
 	return "{" + strings.Join(parts, ",") + "}"

--- a/internal/controller/volume_claim_templates_test.go
+++ b/internal/controller/volume_claim_templates_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -125,6 +126,76 @@ func TestVCTSemanticallyEqual_DetectsLengthDiff(t *testing.T) {
 	}
 	if vctSemanticallyEqual(one, two) {
 		t.Errorf("expected length diff to be detected")
+	}
+}
+
+func TestVCTDifferences_ReturnsEmptyForEqualTemplates(t *testing.T) {
+	mk := func() []corev1.PersistentVolumeClaim {
+		return []corev1.PersistentVolumeClaim{{
+			ObjectMeta: metav1.ObjectMeta{Name: "data"},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("100Gi"),
+					},
+				},
+			},
+		}}
+	}
+	if diffs := vctDifferences(mk(), mk()); len(diffs) != 0 {
+		t.Errorf("expected no differences for equal templates, got %v", diffs)
+	}
+}
+
+func TestVCTDifferences_NamesTheDriftedField(t *testing.T) {
+	mk := func(size, class string) []corev1.PersistentVolumeClaim {
+		var sc *string
+		if class != "" {
+			sc = &class
+		}
+		return []corev1.PersistentVolumeClaim{{
+			ObjectMeta: metav1.ObjectMeta{Name: "mount0"},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				StorageClassName: sc,
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse(size),
+					},
+				},
+			},
+		}}
+	}
+
+	diffs := vctDifferences(mk("100Gi", "fast"), mk("200Gi", "slow"))
+	if len(diffs) == 0 {
+		t.Fatalf("expected differences to be reported")
+	}
+	joined := strings.Join(diffs, " ")
+	if !strings.Contains(joined, "resources.requests") {
+		t.Errorf("expected resources.requests to be named in diff, got %v", diffs)
+	}
+	if !strings.Contains(joined, "storageClassName") {
+		t.Errorf("expected storageClassName to be named in diff, got %v", diffs)
+	}
+	if !strings.Contains(joined, "mount0") {
+		t.Errorf("expected template name to appear in diff prefix, got %v", diffs)
+	}
+}
+
+func TestVCTDifferences_ReportsLengthMismatchOnly(t *testing.T) {
+	one := []corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "a"}}}
+	two := []corev1.PersistentVolumeClaim{
+		{ObjectMeta: metav1.ObjectMeta{Name: "a"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "b"}},
+	}
+	diffs := vctDifferences(one, two)
+	if len(diffs) != 1 {
+		t.Fatalf("expected exactly one diff for length mismatch, got %v", diffs)
+	}
+	if !strings.Contains(diffs[0], "length") {
+		t.Errorf("expected length diff, got %q", diffs[0])
 	}
 }
 

--- a/internal/controller/volume_claim_templates_test.go
+++ b/internal/controller/volume_claim_templates_test.go
@@ -199,6 +199,30 @@ func TestVCTDifferences_ReportsLengthMismatchOnly(t *testing.T) {
 	}
 }
 
+// TestResourceListString_DeterministicAcrossMapIteration pins that the
+// diff message sorts resource names. Without this, repeated reconciles
+// could format the same ResourceList differently — the Warning event
+// body would flap between runs and confuse anyone diffing event logs.
+func TestResourceListString_DeterministicAcrossMapIteration(t *testing.T) {
+	rl := corev1.ResourceList{
+		corev1.ResourceStorage:          resource.MustParse("100Gi"),
+		corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
+		corev1.ResourceMemory:           resource.MustParse("4Gi"),
+		corev1.ResourceCPU:              resource.MustParse("2"),
+	}
+	first := resourceListString(rl)
+	for i := 0; i < 50; i++ {
+		if got := resourceListString(rl); got != first {
+			t.Fatalf("resourceListString output flapped between calls: %q vs %q", first, got)
+		}
+	}
+	// And confirm the order is the expected sorted one, not just stable-by-luck.
+	want := "{cpu=2,ephemeral-storage=1Gi,memory=4Gi,storage=100Gi}"
+	if first != want {
+		t.Errorf("resourceListString = %q, want %q", first, want)
+	}
+}
+
 func TestVCTSemanticallyEqual_DetectsExplicitlyDifferentVolumeMode(t *testing.T) {
 	filesystem := corev1.PersistentVolumeFilesystem
 	block := corev1.PersistentVolumeBlock


### PR DESCRIPTION
## Summary
- The `VolumeClaimTemplatesMismatch` Warning event used to say only that templates "differ but cannot be auto-applied", with no indication of which field tripped the comparator. When a user hit a spurious mismatch (#242), there was nothing actionable to attach to the bug report.
- Add `vctDifferences()` as a sibling to `vctSemanticallyEqual` using the same comparison surface (Name, AccessModes, Resources.Requests, StorageClassName, Selector, VolumeName, VolumeMode-normalized, DataSource), and thread the field-level summary into the recorded event and log line.
- Output is capped at 5 differences with a trailing `...` so event messages stay bounded.

Example new event message:
```
VolumeClaimTemplates on seaweed-saas-volume differ but cannot be auto-applied. Delete the StatefulSet manually to apply changes. Differences: template[0:mount0].storageClassName: <nil> vs "fast"
```

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/controller/ -run "VCT|vct" -v` — all pass, including three new tests for the diff helper (equal-templates returns empty, length mismatch reports length only, drifted fields name the right field and include the template prefix)
- [ ] On the next #242-style report, the event will name the leaking field so we can pinpoint whether the comparator needs to smooth another apiserver default or whether real drift exists

Refs #242.