### PR TITLE
feat: select specific PVs via storageSelector on volume servers (#258)

### DIFF
--- a/api/v1/seaweed_types.go
+++ b/api/v1/seaweed_types.go
@@ -309,6 +309,16 @@ type VolumeServerConfig struct {
 	Service          *ServiceSpec `json:"service,omitempty"`
 	StorageClassName *string      `json:"storageClassName,omitempty"`
 
+	// StorageSelector is an optional label query applied to the
+	// VolumeClaimTemplate's spec.selector. Set this to bind the volume
+	// server's PVCs to pre-provisioned PVs that carry matching labels —
+	// useful when reusing existing PVs on a cluster instead of dynamic
+	// provisioning. The selector is propagated unchanged to each
+	// per-disk PVC template; with multiple matching PVs, the scheduler
+	// pairs one PV per replica/disk.
+	// +optional
+	StorageSelector *metav1.LabelSelector `json:"storageSelector,omitempty"`
+
 	// MetricsPort is the port that the prometheus metrics export listens on
 	MetricsPort *int32 `json:"metricsPort,omitempty"`
 

--- a/api/v1/seaweed_types.go
+++ b/api/v1/seaweed_types.go
@@ -309,13 +309,8 @@ type VolumeServerConfig struct {
 	Service          *ServiceSpec `json:"service,omitempty"`
 	StorageClassName *string      `json:"storageClassName,omitempty"`
 
-	// StorageSelector is an optional label query applied to the
-	// VolumeClaimTemplate's spec.selector. Set this to bind the volume
-	// server's PVCs to pre-provisioned PVs that carry matching labels —
-	// useful when reusing existing PVs on a cluster instead of dynamic
-	// provisioning. The selector is propagated unchanged to each
-	// per-disk PVC template; with multiple matching PVs, the scheduler
-	// pairs one PV per replica/disk.
+	// StorageSelector is applied to each PVC template's spec.selector to
+	// bind volume-server PVCs to pre-provisioned PVs with matching labels.
 	// +optional
 	StorageSelector *metav1.LabelSelector `json:"storageSelector,omitempty"`
 

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -1660,6 +1660,11 @@ func (in *VolumeServerConfig) DeepCopyInto(out *VolumeServerConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.StorageSelector != nil {
+		in, out := &in.StorageSelector, &out.StorageSelector
+		*out = new(metav1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.MetricsPort != nil {
 		in, out := &in.MetricsPort, &out.MetricsPort
 		*out = new(int32)

--- a/config/crd/bases/seaweed.seaweedfs.com_seaweeds.yaml
+++ b/config/crd/bases/seaweed.seaweedfs.com_seaweeds.yaml
@@ -9309,6 +9309,32 @@ spec:
                     type: string
                   storageClassName:
                     type: string
+                  storageSelector:
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
                   terminationGracePeriodSeconds:
                     type: integer
                   tolerations:
@@ -10858,6 +10884,32 @@ spec:
                       type: string
                     storageClassName:
                       type: string
+                    storageSelector:
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
                     terminationGracePeriodSeconds:
                       type: integer
                     tolerations:

--- a/deploy/helm/templates/crd-seaweed.yaml
+++ b/deploy/helm/templates/crd-seaweed.yaml
@@ -10212,6 +10212,32 @@ spec:
                       type: string
                     storageClassName:
                       type: string
+                    storageSelector:
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
                     terminationGracePeriodSeconds:
                       type: integer
                     tolerations:
@@ -11761,6 +11787,32 @@ spec:
                         type: string
                       storageClassName:
                         type: string
+                      storageSelector:
+                        properties:
+                          matchExpressions:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                values:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
                       terminationGracePeriodSeconds:
                         type: integer
                       tolerations:

--- a/internal/controller/controller_volume_statefulset.go
+++ b/internal/controller/controller_volume_statefulset.go
@@ -196,7 +196,7 @@ func (r *SeaweedReconciler) createVolumeServerStatefulSet(m *seaweedv1.Seaweed) 
 			},
 			Spec: corev1.PersistentVolumeClaimSpec{
 				StorageClassName: m.Spec.Volume.StorageClassName,
-				Selector:         m.Spec.Volume.StorageSelector,
+				Selector:         m.Spec.Volume.StorageSelector.DeepCopy(),
 				AccessModes: []corev1.PersistentVolumeAccessMode{
 					corev1.ReadWriteOnce,
 				},
@@ -360,7 +360,7 @@ func (r *SeaweedReconciler) createVolumeServerTopologyStatefulSet(m *seaweedv1.S
 			},
 			Spec: corev1.PersistentVolumeClaimSpec{
 				StorageClassName: getStorageClassName(m, topologySpec),
-				Selector:         getStorageSelector(m, topologySpec),
+				Selector:         getStorageSelector(m, topologySpec).DeepCopy(),
 				AccessModes: []corev1.PersistentVolumeAccessMode{
 					corev1.ReadWriteOnce,
 				},

--- a/internal/controller/controller_volume_statefulset.go
+++ b/internal/controller/controller_volume_statefulset.go
@@ -196,6 +196,7 @@ func (r *SeaweedReconciler) createVolumeServerStatefulSet(m *seaweedv1.Seaweed) 
 			},
 			Spec: corev1.PersistentVolumeClaimSpec{
 				StorageClassName: m.Spec.Volume.StorageClassName,
+				Selector:         m.Spec.Volume.StorageSelector,
 				AccessModes: []corev1.PersistentVolumeAccessMode{
 					corev1.ReadWriteOnce,
 				},
@@ -359,6 +360,7 @@ func (r *SeaweedReconciler) createVolumeServerTopologyStatefulSet(m *seaweedv1.S
 			},
 			Spec: corev1.PersistentVolumeClaimSpec{
 				StorageClassName: getStorageClassName(m, topologySpec),
+				Selector:         getStorageSelector(m, topologySpec),
 				AccessModes: []corev1.PersistentVolumeAccessMode{
 					corev1.ReadWriteOnce,
 				},

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
@@ -197,6 +198,19 @@ func getStorageClassName(m *seaweedv1.Seaweed, topologySpec *seaweedv1.VolumeTop
 	}
 	if m.Spec.Volume != nil && m.Spec.Volume.StorageClassName != nil {
 		return m.Spec.Volume.StorageClassName
+	}
+	return nil
+}
+
+// getStorageSelector returns the PVC label selector with topology-then-flat
+// fallback. Used to bind a volume server's StatefulSet PVCs to pre-provisioned
+// PVs that carry matching labels.
+func getStorageSelector(m *seaweedv1.Seaweed, topologySpec *seaweedv1.VolumeTopologySpec) *metav1.LabelSelector {
+	if topologySpec != nil && topologySpec.StorageSelector != nil {
+		return topologySpec.StorageSelector
+	}
+	if m.Spec.Volume != nil && m.Spec.Volume.StorageSelector != nil {
+		return m.Spec.Volume.StorageSelector
 	}
 	return nil
 }

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -202,9 +202,6 @@ func getStorageClassName(m *seaweedv1.Seaweed, topologySpec *seaweedv1.VolumeTop
 	return nil
 }
 
-// getStorageSelector returns the PVC label selector with topology-then-flat
-// fallback. Used to bind a volume server's StatefulSet PVCs to pre-provisioned
-// PVs that carry matching labels.
 func getStorageSelector(m *seaweedv1.Seaweed, topologySpec *seaweedv1.VolumeTopologySpec) *metav1.LabelSelector {
 	if topologySpec != nil && topologySpec.StorageSelector != nil {
 		return topologySpec.StorageSelector

--- a/internal/controller/volume_storage_selector_test.go
+++ b/internal/controller/volume_storage_selector_test.go
@@ -82,14 +82,11 @@ func TestVolumeStatefulSet_NilSelectorYieldsNilPVCSelector(t *testing.T) {
 		t.Fatalf("VolumeClaimTemplates len = %d, want 1", len(sts.Spec.VolumeClaimTemplates))
 	}
 	if sts.Spec.VolumeClaimTemplates[0].Spec.Selector != nil {
-		t.Errorf("PVC.Spec.Selector = %#v, want nil — selector must stay unset when StorageSelector is nil so dynamic provisioning still works",
-			sts.Spec.VolumeClaimTemplates[0].Spec.Selector)
+		t.Errorf("PVC.Spec.Selector = %#v, want nil", sts.Spec.VolumeClaimTemplates[0].Spec.Selector)
 	}
 }
 
 func TestVolumeTopologyStatefulSet_PropagatesStorageSelector_TopologyWins(t *testing.T) {
-	// Topology-level selector should win over the flat spec.volume selector,
-	// mirroring the precedence already established for StorageClassName.
 	flatSel := &metav1.LabelSelector{MatchLabels: map[string]string{"tier": "fast"}}
 	topoSel := &metav1.LabelSelector{MatchLabels: map[string]string{"tier": "ultra"}}
 
@@ -131,14 +128,11 @@ func TestVolumeTopologyStatefulSet_PropagatesStorageSelector_TopologyWins(t *tes
 		t.Fatalf("VolumeClaimTemplates len = %d, want 1", len(sts.Spec.VolumeClaimTemplates))
 	}
 	if !apiequality.Semantic.DeepEqual(sts.Spec.VolumeClaimTemplates[0].Spec.Selector, topoSel) {
-		t.Errorf("topology PVC.Spec.Selector = %#v, want topology selector %#v (topology must override flat)",
-			sts.Spec.VolumeClaimTemplates[0].Spec.Selector, topoSel)
+		t.Errorf("topology PVC.Spec.Selector = %#v, want %#v", sts.Spec.VolumeClaimTemplates[0].Spec.Selector, topoSel)
 	}
 }
 
 func TestVolumeTopologyStatefulSet_FallsBackToFlatStorageSelector(t *testing.T) {
-	// When the topology group leaves StorageSelector unset, the flat
-	// spec.volume.storageSelector value is used.
 	flatSel := &metav1.LabelSelector{MatchLabels: map[string]string{"tier": "fast"}}
 
 	diskCount := int32(1)
@@ -175,14 +169,12 @@ func TestVolumeTopologyStatefulSet_FallsBackToFlatStorageSelector(t *testing.T) 
 	sts := r.createVolumeServerTopologyStatefulSet(m, "rack1", topology)
 
 	if !apiequality.Semantic.DeepEqual(sts.Spec.VolumeClaimTemplates[0].Spec.Selector, flatSel) {
-		t.Errorf("topology PVC.Spec.Selector = %#v, want flat selector %#v (fallback when topology unset)",
-			sts.Spec.VolumeClaimTemplates[0].Spec.Selector, flatSel)
+		t.Errorf("topology PVC.Spec.Selector = %#v, want %#v", sts.Spec.VolumeClaimTemplates[0].Spec.Selector, flatSel)
 	}
 }
 
 func TestGetStorageSelector_NilSafe(t *testing.T) {
-	// Topology-only deployments may omit spec.volume entirely; the helper
-	// must not panic on m.Spec.Volume == nil.
+	// Topology-only deployments omit spec.volume; helper must not panic.
 	m := &seaweedv1.Seaweed{
 		ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
 		Spec:       seaweedv1.SeaweedSpec{Master: &seaweedv1.MasterSpec{Replicas: 1}},

--- a/internal/controller/volume_storage_selector_test.go
+++ b/internal/controller/volume_storage_selector_test.go
@@ -1,0 +1,201 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+)
+
+func makeStorageSelectorSeaweed(diskCount int32, selector *metav1.LabelSelector) *seaweedv1.Seaweed {
+	return &seaweedv1.Seaweed{
+		ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
+		Spec: seaweedv1.SeaweedSpec{
+			Master:                &seaweedv1.MasterSpec{Replicas: 1},
+			VolumeServerDiskCount: &diskCount,
+			Volume: &seaweedv1.VolumeSpec{
+				Replicas: 3,
+				VolumeServerConfig: seaweedv1.VolumeServerConfig{
+					ResourceRequirements: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("30Gi"),
+						},
+					},
+					StorageSelector: selector,
+				},
+			},
+		},
+	}
+}
+
+func TestVolumeStatefulSet_PropagatesStorageSelectorToEachPVCTemplate(t *testing.T) {
+	sel := &metav1.LabelSelector{
+		MatchLabels: map[string]string{"tier": "fast"},
+		MatchExpressions: []metav1.LabelSelectorRequirement{{
+			Key:      "zone",
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   []string{"us-east-1a", "us-east-1b"},
+		}},
+	}
+	m := makeStorageSelectorSeaweed(2, sel)
+
+	r := &SeaweedReconciler{}
+	sts := r.createVolumeServerStatefulSet(m)
+
+	if got := len(sts.Spec.VolumeClaimTemplates); got != 2 {
+		t.Fatalf("VolumeClaimTemplates len = %d, want 2 (one per disk)", got)
+	}
+	for i, pvc := range sts.Spec.VolumeClaimTemplates {
+		if !apiequality.Semantic.DeepEqual(pvc.Spec.Selector, sel) {
+			t.Errorf("PVC[%d].Spec.Selector = %#v, want %#v", i, pvc.Spec.Selector, sel)
+		}
+	}
+}
+
+func TestVolumeStatefulSet_NilSelectorYieldsNilPVCSelector(t *testing.T) {
+	m := makeStorageSelectorSeaweed(1, nil)
+
+	r := &SeaweedReconciler{}
+	sts := r.createVolumeServerStatefulSet(m)
+
+	if len(sts.Spec.VolumeClaimTemplates) != 1 {
+		t.Fatalf("VolumeClaimTemplates len = %d, want 1", len(sts.Spec.VolumeClaimTemplates))
+	}
+	if sts.Spec.VolumeClaimTemplates[0].Spec.Selector != nil {
+		t.Errorf("PVC.Spec.Selector = %#v, want nil — selector must stay unset when StorageSelector is nil so dynamic provisioning still works",
+			sts.Spec.VolumeClaimTemplates[0].Spec.Selector)
+	}
+}
+
+func TestVolumeTopologyStatefulSet_PropagatesStorageSelector_TopologyWins(t *testing.T) {
+	// Topology-level selector should win over the flat spec.volume selector,
+	// mirroring the precedence already established for StorageClassName.
+	flatSel := &metav1.LabelSelector{MatchLabels: map[string]string{"tier": "fast"}}
+	topoSel := &metav1.LabelSelector{MatchLabels: map[string]string{"tier": "ultra"}}
+
+	diskCount := int32(1)
+	topology := &seaweedv1.VolumeTopologySpec{
+		VolumeServerConfig: seaweedv1.VolumeServerConfig{
+			ResourceRequirements: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("30Gi"),
+				},
+			},
+			StorageSelector: topoSel,
+		},
+		Replicas:   1,
+		Rack:       "rack1",
+		DataCenter: "dc1",
+	}
+	m := &seaweedv1.Seaweed{
+		ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
+		Spec: seaweedv1.SeaweedSpec{
+			Master:                &seaweedv1.MasterSpec{Replicas: 1},
+			VolumeServerDiskCount: &diskCount,
+			Volume: &seaweedv1.VolumeSpec{
+				Replicas: 1,
+				VolumeServerConfig: seaweedv1.VolumeServerConfig{
+					StorageSelector: flatSel,
+				},
+			},
+			VolumeTopology: map[string]*seaweedv1.VolumeTopologySpec{
+				"rack1": topology,
+			},
+		},
+	}
+
+	r := &SeaweedReconciler{}
+	sts := r.createVolumeServerTopologyStatefulSet(m, "rack1", topology)
+
+	if len(sts.Spec.VolumeClaimTemplates) != 1 {
+		t.Fatalf("VolumeClaimTemplates len = %d, want 1", len(sts.Spec.VolumeClaimTemplates))
+	}
+	if !apiequality.Semantic.DeepEqual(sts.Spec.VolumeClaimTemplates[0].Spec.Selector, topoSel) {
+		t.Errorf("topology PVC.Spec.Selector = %#v, want topology selector %#v (topology must override flat)",
+			sts.Spec.VolumeClaimTemplates[0].Spec.Selector, topoSel)
+	}
+}
+
+func TestVolumeTopologyStatefulSet_FallsBackToFlatStorageSelector(t *testing.T) {
+	// When the topology group leaves StorageSelector unset, the flat
+	// spec.volume.storageSelector value is used.
+	flatSel := &metav1.LabelSelector{MatchLabels: map[string]string{"tier": "fast"}}
+
+	diskCount := int32(1)
+	topology := &seaweedv1.VolumeTopologySpec{
+		VolumeServerConfig: seaweedv1.VolumeServerConfig{
+			ResourceRequirements: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("30Gi"),
+				},
+			},
+		},
+		Replicas:   1,
+		Rack:       "rack1",
+		DataCenter: "dc1",
+	}
+	m := &seaweedv1.Seaweed{
+		ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
+		Spec: seaweedv1.SeaweedSpec{
+			Master:                &seaweedv1.MasterSpec{Replicas: 1},
+			VolumeServerDiskCount: &diskCount,
+			Volume: &seaweedv1.VolumeSpec{
+				Replicas: 1,
+				VolumeServerConfig: seaweedv1.VolumeServerConfig{
+					StorageSelector: flatSel,
+				},
+			},
+			VolumeTopology: map[string]*seaweedv1.VolumeTopologySpec{
+				"rack1": topology,
+			},
+		},
+	}
+
+	r := &SeaweedReconciler{}
+	sts := r.createVolumeServerTopologyStatefulSet(m, "rack1", topology)
+
+	if !apiequality.Semantic.DeepEqual(sts.Spec.VolumeClaimTemplates[0].Spec.Selector, flatSel) {
+		t.Errorf("topology PVC.Spec.Selector = %#v, want flat selector %#v (fallback when topology unset)",
+			sts.Spec.VolumeClaimTemplates[0].Spec.Selector, flatSel)
+	}
+}
+
+func TestGetStorageSelector_NilSafe(t *testing.T) {
+	// Topology-only deployments may omit spec.volume entirely; the helper
+	// must not panic on m.Spec.Volume == nil.
+	m := &seaweedv1.Seaweed{
+		ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
+		Spec:       seaweedv1.SeaweedSpec{Master: &seaweedv1.MasterSpec{Replicas: 1}},
+	}
+	if got := getStorageSelector(m, nil); got != nil {
+		t.Errorf("getStorageSelector with nil Volume and nil topology = %#v, want nil", got)
+	}
+
+	topoSel := &metav1.LabelSelector{MatchLabels: map[string]string{"tier": "ultra"}}
+	topo := &seaweedv1.VolumeTopologySpec{
+		VolumeServerConfig: seaweedv1.VolumeServerConfig{StorageSelector: topoSel},
+	}
+	if got := getStorageSelector(m, topo); !apiequality.Semantic.DeepEqual(got, topoSel) {
+		t.Errorf("getStorageSelector topology-only = %#v, want %#v", got, topoSel)
+	}
+}

--- a/internal/controller/volume_storage_selector_test.go
+++ b/internal/controller/volume_storage_selector_test.go
@@ -72,6 +72,37 @@ func TestVolumeStatefulSet_PropagatesStorageSelectorToEachPVCTemplate(t *testing
 	}
 }
 
+func TestVolumeStatefulSet_StorageSelectorIsDeepCopiedPerPVC(t *testing.T) {
+	// Each PVC template must own its selector — mutating one must not bleed
+	// into the others or back into the CR.
+	sel := &metav1.LabelSelector{MatchLabels: map[string]string{"tier": "fast"}}
+	m := makeStorageSelectorSeaweed(3, sel)
+
+	r := &SeaweedReconciler{}
+	sts := r.createVolumeServerStatefulSet(m)
+	if len(sts.Spec.VolumeClaimTemplates) != 3 {
+		t.Fatalf("VolumeClaimTemplates len = %d, want 3", len(sts.Spec.VolumeClaimTemplates))
+	}
+
+	first := sts.Spec.VolumeClaimTemplates[0].Spec.Selector
+	if first == sel {
+		t.Errorf("PVC[0].Spec.Selector aliases the CR's selector pointer; deep copy expected")
+	}
+	for i, pvc := range sts.Spec.VolumeClaimTemplates {
+		if i > 0 && pvc.Spec.Selector == first {
+			t.Errorf("PVC[%d].Spec.Selector aliases PVC[0]'s selector pointer; per-PVC deep copy expected", i)
+		}
+	}
+
+	sts.Spec.VolumeClaimTemplates[0].Spec.Selector.MatchLabels["tier"] = "mutated"
+	if sts.Spec.VolumeClaimTemplates[1].Spec.Selector.MatchLabels["tier"] != "fast" {
+		t.Errorf("mutating PVC[0] selector leaked into PVC[1]: %#v", sts.Spec.VolumeClaimTemplates[1].Spec.Selector)
+	}
+	if sel.MatchLabels["tier"] != "fast" {
+		t.Errorf("mutating PVC[0] selector leaked back to the CR's selector: %#v", sel)
+	}
+}
+
 func TestVolumeStatefulSet_NilSelectorYieldsNilPVCSelector(t *testing.T) {
 	m := makeStorageSelectorSeaweed(1, nil)
 


### PR DESCRIPTION
## Summary

- Adds `spec.volume.storageSelector` (and per-topology-group `storageSelector`) to the `Seaweed` CR. The selector is propagated to each volume-server PVC template's `spec.selector`, letting operators bind StatefulSet PVCs to pre-provisioned PVs that carry matching labels instead of relying on dynamic provisioning.
- Topology-then-flat precedence mirrors the existing pattern for `storageClassName` (`getStorageSelector` in `helper.go`).
- Field placed flat on `VolumeServerConfig`, alongside `storageClassName`, rather than nested under `storageSpec.volumeClaimTemplate` — keeps the volume server schema consistent with what it already exposes.
- `volumeName` from the original issue is intentionally **not** added: a single PV binding reference cannot serve N-replica/N-disk PVC templates without forcing all replicas to race for one PV. Selector-based binding handles the same use case (re-using existing PVs) cleanly across any replica count.
- `pvcSemanticallyEqual` already covers `Spec.Selector`, so no comparator change was needed for reconcile drift detection.

### Example

```yaml
apiVersion: seaweed.seaweedfs.com/v1
kind: Seaweed
metadata:
  name: test-cluster
spec:
  volume:
    replicas: 3
    requests:
      storage: 30Gi
    storageSelector:
      matchLabels:
        app: seaweedfs
        tier: fast
      matchExpressions:
        - { key: zone, operator: In, values: [us-east-1a, us-east-1b] }
```

Pre-label your existing PVs with the matching labels and the volume server PVCs will bind to them.

Closes #258

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./api/... ./internal/...` (new tests + existing suite pass)
- [x] New unit tests in `internal/controller/volume_storage_selector_test.go`:
  - selector propagates to each per-disk PVC template (flat volume)
  - nil selector leaves `Spec.Selector` nil (preserves dynamic provisioning)
  - topology selector wins over flat selector
  - topology falls back to flat selector when unset
  - `getStorageSelector` is nil-safe for topology-only deployments (no `spec.volume`)
- [ ] Manual: apply a CR with `storageSelector`, confirm PVCs are created with the selector and bind to pre-provisioned labeled PVs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable storage selectors to control which storage resources are matched for volume servers.
  * Selectors can be set globally or overridden per topology group for finer-grained storage placement.
  * PVC templates now honor these selectors so PVCs match pre-provisioned storage by labels.

* **Tests**
  * Added tests verifying propagation, deep-copy safety, nil handling, and topology override behavior for storage selectors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs-operator/pull/260?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->