### PR TITLE
fix(iam): sign admin Bearer tokens so IAM CRDs work on operator-managed clusters

### DIFF
--- a/internal/controller/iam_admin.go
+++ b/internal/controller/iam_admin.go
@@ -69,8 +69,10 @@ type IAMAdmin interface {
 }
 
 // IAMAdminFactory creates an IAMAdmin for the IAM service on a target filer.
+// adminSigningKey is jwt.filer_signing.key from the cluster's security.toml
+// (nil/empty when the cluster does not require admin Bearer auth).
 // Replaceable in tests.
-type IAMAdminFactory func(filer string, log logr.Logger) (IAMAdmin, error)
+type IAMAdminFactory func(filer string, adminSigningKey []byte, log logr.Logger) (IAMAdmin, error)
 
 // Sentinel errors returned by IAMAdmin implementations.
 var (
@@ -91,8 +93,11 @@ type swadminIAMAdmin struct {
 }
 
 // NewSwadminIAMAdmin returns an IAMAdmin that talks to the filer IAM gRPC API.
-func NewSwadminIAMAdmin(filer string, log logr.Logger) (IAMAdmin, error) {
-	return &swadminIAMAdmin{c: swadmin.NewIAMClient(filer), log: log}, nil
+// adminSigningKey is forwarded to the underlying IAMClient so it can sign
+// admin Bearer tokens; pass nil/empty when the cluster's security.toml does
+// not configure jwt.filer_signing.key.
+func NewSwadminIAMAdmin(filer string, adminSigningKey []byte, log logr.Logger) (IAMAdmin, error) {
+	return &swadminIAMAdmin{c: swadmin.NewIAMClient(filer, adminSigningKey), log: log}, nil
 }
 
 func (a *swadminIAMAdmin) GetUser(ctx context.Context, name string) (*swadmin.IAMUser, error) {

--- a/internal/controller/iam_controller_common.go
+++ b/internal/controller/iam_controller_common.go
@@ -18,10 +18,13 @@ package controller
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"sync"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,31 +56,53 @@ type iamAdminProvider struct {
 	mu    sync.Mutex
 }
 
-func (p *iamAdminProvider) getIAMAdmin(filer string, log logr.Logger) (IAMAdmin, error) {
+func (p *iamAdminProvider) getIAMAdmin(filer string, adminSigningKey []byte, log logr.Logger) (IAMAdmin, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.cache == nil {
 		p.cache = make(map[string]IAMAdmin)
 	}
-	if a, ok := p.cache[filer]; ok {
+	// Cache key folds in a hash of the signing key so that key rotation (a
+	// user editing the security.toml ConfigMap) invalidates the cached
+	// client instead of leaving a stale Bearer issuer behind.
+	cacheKey := filer + "\x00" + signingKeyFingerprint(adminSigningKey)
+	if a, ok := p.cache[cacheKey]; ok {
 		return a, nil
 	}
 	if p.AdminFactory == nil {
 		return nil, fmt.Errorf("iam admin factory is not configured")
 	}
-	a, err := p.AdminFactory(filer, log)
+	a, err := p.AdminFactory(filer, adminSigningKey, log)
 	if err != nil {
 		return nil, err
 	}
-	p.cache[filer] = a
+	p.cache[cacheKey] = a
 	return a, nil
 }
 
+func signingKeyFingerprint(key []byte) string {
+	if len(key) == 0 {
+		return ""
+	}
+	sum := sha256.Sum256(key)
+	return hex.EncodeToString(sum[:8])
+}
+
 // resolveSeaweedFiler looks up the Seaweed CR named by ref and returns its
-// filer address. found is false (with a nil error) when the Seaweed CR does
-// not exist, so callers can surface a transient "cluster not found" condition
-// and requeue rather than treating it as a hard error.
-func resolveSeaweedFiler(ctx context.Context, c client.Client, ref seaweedv1.SeaweedReference, ownNamespace string) (filer string, found bool, err error) {
+// filer address along with the admin signing key the operator rendered into
+// the cluster's security.toml ConfigMap (issue #257: the filer's IAM gRPC
+// service rejects unauthenticated calls when jwt.filer_signing.key is set, so
+// the operator must sign its own Bearer tokens with the same key). found is
+// false (with a nil error) when the Seaweed CR does not exist, so callers can
+// surface a transient "cluster not found" condition and requeue rather than
+// treating it as a hard error.
+//
+// adminSigningKey is nil when the security ConfigMap has not been reconciled
+// yet, when its data is missing/malformed, or when the cluster was not
+// provisioned by this operator (no ConfigMap to read). In those cases the IAM
+// client falls back to unauthenticated calls, matching the cluster's likely
+// configuration.
+func resolveSeaweedFiler(ctx context.Context, c client.Client, ref seaweedv1.SeaweedReference, ownNamespace string) (filer string, adminSigningKey []byte, found bool, err error) {
 	ns := ref.Namespace
 	if ns == "" {
 		ns = ownNamespace
@@ -85,11 +110,39 @@ func resolveSeaweedFiler(ctx context.Context, c client.Client, ref seaweedv1.Sea
 	var sw seaweedv1.Seaweed
 	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: ref.Name}, &sw); err != nil {
 		if apierrors.IsNotFound(err) {
-			return "", false, nil
+			return "", nil, false, nil
 		}
-		return "", false, err
+		return "", nil, false, err
 	}
-	return getFilerAddress(&sw), true, nil
+	key, err := loadFilerAdminSigningKey(ctx, c, &sw)
+	if err != nil {
+		return "", nil, false, err
+	}
+	return getFilerAddress(&sw), key, true, nil
+}
+
+// loadFilerAdminSigningKey reads jwt.filer_signing.key from the
+// seaweedfs-security-config ConfigMap the operator renders for sw. Returns
+// nil with no error when the ConfigMap does not exist or its security.toml
+// has no key (the cluster will be running unauthenticated in that case).
+// A non-NotFound API error is propagated so the reconciler can requeue.
+func loadFilerAdminSigningKey(ctx context.Context, c client.Client, sw *seaweedv1.Seaweed) ([]byte, error) {
+	if !securityConfigNeeded(sw) {
+		return nil, nil
+	}
+	var cm corev1.ConfigMap
+	err := c.Get(ctx, types.NamespacedName{Namespace: sw.Namespace, Name: SecurityConfigMapName(sw)}, &cm)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	raw := extractTOMLKey(cm.Data["security.toml"], "jwt.filer_signing", "key")
+	if raw == "" {
+		return nil, nil
+	}
+	return []byte(raw), nil
 }
 
 // setIAMCondition upserts a condition on an IAM CR's condition list, stamping

--- a/internal/controller/iam_controller_test.go
+++ b/internal/controller/iam_controller_test.go
@@ -92,7 +92,7 @@ func reconcileOnce(t *testing.T, r reconcile.Reconciler, key types.NamespacedNam
 }
 
 func fakeIAMFactory(fa IAMAdmin) IAMAdminFactory {
-	return func(_ string, _ logr.Logger) (IAMAdmin, error) { return fa, nil }
+	return func(_ string, _ []byte, _ logr.Logger) (IAMAdmin, error) { return fa, nil }
 }
 
 // --- S3Identity ---
@@ -600,3 +600,63 @@ var (
 	_ reconcile.Reconciler = (*S3PolicyReconciler)(nil)
 	_ reconcile.Reconciler = (*S3PolicyBindingReconciler)(nil)
 )
+
+// TestResolveSeaweedFiler_LoadsAdminSigningKey pins the issue #257 fix:
+// resolveSeaweedFiler must surface jwt.filer_signing.key from the rendered
+// security ConfigMap so the IAM client can mint admin Bearer tokens. A
+// missing ConfigMap (cluster mid-reconcile, or an externally managed cluster)
+// degrades to an empty key — matching the filer's unauthenticated branch.
+func TestResolveSeaweedFiler_LoadsAdminSigningKey(t *testing.T) {
+	scheme := iamTestScheme(t)
+	sw := newTestSeaweedWithFiler()
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      SecurityConfigMapName(sw),
+			Namespace: sw.Namespace,
+		},
+		Data: map[string]string{
+			"security.toml": "[jwt.filer_signing]\nkey = \"abc123==\"\n",
+		},
+	}
+	cli := iamTestClient(t, scheme, sw, cm)
+
+	filer, key, found, err := resolveSeaweedFiler(context.Background(), cli, iamSeaweedRef(), "media")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if !found {
+		t.Fatal("expected cluster to be found")
+	}
+	if filer == "" {
+		t.Fatal("expected non-empty filer address")
+	}
+	if string(key) != "abc123==" {
+		t.Fatalf("admin signing key = %q, want %q", string(key), "abc123==")
+	}
+}
+
+func TestResolveSeaweedFiler_MissingConfigMapReturnsEmptyKey(t *testing.T) {
+	scheme := iamTestScheme(t)
+	sw := newTestSeaweedWithFiler()
+	cli := iamTestClient(t, scheme, sw)
+
+	_, key, found, err := resolveSeaweedFiler(context.Background(), cli, iamSeaweedRef(), "media")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if !found {
+		t.Fatal("expected cluster to be found")
+	}
+	if len(key) != 0 {
+		t.Fatalf("expected empty key when ConfigMap missing, got %q", string(key))
+	}
+}
+
+// newTestSeaweedWithFiler returns the standard test Seaweed CR with a Filer
+// spec so securityConfigNeeded returns true and the operator would render a
+// security.toml ConfigMap with jwt.filer_signing.key.
+func newTestSeaweedWithFiler() *seaweedv1.Seaweed {
+	sw := newTestSeaweed()
+	sw.Spec.Filer = &seaweedv1.FilerSpec{Replicas: 1}
+	return sw
+}

--- a/internal/controller/s3credentials_controller.go
+++ b/internal/controller/s3credentials_controller.go
@@ -77,7 +77,7 @@ func (r *S3CredentialsReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		secretName = cred.Name
 	}
 
-	filer, found, err := resolveSeaweedFiler(ctx, r.Client, cred.Spec.SeaweedRef, cred.Namespace)
+	filer, adminKey, found, err := resolveSeaweedFiler(ctx, r.Client, cred.Spec.SeaweedRef, cred.Namespace)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -86,7 +86,7 @@ func (r *S3CredentialsReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 	setIAMCondition(&cred.Status.Conditions, cred.Generation, seaweedv1.S3ConditionClusterReachable, metav1.ConditionTrue, "Reachable", "")
 
-	admin, err := r.getIAMAdmin(filer, log)
+	admin, err := r.getIAMAdmin(filer, adminKey, log)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/s3identity_controller.go
+++ b/internal/controller/s3identity_controller.go
@@ -69,7 +69,7 @@ func (r *S3IdentityReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				identity.Status.IdentityName, name))
 	}
 
-	filer, found, err := resolveSeaweedFiler(ctx, r.Client, identity.Spec.SeaweedRef, identity.Namespace)
+	filer, adminKey, found, err := resolveSeaweedFiler(ctx, r.Client, identity.Spec.SeaweedRef, identity.Namespace)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -78,7 +78,7 @@ func (r *S3IdentityReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 	setIAMCondition(&identity.Status.Conditions, identity.Generation, seaweedv1.S3ConditionClusterReachable, metav1.ConditionTrue, "Reachable", "")
 
-	admin, err := r.getIAMAdmin(filer, log)
+	admin, err := r.getIAMAdmin(filer, adminKey, log)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/s3policy_controller.go
+++ b/internal/controller/s3policy_controller.go
@@ -67,7 +67,7 @@ func (r *S3PolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				policy.Status.PolicyName, name))
 	}
 
-	filer, found, err := resolveSeaweedFiler(ctx, r.Client, policy.Spec.SeaweedRef, policy.Namespace)
+	filer, adminKey, found, err := resolveSeaweedFiler(ctx, r.Client, policy.Spec.SeaweedRef, policy.Namespace)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -76,7 +76,7 @@ func (r *S3PolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 	setIAMCondition(&policy.Status.Conditions, policy.Generation, seaweedv1.S3ConditionClusterReachable, metav1.ConditionTrue, "Reachable", "")
 
-	admin, err := r.getIAMAdmin(filer, log)
+	admin, err := r.getIAMAdmin(filer, adminKey, log)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/s3policybinding_controller.go
+++ b/internal/controller/s3policybinding_controller.go
@@ -60,7 +60,7 @@ func (r *S3PolicyBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	policyName := binding.Spec.PolicyRef.Name
 
-	filer, found, err := resolveSeaweedFiler(ctx, r.Client, binding.Spec.SeaweedRef, binding.Namespace)
+	filer, adminKey, found, err := resolveSeaweedFiler(ctx, r.Client, binding.Spec.SeaweedRef, binding.Namespace)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -69,7 +69,7 @@ func (r *S3PolicyBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 	setIAMCondition(&binding.Status.Conditions, binding.Generation, seaweedv1.S3ConditionClusterReachable, metav1.ConditionTrue, "Reachable", "")
 
-	admin, err := r.getIAMAdmin(filer, log)
+	admin, err := r.getIAMAdmin(filer, adminKey, log)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/swadmin/iam_client.go
+++ b/internal/controller/swadmin/iam_client.go
@@ -9,8 +9,10 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/iam"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/iam_pb"
+	"github.com/seaweedfs/seaweedfs/weed/security"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 )
 
 // iamRequestTimeout caps every IAM gRPC call so a reconcile can't hang on an
@@ -57,34 +59,62 @@ var iamUserLocks = &keyedMutex{}
 // file-based policy I/O and stderr-only secret printing) so the operator can
 // run with a read-only root filesystem and capture every result.
 //
-// Like the bucket admin's master connection, this dials without TLS and
-// without a JWT admin token. Clusters that set jwt.filer_signing.key in
-// security.toml reject unauthenticated IAM calls; supporting those is a
-// follow-up (the operator would need the signing key mounted).
+// Like the bucket admin's master connection, this dials without TLS. When
+// adminSigningKey is non-empty (the operator reads it from the rendered
+// security.toml ConfigMap) every RPC is stamped with a freshly minted admin
+// Bearer token in the "authorization" metadata — matching the upstream
+// `weed shell` IAM client. When the key is empty the calls are
+// unauthenticated, which the filer accepts when jwt.filer_signing.key is not
+// set in its security.toml.
 type IAMClient struct {
 	filerGrpcAddress string
 	dialOption       grpc.DialOption
+	adminSigningKey  security.SigningKey
 }
 
 // NewIAMClient builds an IAMClient for the given filer. filer is the filer's
 // HTTP host:port (as returned by getFilerAddress); seaweedfs derives the gRPC
-// port from it internally.
-func NewIAMClient(filer string) *IAMClient {
+// port from it internally. adminSigningKey is the jwt.filer_signing.key from
+// the cluster's security.toml; pass nil/empty when the cluster does not
+// require admin Bearer auth.
+func NewIAMClient(filer string, adminSigningKey []byte) *IAMClient {
 	return &IAMClient{
 		filerGrpcAddress: pb.ServerAddress(filer).ToGrpcAddress(),
 		dialOption:       grpc.WithTransportCredentials(insecure.NewCredentials()),
+		adminSigningKey:  security.SigningKey(adminSigningKey),
 	}
 }
 
 // withClient opens a short-lived connection to the filer IAM service, applies
-// the request timeout, and invokes fn. Errors are returned verbatim so
-// callers can classify gRPC status codes.
+// the request timeout, attaches an admin Bearer token when one is configured,
+// and invokes fn. Errors are returned verbatim so callers can classify gRPC
+// status codes.
 func (c *IAMClient) withClient(ctx context.Context, fn func(ctx context.Context, client iam_pb.SeaweedIdentityAccessManagementClient) error) error {
 	return pb.WithGrpcClient(false, 0, func(conn *grpc.ClientConn) error {
-		callCtx, cancel := context.WithTimeout(ctx, iamRequestTimeout)
+		callCtx, cancel := context.WithTimeout(c.authContext(ctx), iamRequestTimeout)
 		defer cancel()
 		return fn(callCtx, iam_pb.NewSeaweedIdentityAccessManagementClient(conn))
 	}, c.filerGrpcAddress, false, c.dialOption)
+}
+
+// authContext returns ctx with an admin Bearer token appended to the outgoing
+// metadata when adminSigningKey is configured; otherwise ctx is returned
+// unchanged. The token is minted per call (claims carry no per-request data
+// but jwt/v5 stamps a fresh iat/exp) — cheap enough at IAM-CR-reconcile rate.
+// Mirrors weed/shell/command_s3_iam_client.go:iamAdminAuthContext.
+func (c *IAMClient) authContext(ctx context.Context) context.Context {
+	if len(c.adminSigningKey) == 0 {
+		return ctx
+	}
+	// expiresAfterSec=0 → no exp claim. The filer's checkAdminAuth only
+	// validates the signature + RegisteredClaims; not pinning an expiry here
+	// keeps the operator's IAM reconciles working without a clock-skew
+	// allowance against the filer pod.
+	token := security.GenJwtForFilerAdmin(c.adminSigningKey, 0)
+	if token == "" {
+		return ctx
+	}
+	return metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+string(token))
 }
 
 // lockUser serializes read-modify-write updates to a single identity on this

--- a/internal/controller/swadmin/iam_client_test.go
+++ b/internal/controller/swadmin/iam_client_test.go
@@ -140,4 +140,3 @@ func (s *authRecordingIAM) GetUser(ctx context.Context, req *iam_pb.GetUserReque
 	}
 	return &iam_pb.GetUserResponse{Identity: &iam_pb.Identity{Name: req.Username}}, nil
 }
-

--- a/internal/controller/swadmin/iam_client_test.go
+++ b/internal/controller/swadmin/iam_client_test.go
@@ -1,0 +1,143 @@
+package swadmin
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/iam_pb"
+	"github.com/seaweedfs/seaweedfs/weed/security"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// TestIAMClient_AuthContext_AppendsBearerWhenKeySet guards against regressing
+// https://github.com/seaweedfs/seaweedfs-operator/issues/257: the operator
+// always renders jwt.filer_signing.key into security.toml when spec.Filer is
+// defined, so the filer's IAM gRPC service requires an admin Bearer token on
+// every call; before this fix the IAMClient sent none and every IAM CR
+// failed with "Unauthenticated desc = missing authorization metadata".
+func TestIAMClient_AuthContext_AppendsBearerWhenKeySet(t *testing.T) {
+	key := []byte("test-jwt-signing-key")
+	c := NewIAMClient("seaweed-filer.invalid:8888", key)
+
+	ctx := c.authContext(context.Background())
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		t.Fatal("expected outgoing metadata")
+	}
+	authHeaders := md.Get("authorization")
+	if len(authHeaders) != 1 {
+		t.Fatalf("expected exactly one authorization header, got %v", authHeaders)
+	}
+	if !strings.HasPrefix(authHeaders[0], "Bearer ") {
+		t.Fatalf("expected Bearer scheme, got %q", authHeaders[0])
+	}
+	token := strings.TrimPrefix(authHeaders[0], "Bearer ")
+	if token == "" {
+		t.Fatal("Bearer token is empty")
+	}
+	// Confirm the token round-trips against the same checkAdminAuth path the
+	// upstream filer uses (security.DecodeJwt with SeaweedFilerAdminClaims).
+	parsed, err := security.DecodeJwt(security.SigningKey(key), security.EncodedJwt(token), &security.SeaweedFilerAdminClaims{})
+	if err != nil {
+		t.Fatalf("DecodeJwt returned error: %v", err)
+	}
+	if parsed == nil || !parsed.Valid {
+		t.Fatal("parsed token is not valid")
+	}
+}
+
+// TestIAMClient_AuthContext_NoMetadataWhenKeyEmpty pins the unauthenticated
+// path so clusters whose security.toml has no jwt.filer_signing.key keep
+// working — matching the filer's checkAdminAuth no-op branch.
+func TestIAMClient_AuthContext_NoMetadataWhenKeyEmpty(t *testing.T) {
+	c := NewIAMClient("seaweed-filer.invalid:8888", nil)
+	ctx := c.authContext(context.Background())
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if ok && len(md.Get("authorization")) > 0 {
+		t.Fatalf("expected no authorization metadata, got %v", md.Get("authorization"))
+	}
+}
+
+// TestIAMClient_GetUser_SendsBearer end-to-end-confirms the Bearer header
+// reaches the filer's IAM gRPC server by spinning up an in-process gRPC
+// server that asserts the incoming metadata. This is the regression test the
+// previous fake-IAMAdmin tests could never catch: it exercises the actual
+// withClient → pb.WithGrpcClient → unary call path.
+func TestIAMClient_GetUser_SendsBearer(t *testing.T) {
+	key := []byte("test-jwt-signing-key")
+
+	srv := grpc.NewServer()
+	t.Cleanup(srv.Stop)
+	rec := &authRecordingIAM{adminSigningKey: security.SigningKey(key)}
+	iam_pb.RegisterSeaweedIdentityAccessManagementServer(srv, rec)
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() { _ = srv.Serve(lis) }()
+
+	// pb.ServerAddress treats host:HTTPPort and derives grpc as HTTPPort+10000.
+	// The in-process server listens on whatever ephemeral port net.Listen
+	// picked; subtract 10000 so IAMClient ends up dialing back to it.
+	grpcPort := lis.Addr().(*net.TCPAddr).Port
+	if grpcPort < 10001 {
+		t.Skipf("ephemeral gRPC port %d too low to map to a valid HTTP port", grpcPort)
+	}
+	httpPort := grpcPort - 10000
+	c := NewIAMClient(net.JoinHostPort("127.0.0.1", strconv.Itoa(httpPort)), key)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := c.GetUser(ctx, "alice"); err != nil {
+		t.Fatalf("GetUser: %v", err)
+	}
+
+	if !rec.sawAuth {
+		t.Fatal("filer never saw an authorization header")
+	}
+	if rec.authErr != nil {
+		t.Fatalf("filer rejected the token: %v", rec.authErr)
+	}
+}
+
+// authRecordingIAM is a minimal IAM gRPC server stand-in that records whether
+// each request carried an authorization Bearer header and whether that header
+// validates against adminSigningKey using the same DecodeJwt path the real
+// filer uses. Only GetUser is exercised — that's enough to assert the auth
+// plumbing.
+type authRecordingIAM struct {
+	iam_pb.UnimplementedSeaweedIdentityAccessManagementServer
+	adminSigningKey security.SigningKey
+	sawAuth         bool
+	authErr         error
+}
+
+func (s *authRecordingIAM) GetUser(ctx context.Context, req *iam_pb.GetUserRequest) (*iam_pb.GetUserResponse, error) {
+	md, _ := metadata.FromIncomingContext(ctx)
+	hdr := md.Get("authorization")
+	if len(hdr) == 0 {
+		s.authErr = status.Error(codes.Unauthenticated, "missing authorization metadata")
+		return nil, s.authErr
+	}
+	s.sawAuth = true
+	parts := strings.Fields(hdr[0])
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+		s.authErr = status.Error(codes.Unauthenticated, "authorization header must use Bearer scheme")
+		return nil, s.authErr
+	}
+	parsed, err := security.DecodeJwt(s.adminSigningKey, security.EncodedJwt(parts[1]), &security.SeaweedFilerAdminClaims{})
+	if err != nil || parsed == nil || !parsed.Valid {
+		s.authErr = status.Error(codes.Unauthenticated, "invalid admin token")
+		return nil, s.authErr
+	}
+	return &iam_pb.GetUserResponse{Identity: &iam_pb.Identity{Name: req.Username}}, nil
+}
+


### PR DESCRIPTION
## Summary
- Operator always renders `jwt.filer_signing.key` into the security ConfigMap when `spec.Filer` (or `spec.Admin`) is set, but `swadmin.IAMClient` never sent a Bearer token. The filer's IAM gRPC service therefore rejected every call with `Unauthenticated desc = missing authorization metadata` — all four S3* IAM CRs stayed permanently `Failed`.
- Read the rendered signing key from the security ConfigMap during reconcile, plumb it through `IAMAdminFactory` → `swadmin.IAMClient`, and stamp a freshly minted admin Bearer token onto every outgoing IAM gRPC context. Mirrors the upstream `weed shell` IAM client (`weed/shell/command_s3_iam_client.go:iamAdminAuthContext`).
- When the key is empty (cluster mid-reconcile, externally managed cluster, or no key configured) the calls stay unauthenticated, matching the filer's no-op auth branch — no behavior change for those setups.

Fixes #257

## Test plan
- [x] `go test ./internal/controller/...` — existing IAM controller tests still green (factory signature change rippled through `fakeIAMFactory`).
- [x] New `TestIAMClient_AuthContext_AppendsBearerWhenKeySet` / `_NoMetadataWhenKeyEmpty` cover the in-process auth header path including DecodeJwt round-trip with `security.SeaweedFilerAdminClaims`.
- [x] New `TestIAMClient_GetUser_SendsBearer` boots an in-process IAM gRPC server that asserts the operator's `withClient` actually puts the Bearer header on the wire (the previous fake-IAMAdmin tests could not catch this regression).
- [x] New `TestResolveSeaweedFiler_LoadsAdminSigningKey` / `_MissingConfigMapReturnsEmptyKey` cover the ConfigMap → resolver path, including the missing-CM degrade-to-empty-key branch.
- [ ] Manual verification on a live cluster with `spec.filer` defined: create an `S3Identity`, observe Phase=Ready (previously stuck Failed). Not run here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * IAM admin operations now support Bearer-token authentication using optional admin signing keys.
  * Admin signing keys are loaded from cluster security configuration and used during reconciliation.
  * Admin client caching respects signing-key rotation, invalidating cached clients when keys change.

* **Tests**
  * Added comprehensive tests for IAM admin authentication behavior and security-config loading.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs-operator/pull/259?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->