### PR TITLE
feat(api): add custom pod labels per component

### DIFF
--- a/api/v1/component_accessor.go
+++ b/api/v1/component_accessor.go
@@ -17,6 +17,7 @@ type ComponentAccessor interface {
 	PriorityClassName() *string
 	NodeSelector() map[string]string
 	Annotations() map[string]string
+	Labels() map[string]string
 	Tolerations() []corev1.Toleration
 	SchedulerName() string
 	DNSPolicy() corev1.DNSPolicy
@@ -39,6 +40,7 @@ type componentAccessorImpl struct {
 	schedulerName             string
 	clusterNodeSelector       map[string]string
 	clusterAnnotations        map[string]string
+	clusterLabels             map[string]string
 	tolerations               []corev1.Toleration
 	statefulSetUpdateStrategy appsv1.StatefulSetUpdateStrategyType
 
@@ -133,6 +135,17 @@ func (a *componentAccessorImpl) Annotations() map[string]string {
 	return anno
 }
 
+func (a *componentAccessorImpl) Labels() map[string]string {
+	lbl := map[string]string{}
+	for k, v := range a.clusterLabels {
+		lbl[k] = v
+	}
+	for k, v := range a.ComponentSpec.Labels {
+		lbl[k] = v
+	}
+	return lbl
+}
+
 func (a *componentAccessorImpl) Tolerations() []corev1.Toleration {
 	tols := a.ComponentSpec.Tolerations
 	if len(tols) == 0 {
@@ -204,6 +217,7 @@ func buildSeaweedComponentAccessor(spec *SeaweedSpec, componentSpec *ComponentSp
 		schedulerName:             spec.SchedulerName,
 		clusterNodeSelector:       spec.NodeSelector,
 		clusterAnnotations:        spec.Annotations,
+		clusterLabels:             spec.Labels,
 		tolerations:               spec.Tolerations,
 		statefulSetUpdateStrategy: spec.StatefulSetUpdateStrategy,
 

--- a/api/v1/component_accessor_test.go
+++ b/api/v1/component_accessor_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package v1
+
+import "testing"
+
+// TestComponentAccessorLabels pins the cluster+component label merge for
+// issue #243: component-level labels override cluster-level keys, and both
+// flow through unchanged when one side is empty.
+func TestComponentAccessorLabels(t *testing.T) {
+	t.Run("merges cluster and component labels with component winning", func(t *testing.T) {
+		s := &Seaweed{
+			Spec: SeaweedSpec{
+				Labels: map[string]string{"team": "platform", "env": "prod"},
+				Filer: &FilerSpec{
+					ComponentSpec: ComponentSpec{
+						Labels: map[string]string{"team": "storage", "backup": "true"},
+					},
+				},
+			},
+		}
+		got := s.BaseFilerSpec().Labels()
+		want := map[string]string{
+			"team":   "storage", // component overrides cluster
+			"env":    "prod",    // cluster passes through
+			"backup": "true",    // component-only
+		}
+		if len(got) != len(want) {
+			t.Fatalf("len = %d, want %d (got %v)", len(got), len(want), got)
+		}
+		for k, v := range want {
+			if got[k] != v {
+				t.Errorf("got[%q] = %q, want %q", k, got[k], v)
+			}
+		}
+	})
+
+	t.Run("empty inputs return an empty map (never nil)", func(t *testing.T) {
+		s := &Seaweed{Spec: SeaweedSpec{Filer: &FilerSpec{}}}
+		got := s.BaseFilerSpec().Labels()
+		if got == nil {
+			t.Fatal("Labels() returned nil; expected empty map")
+		}
+		if len(got) != 0 {
+			t.Errorf("len = %d, want 0", len(got))
+		}
+	})
+}

--- a/api/v1/seaweed_types.go
+++ b/api/v1/seaweed_types.go
@@ -193,6 +193,12 @@ type SeaweedSpec struct {
 	// Base annotations of Pods, components may add or override selectors upon this respectively
 	Annotations map[string]string `json:"annotations,omitempty"`
 
+	// Base labels of Pods, components may add or override labels upon this respectively.
+	// Note that user-supplied keys cannot replace the operator-managed selector labels
+	// (app.kubernetes.io/name, /instance, /component, /managed-by) — those are required
+	// for the StatefulSet/Deployment selector and will be preserved.
+	Labels map[string]string `json:"labels,omitempty"`
+
 	// Base tolerations of Pods, components may add more tolerations upon this respectively
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 
@@ -620,6 +626,12 @@ type ComponentSpec struct {
 
 	// Annotations of the component. Merged into the cluster-level annotations if non-empty
 	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// Labels of the component. Merged into the cluster-level labels and onto the pod
+	// template labels. Operator-managed selector labels (app.kubernetes.io/name,
+	// /instance, /component, /managed-by) cannot be overridden and will always win,
+	// so the StatefulSet/Deployment selector keeps matching its pods.
+	Labels map[string]string `json:"labels,omitempty"`
 
 	// Tolerations of the component. Override the cluster-level tolerations if non-empty
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -344,6 +344,13 @@ func (in *ComponentSpec) DeepCopyInto(out *ComponentSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Tolerations != nil {
 		in, out := &in.Tolerations, &out.Tolerations
 		*out = make([]corev1.Toleration, len(*in))
@@ -951,6 +958,13 @@ func (in *SeaweedSpec) DeepCopyInto(out *SeaweedSpec) {
 	}
 	if in.Annotations != nil {
 		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val

--- a/config/crd/bases/seaweed.seaweedfs.com_seaweeds.yaml
+++ b/config/crd/bases/seaweed.seaweedfs.com_seaweeds.yaml
@@ -598,6 +598,10 @@ spec:
                           type: object
                         type: array
                     type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
                   limits:
                     additionalProperties:
                       anyOf:
@@ -2456,6 +2460,10 @@ spec:
                           type: object
                         type: array
                     type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
                   limits:
                     additionalProperties:
                       anyOf:
@@ -3449,6 +3457,10 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
+              labels:
+                additionalProperties:
+                  type: string
+                type: object
               master:
                 properties:
                   affinity:
@@ -4021,6 +4033,10 @@ spec:
                               type: string
                           type: object
                         type: array
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
                     type: object
                   limits:
                     additionalProperties:
@@ -5460,6 +5476,10 @@ spec:
                           type: object
                         type: array
                     type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
                   limits:
                     additionalProperties:
                       anyOf:
@@ -6879,6 +6899,10 @@ spec:
                               type: string
                           type: object
                         type: array
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
                     type: object
                   limits:
                     additionalProperties:
@@ -8357,6 +8381,10 @@ spec:
                           type: object
                         type: array
                     type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
                   limits:
                     additionalProperties:
                       anyOf:
@@ -9757,6 +9785,10 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       type: array
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
                     limits:
                       additionalProperties:
                         anyOf:
@@ -11150,6 +11182,10 @@ spec:
                   jobType:
                     default: all
                     type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
                   limits:
                     additionalProperties:
                       anyOf:

--- a/deploy/helm/templates/crd-seaweed.yaml
+++ b/deploy/helm/templates/crd-seaweed.yaml
@@ -872,6 +872,10 @@ spec:
                             type: object
                           type: array
                       type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
                     limits:
                       additionalProperties:
                         anyOf:
@@ -2730,6 +2734,10 @@ spec:
                             type: object
                           type: array
                       type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
                     limits:
                       additionalProperties:
                         anyOf:
@@ -3723,6 +3731,10 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
+                labels:
+                  additionalProperties:
+                    type: string
+                  type: object
                 master:
                   properties:
                     affinity:
@@ -4295,6 +4307,10 @@ spec:
                                 type: string
                             type: object
                           type: array
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
                       type: object
                     limits:
                       additionalProperties:
@@ -5734,6 +5750,10 @@ spec:
                             type: object
                           type: array
                       type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
                     limits:
                       additionalProperties:
                         anyOf:
@@ -7153,6 +7173,10 @@ spec:
                                 type: string
                             type: object
                           type: array
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
                       type: object
                     limits:
                       additionalProperties:
@@ -8631,6 +8655,10 @@ spec:
                             type: object
                           type: array
                       type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
                     limits:
                       additionalProperties:
                         anyOf:
@@ -10031,6 +10059,10 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         type: array
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
                       limits:
                         additionalProperties:
                           anyOf:
@@ -11424,6 +11456,10 @@ spec:
                     jobType:
                       default: all
                       type: string
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
                     limits:
                       additionalProperties:
                         anyOf:

--- a/internal/controller/controller_admin_statefulset.go
+++ b/internal/controller/controller_admin_statefulset.go
@@ -118,6 +118,7 @@ func adminRoutePath(extraArgs []string, route string) string {
 
 func (r *SeaweedReconciler) createAdminStatefulSet(m *seaweedv1.Seaweed) *appsv1.StatefulSet {
 	labels := labelsForAdmin(m.Name)
+	podLabels := mergePodLabels(labels, m.BaseAdminSpec().Labels())
 	annotations := m.BaseAdminSpec().Annotations()
 	ports := []corev1.ContainerPort{
 		{
@@ -236,7 +237,7 @@ func (r *SeaweedReconciler) createAdminStatefulSet(m *seaweedv1.Seaweed) *appsv1
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      labels,
+					Labels:      podLabels,
 					Annotations: annotations,
 				},
 				Spec: adminPodSpec,

--- a/internal/controller/controller_filer_statefulset.go
+++ b/internal/controller/controller_filer_statefulset.go
@@ -46,6 +46,7 @@ func buildFilerStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string {
 
 func (r *SeaweedReconciler) createFilerStatefulSet(m *seaweedv1.Seaweed) *appsv1.StatefulSet {
 	labels := labelsForFiler(m.Name)
+	podLabels := mergePodLabels(labels, m.BaseFilerSpec().Labels())
 	annotations := m.Spec.Filer.Annotations
 	ports := []corev1.ContainerPort{
 		{
@@ -235,7 +236,7 @@ func (r *SeaweedReconciler) createFilerStatefulSet(m *seaweedv1.Seaweed) *appsv1
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      labels,
+					Labels:      podLabels,
 					Annotations: annotations,
 				},
 				Spec: filerPodSpec,

--- a/internal/controller/controller_master_statefulset.go
+++ b/internal/controller/controller_master_statefulset.go
@@ -53,6 +53,7 @@ func buildMasterStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string 
 
 func (r *SeaweedReconciler) createMasterStatefulSet(m *seaweedv1.Seaweed) *appsv1.StatefulSet {
 	labels := labelsForMaster(m.Name)
+	podLabels := mergePodLabels(labels, m.BaseMasterSpec().Labels())
 	annotations := m.Spec.Master.Annotations
 	ports := []corev1.ContainerPort{
 		{
@@ -165,7 +166,7 @@ func (r *SeaweedReconciler) createMasterStatefulSet(m *seaweedv1.Seaweed) *appsv
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      labels,
+					Labels:      podLabels,
 					Annotations: annotations,
 				},
 				Spec: masterPodSpec,

--- a/internal/controller/controller_s3.go
+++ b/internal/controller/controller_s3.go
@@ -226,6 +226,7 @@ func (r *SeaweedReconciler) ensureS3Deployment(ctx context.Context, m *seaweedv1
 
 func (r *SeaweedReconciler) buildS3Deployment(m *seaweedv1.Seaweed) *appsv1.Deployment {
 	labels := labelsForS3(m.Name)
+	podLabels := mergePodLabels(labels, m.BaseS3Spec().Labels())
 	replicas := m.Spec.S3.Replicas
 
 	podSpec := m.BaseS3Spec().BuildPodSpec()
@@ -301,7 +302,7 @@ func (r *SeaweedReconciler) buildS3Deployment(m *seaweedv1.Seaweed) *appsv1.Depl
 			Selector: &metav1.LabelSelector{MatchLabels: labels},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      labels,
+					Labels:      podLabels,
 					Annotations: m.Spec.S3.Annotations,
 				},
 				Spec: podSpec,

--- a/internal/controller/controller_sftp.go
+++ b/internal/controller/controller_sftp.go
@@ -213,6 +213,7 @@ func (r *SeaweedReconciler) ensureSFTPDeployment(ctx context.Context, m *seaweed
 
 func (r *SeaweedReconciler) buildSFTPDeployment(m *seaweedv1.Seaweed) *appsv1.Deployment {
 	labels := labelsForSFTP(m.Name)
+	podLabels := mergePodLabels(labels, m.BaseSFTPSpec().Labels())
 	replicas := m.Spec.SFTP.Replicas
 
 	podSpec := m.BaseSFTPSpec().BuildPodSpec()
@@ -311,7 +312,7 @@ func (r *SeaweedReconciler) buildSFTPDeployment(m *seaweedv1.Seaweed) *appsv1.De
 			Selector: &metav1.LabelSelector{MatchLabels: labels},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      labels,
+					Labels:      podLabels,
 					Annotations: m.Spec.SFTP.Annotations,
 				},
 				Spec: podSpec,

--- a/internal/controller/controller_volume_statefulset.go
+++ b/internal/controller/controller_volume_statefulset.go
@@ -126,6 +126,7 @@ func buildVolumeServerStartupScript(m *seaweedv1.Seaweed, dirs []string, extraAr
 
 func (r *SeaweedReconciler) createVolumeServerStatefulSet(m *seaweedv1.Seaweed) *appsv1.StatefulSet {
 	labels := labelsForVolumeServer(m.Name)
+	podLabels := mergePodLabels(labels, m.BaseVolumeSpec().Labels())
 	annotations := m.Spec.Volume.Annotations
 	ports := []corev1.ContainerPort{
 		{
@@ -268,7 +269,7 @@ func (r *SeaweedReconciler) createVolumeServerStatefulSet(m *seaweedv1.Seaweed) 
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      labels,
+					Labels:      podLabels,
 					Annotations: annotations,
 				},
 				Spec: volumePodSpec,
@@ -281,6 +282,7 @@ func (r *SeaweedReconciler) createVolumeServerStatefulSet(m *seaweedv1.Seaweed) 
 
 func (r *SeaweedReconciler) createVolumeServerTopologyStatefulSet(m *seaweedv1.Seaweed, topologyName string, topologySpec *seaweedv1.VolumeTopologySpec) *appsv1.StatefulSet {
 	labels := labelsForVolumeServerTopology(m.Name, topologyName)
+	podLabels := mergePodLabels(labels, mergeAnnotations(m.Spec.Labels, topologySpec.Labels))
 	annotations := mergeAnnotations(m.Spec.Annotations, topologySpec.Annotations)
 	ports := []corev1.ContainerPort{
 		{
@@ -426,7 +428,7 @@ func (r *SeaweedReconciler) createVolumeServerTopologyStatefulSet(m *seaweedv1.S
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      labels,
+					Labels:      podLabels,
 					Annotations: annotations,
 				},
 				Spec: volumePodSpec,

--- a/internal/controller/controller_volume_statefulset.go
+++ b/internal/controller/controller_volume_statefulset.go
@@ -282,7 +282,10 @@ func (r *SeaweedReconciler) createVolumeServerStatefulSet(m *seaweedv1.Seaweed) 
 
 func (r *SeaweedReconciler) createVolumeServerTopologyStatefulSet(m *seaweedv1.Seaweed, topologyName string, topologySpec *seaweedv1.VolumeTopologySpec) *appsv1.StatefulSet {
 	labels := labelsForVolumeServerTopology(m.Name, topologyName)
-	podLabels := mergePodLabels(labels, mergeAnnotations(m.Spec.Labels, topologySpec.Labels))
+	// 3-tier inheritance for topology pods: cluster + volume + topology, with
+	// the topology winning on collisions. BaseVolumeSpec().Labels() already
+	// returns cluster+volume merged.
+	podLabels := mergePodLabels(labels, mergeLabels(m.BaseVolumeSpec().Labels(), topologySpec.Labels))
 	annotations := mergeAnnotations(m.Spec.Annotations, topologySpec.Annotations)
 	ports := []corev1.ContainerPort{
 		{

--- a/internal/controller/controller_worker_deployment.go
+++ b/internal/controller/controller_worker_deployment.go
@@ -49,6 +49,7 @@ func buildWorkerStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string 
 
 func (r *SeaweedReconciler) createWorkerDeployment(m *seaweedv1.Seaweed) *appsv1.Deployment {
 	labels := labelsForWorker(m.Name)
+	podLabels := mergePodLabels(labels, m.BaseWorkerSpec().Labels())
 	annotations := m.BaseWorkerSpec().Annotations()
 	var ports []corev1.ContainerPort
 	if m.Spec.Worker.MetricsPort != nil {
@@ -169,7 +170,7 @@ func (r *SeaweedReconciler) createWorkerDeployment(m *seaweedv1.Seaweed) *appsv1
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      labels,
+					Labels:      podLabels,
 					Annotations: annotations,
 				},
 				Spec: workerPodSpec,

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -82,6 +82,23 @@ func copyAnnotations(src map[string]string) map[string]string {
 	return dst
 }
 
+// mergePodLabels returns the pod template label set: user-supplied labels first,
+// then operator-managed selector labels layered on top so the StatefulSet/Deployment
+// selector keeps matching its pods even when the user supplies a colliding key.
+func mergePodLabels(selectorLabels, userLabels map[string]string) map[string]string {
+	if len(userLabels) == 0 {
+		return selectorLabels
+	}
+	merged := map[string]string{}
+	for k, v := range userLabels {
+		merged[k] = v
+	}
+	for k, v := range selectorLabels {
+		merged[k] = v
+	}
+	return merged
+}
+
 // mergeAnnotations merges cluster-level annotations with component-level annotations
 // Component-level annotations take precedence over cluster-level ones
 func mergeAnnotations(clusterAnnotations, componentAnnotations map[string]string) map[string]string {

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -99,6 +99,25 @@ func mergePodLabels(selectorLabels, userLabels map[string]string) map[string]str
 	return merged
 }
 
+// mergeLabels merges two label sets. The second argument takes precedence
+// over the first on key collisions — used to layer component- or
+// topology-level labels on top of cluster/volume-level defaults.
+func mergeLabels(base, override map[string]string) map[string]string {
+	if base == nil && override == nil {
+		return nil
+	}
+
+	merged := map[string]string{}
+	for k, v := range base {
+		merged[k] = v
+	}
+	for k, v := range override {
+		merged[k] = v
+	}
+
+	return merged
+}
+
 // mergeAnnotations merges cluster-level annotations with component-level annotations
 // Component-level annotations take precedence over cluster-level ones
 func mergeAnnotations(clusterAnnotations, componentAnnotations map[string]string) map[string]string {

--- a/internal/controller/helper_test.go
+++ b/internal/controller/helper_test.go
@@ -89,3 +89,57 @@ func TestGetFilerAddress(t *testing.T) {
 		t.Fatalf("getFilerAddress = %q, want %q", got, want)
 	}
 }
+
+// TestMergePodLabels pins the contract for issue #243: user-supplied labels
+// are added to the pod template, but operator-managed selector labels always
+// win on key collisions so the StatefulSet/Deployment selector keeps matching.
+func TestMergePodLabels(t *testing.T) {
+	selector := map[string]string{
+		"app.kubernetes.io/name":       "seaweedfs",
+		"app.kubernetes.io/instance":   "seaweed",
+		"app.kubernetes.io/component":  "filer",
+		"app.kubernetes.io/managed-by": "seaweedfs-operator",
+	}
+
+	t.Run("nil user labels returns the selector unchanged", func(t *testing.T) {
+		got := mergePodLabels(selector, nil)
+		if len(got) != len(selector) {
+			t.Fatalf("len = %d, want %d", len(got), len(selector))
+		}
+		for k, v := range selector {
+			if got[k] != v {
+				t.Errorf("got[%q] = %q, want %q", k, got[k], v)
+			}
+		}
+	})
+
+	t.Run("user labels are added alongside selector labels", func(t *testing.T) {
+		user := map[string]string{"backup": "true", "team": "storage"}
+		got := mergePodLabels(selector, user)
+		for k, v := range selector {
+			if got[k] != v {
+				t.Errorf("selector label %q lost: got %q, want %q", k, got[k], v)
+			}
+		}
+		for k, v := range user {
+			if got[k] != v {
+				t.Errorf("user label %q missing: got %q, want %q", k, got[k], v)
+			}
+		}
+	})
+
+	t.Run("user cannot override operator selector keys", func(t *testing.T) {
+		user := map[string]string{
+			"app.kubernetes.io/component": "hijacked",
+			"backup":                      "true",
+		}
+		got := mergePodLabels(selector, user)
+		if got["app.kubernetes.io/component"] != "filer" {
+			t.Errorf("operator component label was overridden: got %q, want %q",
+				got["app.kubernetes.io/component"], "filer")
+		}
+		if got["backup"] != "true" {
+			t.Errorf("user label backup missing: got %q", got["backup"])
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Adds `labels` to `SeaweedSpec` (cluster-wide) and `ComponentSpec` (per master/filer/volume/admin/worker/s3/sftp, plus volume topologies), mirroring the existing `annotations` shape.
- Operator-managed selector labels (`app.kubernetes.io/{name,instance,component,managed-by}`) always win on key collisions, so the StatefulSet/Deployment selector keeps matching its pods even when users supply a colliding key.
- New `mergePodLabels` helper wired into every workload builder.

Closes #243.

### User-facing
```yaml
spec:
  labels:               # optional, cluster-wide
    team: storage
  filer:
    labels:             # merged on top of cluster-wide
      backup: "true"
```
Custom labels survive reconciliation; previously `kubectl patch` was reverted within ~30s.

## Test plan
- [x] `go test ./api/... ./internal/controller/...` passes
- [x] New `TestMergePodLabels` pins the selector-wins contract (3 subtests: no user labels, additive, collision)
- [x] New `TestComponentAccessorLabels` pins cluster+component merge precedence
- [x] `make generate manifests helm-crd-copy` regenerated CRD + helm template
- [ ] Manual: deploy a Seaweed CR with `spec.filer.labels: {backup: "true"}`, confirm pods carry the label and a `kubectl patch sts` no longer round-trips
- [ ] (Optional follow-up) envtest using `mustEnvtest` that calls `createFilerStatefulSet` and asserts the merged pod template labels end-to-end