### PR TITLE
feat: add LoggingArgs for pre-subcommand weed logging flags

### DIFF
--- a/api/v1/component_accessor.go
+++ b/api/v1/component_accessor.go
@@ -29,6 +29,7 @@ type ComponentAccessor interface {
 	Volumes() []corev1.Volume
 	VolumeMounts() []corev1.VolumeMount
 	ExtraArgs() []string
+	LoggingArgs() []string
 	Sidecars() []corev1.Container
 	InitContainers() []corev1.Container
 	PodSecurityContext() *corev1.PodSecurityContext
@@ -47,6 +48,7 @@ type componentAccessorImpl struct {
 	clusterLabels             map[string]string
 	tolerations               []corev1.Toleration
 	statefulSetUpdateStrategy appsv1.StatefulSetUpdateStrategyType
+	loggingArgs               []string
 
 	// ComponentSpec is the Component Spec
 	ComponentSpec *ComponentSpec
@@ -222,6 +224,14 @@ func (a *componentAccessorImpl) ExtraArgs() []string {
 	return a.ComponentSpec.ExtraArgs
 }
 
+func (a *componentAccessorImpl) LoggingArgs() []string {
+	args := a.ComponentSpec.LoggingArgs
+	if len(args) == 0 {
+		args = a.loggingArgs
+	}
+	return args
+}
+
 func (a *componentAccessorImpl) Sidecars() []corev1.Container {
 	return a.ComponentSpec.Sidecars
 }
@@ -250,6 +260,7 @@ func buildSeaweedComponentAccessor(spec *SeaweedSpec, componentSpec *ComponentSp
 		clusterLabels:             spec.Labels,
 		tolerations:               spec.Tolerations,
 		statefulSetUpdateStrategy: spec.StatefulSetUpdateStrategy,
+		loggingArgs:               spec.LoggingArgs,
 
 		ComponentSpec: componentSpec,
 	}

--- a/api/v1/seaweed_types.go
+++ b/api/v1/seaweed_types.go
@@ -212,6 +212,18 @@ type SeaweedSpec struct {
 
 	// Ingresses
 	HostSuffix *string `json:"hostSuffix,omitempty"`
+
+	// LoggingArgs are command line flags placed before the weed subcommand,
+	// e.g. ["-logJson", "-v=2"]. seaweedfs's logging flags (defined by the
+	// embedded fla9 parser) must precede the subcommand — they are rejected
+	// after "master", "filer", etc. — so they cannot be expressed through
+	// ExtraArgs. When this slice is non-empty the operator drops its default
+	// `-logtostderr=true` and emits the user-supplied flags verbatim, giving
+	// full control over log destination, format, and verbosity. Components
+	// may override via ComponentSpec.LoggingArgs.
+	// +optional
+	// +listType=atomic
+	LoggingArgs []string `json:"loggingArgs,omitempty"`
 }
 
 // SeaweedStatus defines the observed state of Seaweed
@@ -677,6 +689,17 @@ type ComponentSpec struct {
 	// ExtraArgs are additional command line arguments passed to the component container
 	// +listType=atomic
 	ExtraArgs []string `json:"extraArgs,omitempty"`
+
+	// LoggingArgs are command line flags placed before the weed subcommand
+	// (e.g. ["-logJson", "-v=2"]). When non-empty, this slice fully replaces
+	// the cluster-level SeaweedSpec.LoggingArgs for this component — there
+	// is no per-flag merge, matching how ExtraArgs and Tolerations work.
+	// Leave unset to inherit the cluster-level value. See
+	// SeaweedSpec.LoggingArgs for the rationale (logging flags must precede
+	// the subcommand and therefore cannot be expressed via ExtraArgs).
+	// +optional
+	// +listType=atomic
+	LoggingArgs []string `json:"loggingArgs,omitempty"`
 
 	// Sidecars are additional containers run alongside the operator-managed
 	// container in each pod of this component. Use this to attach helpers

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -394,6 +394,11 @@ func (in *ComponentSpec) DeepCopyInto(out *ComponentSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.LoggingArgs != nil {
+		in, out := &in.LoggingArgs, &out.LoggingArgs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Sidecars != nil {
 		in, out := &in.Sidecars, &out.Sidecars
 		*out = make([]corev1.Container, len(*in))
@@ -1536,6 +1541,11 @@ func (in *SeaweedSpec) DeepCopyInto(out *SeaweedSpec) {
 		in, out := &in.HostSuffix, &out.HostSuffix
 		*out = new(string)
 		**out = **in
+	}
+	if in.LoggingArgs != nil {
+		in, out := &in.LoggingArgs, &out.LoggingArgs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 }
 

--- a/config/crd/bases/seaweed.seaweedfs.com_seaweeds.yaml
+++ b/config/crd/bases/seaweed.seaweedfs.com_seaweeds.yaml
@@ -682,6 +682,11 @@ spec:
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
                     type: object
+                  loggingArgs:
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
                   metricsPort:
                     type: integer
                   nodeSelector:
@@ -2689,6 +2694,11 @@ spec:
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
                     type: object
+                  loggingArgs:
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
                   maxMB:
                     type: integer
                   metricsPort:
@@ -3751,6 +3761,11 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
+              loggingArgs:
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: atomic
               master:
                 properties:
                   affinity:
@@ -4408,6 +4423,11 @@ spec:
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
                     type: object
+                  loggingArgs:
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
                   metricsPort:
                     type: integer
                   nodeSelector:
@@ -5995,6 +6015,11 @@ spec:
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
                     type: object
+                  loggingArgs:
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
                   metricsPort:
                     type: integer
                   nodeSelector:
@@ -7564,6 +7589,11 @@ spec:
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
                     type: object
+                  loggingArgs:
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
                   maxAuthTries:
                     minimum: 1
                     type: integer
@@ -9190,6 +9220,11 @@ spec:
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
                     type: object
+                  loggingArgs:
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
                   maxVolumeCounts:
                     type: integer
                   metricsPort:
@@ -10739,6 +10774,11 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       type: object
+                    loggingArgs:
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
                     maxVolumeCounts:
                       type: integer
                     metricsPort:
@@ -12281,6 +12321,11 @@ spec:
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
                     type: object
+                  loggingArgs:
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
                   maxDetect:
                     minimum: 1
                     type: integer

--- a/deploy/helm/templates/crd-seaweed.yaml
+++ b/deploy/helm/templates/crd-seaweed.yaml
@@ -1585,6 +1585,11 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       type: object
+                    loggingArgs:
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
                     metricsPort:
                       type: integer
                     nodeSelector:
@@ -3592,6 +3597,11 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       type: object
+                    loggingArgs:
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
                     maxMB:
                       type: integer
                     metricsPort:
@@ -4654,6 +4664,11 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
+                loggingArgs:
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: atomic
                 master:
                   properties:
                     affinity:
@@ -5311,6 +5326,11 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       type: object
+                    loggingArgs:
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
                     metricsPort:
                       type: integer
                     nodeSelector:
@@ -6898,6 +6918,11 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       type: object
+                    loggingArgs:
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
                     metricsPort:
                       type: integer
                     nodeSelector:
@@ -8467,6 +8492,11 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       type: object
+                    loggingArgs:
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
                     maxAuthTries:
                       minimum: 1
                       type: integer
@@ -10093,6 +10123,11 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       type: object
+                    loggingArgs:
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
                     maxVolumeCounts:
                       type: integer
                     metricsPort:
@@ -11642,6 +11677,11 @@ spec:
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         type: object
+                      loggingArgs:
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
                       maxVolumeCounts:
                         type: integer
                       metricsPort:
@@ -13184,6 +13224,11 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       type: object
+                    loggingArgs:
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
                     maxDetect:
                       minimum: 1
                       type: integer

--- a/internal/controller/controller_admin_statefulset.go
+++ b/internal/controller/controller_admin_statefulset.go
@@ -25,11 +25,7 @@ const adminCredentialsMountPath = "/etc/sw/admin"
 var adminCredentialKeys = []string{"adminUser", "adminPassword", "readOnlyUser", "readOnlyPassword"}
 
 func buildAdminStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string {
-	commands := []string{"weed", "-logtostderr=true"}
-	if arg := tlsConfigDirArg(m); arg != "" {
-		commands = append(commands, arg)
-	}
-	commands = append(commands, "admin")
+	commands := weedPreamble(m, m.BaseAdminSpec().LoggingArgs(), "admin")
 	commands = append(commands, fmt.Sprintf("-port=%d", seaweedv1.AdminHTTPPort))
 	commands = append(commands, fmt.Sprintf("-master=%s", getMasterPeersString(m)))
 	if m.Spec.Admin.MetricsPort != nil {

--- a/internal/controller/controller_filer_statefulset.go
+++ b/internal/controller/controller_filer_statefulset.go
@@ -13,11 +13,7 @@ import (
 )
 
 func buildFilerStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string {
-	commands := []string{"weed", "-logtostderr=true"}
-	if arg := tlsConfigDirArg(m); arg != "" {
-		commands = append(commands, arg)
-	}
-	commands = append(commands, "filer")
+	commands := weedPreamble(m, m.BaseFilerSpec().LoggingArgs(), "filer")
 	commands = append(commands, fmt.Sprintf("-port=%d", seaweedv1.FilerHTTPPort))
 	commands = append(commands, fmt.Sprintf("-ip=$(POD_NAME).%s-filer-peer.%s", m.Name, m.Namespace))
 	commands = append(commands, fmt.Sprintf("-master=%s", getMasterPeersString(m)))

--- a/internal/controller/controller_master_statefulset.go
+++ b/internal/controller/controller_master_statefulset.go
@@ -13,13 +13,7 @@ import (
 )
 
 func buildMasterStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string {
-	command := []string{"weed", "-logtostderr=true"}
-	if arg := tlsConfigDirArg(m); arg != "" {
-		// -config_dir is a top-level weed flag and must come before the
-		// subcommand.
-		command = append(command, arg)
-	}
-	command = append(command, "master")
+	command := weedPreamble(m, m.BaseMasterSpec().LoggingArgs(), "master")
 	spec := m.Spec.Master
 	if spec.VolumePreallocate != nil && *spec.VolumePreallocate {
 		command = append(command, "-volumePreallocate")

--- a/internal/controller/controller_s3.go
+++ b/internal/controller/controller_s3.go
@@ -314,11 +314,7 @@ func (r *SeaweedReconciler) buildS3Deployment(m *seaweedv1.Seaweed) *appsv1.Depl
 }
 
 func buildS3GatewayStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string {
-	commands := []string{"weed", "-logtostderr=true"}
-	if arg := tlsConfigDirArg(m); arg != "" {
-		commands = append(commands, arg)
-	}
-	commands = append(commands, "s3")
+	commands := weedPreamble(m, m.BaseS3Spec().LoggingArgs(), "s3")
 	commands = append(commands, fmt.Sprintf("-port=%d", s3EffectivePort(m)))
 	commands = append(commands, fmt.Sprintf("-filer=%s-filer:%d", m.Name, seaweedv1.FilerHTTPPort))
 	if m.Spec.S3.ConfigSecret != nil && m.Spec.S3.ConfigSecret.Key != "" {

--- a/internal/controller/controller_sftp.go
+++ b/internal/controller/controller_sftp.go
@@ -324,11 +324,7 @@ func (r *SeaweedReconciler) buildSFTPDeployment(m *seaweedv1.Seaweed) *appsv1.De
 }
 
 func buildSFTPGatewayStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string {
-	commands := []string{"weed", "-logtostderr=true"}
-	if arg := tlsConfigDirArg(m); arg != "" {
-		commands = append(commands, arg)
-	}
-	commands = append(commands, "sftp")
+	commands := weedPreamble(m, m.BaseSFTPSpec().LoggingArgs(), "sftp")
 	commands = append(commands, fmt.Sprintf("-port=%d", sftpEffectivePort(m)))
 	commands = append(commands, fmt.Sprintf("-filer=%s-filer:%d", m.Name, seaweedv1.FilerHTTPPort))
 	if m.Spec.SFTP.MetricsPort != nil {

--- a/internal/controller/controller_volume_statefulset.go
+++ b/internal/controller/controller_volume_statefulset.go
@@ -22,11 +22,7 @@ func buildVolumeServerStartupScriptWithTopology(m *seaweedv1.Seaweed, dirs []str
 		fallback = m.Spec.Volume.VolumeServerConfig
 	}
 
-	commands := []string{"weed", "-logtostderr=true"}
-	if arg := tlsConfigDirArg(m); arg != "" {
-		commands = append(commands, arg)
-	}
-	commands = append(commands, "volume")
+	commands := weedPreamble(m, topologyLoggingArgs(m, topologySpec), "volume")
 	commands = append(commands, fmt.Sprintf("-port=%d", seaweedv1.VolumeHTTPPort))
 
 	// Configure max volume counts with fallback
@@ -81,11 +77,7 @@ func buildVolumeServerStartupScriptWithTopology(m *seaweedv1.Seaweed, dirs []str
 }
 
 func buildVolumeServerStartupScript(m *seaweedv1.Seaweed, dirs []string, extraArgs ...string) string {
-	commands := []string{"weed", "-logtostderr=true"}
-	if arg := tlsConfigDirArg(m); arg != "" {
-		commands = append(commands, arg)
-	}
-	commands = append(commands, "volume")
+	commands := weedPreamble(m, m.BaseVolumeSpec().LoggingArgs(), "volume")
 	commands = append(commands, fmt.Sprintf("-port=%d", seaweedv1.VolumeHTTPPort))
 	if m.Spec.Volume.MaxVolumeCounts != nil && *m.Spec.Volume.MaxVolumeCounts > 0 {
 		commands = append(commands, fmt.Sprintf("-max=%d", *m.Spec.Volume.MaxVolumeCounts))

--- a/internal/controller/controller_worker_deployment.go
+++ b/internal/controller/controller_worker_deployment.go
@@ -17,11 +17,7 @@ func getAdminAddress(m *seaweedv1.Seaweed) string {
 }
 
 func buildWorkerStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string {
-	commands := []string{"weed", "-logtostderr=true"}
-	if arg := tlsConfigDirArg(m); arg != "" {
-		commands = append(commands, arg)
-	}
-	commands = append(commands, "worker")
+	commands := weedPreamble(m, m.BaseWorkerSpec().LoggingArgs(), "worker")
 	commands = append(commands, fmt.Sprintf("-admin=%s", getAdminAddress(m)))
 	if m.Spec.Worker.Persistence != nil && m.Spec.Worker.Persistence.Enabled {
 		mountPath := "/data"

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -236,6 +236,19 @@ func getMetricsPort(m *seaweedv1.Seaweed, topologySpec *seaweedv1.VolumeTopology
 	return nil
 }
 
+// topologyLoggingArgs returns the logging args for a topology group, following
+// the same precedence as the other topology getters: topology spec, then
+// spec.volume, then cluster-level. The first non-empty value wins.
+func topologyLoggingArgs(m *seaweedv1.Seaweed, topologySpec *seaweedv1.VolumeTopologySpec) []string {
+	if topologySpec != nil && len(topologySpec.LoggingArgs) > 0 {
+		return topologySpec.LoggingArgs
+	}
+	if m.Spec.Volume != nil && len(m.Spec.Volume.LoggingArgs) > 0 {
+		return m.Spec.Volume.LoggingArgs
+	}
+	return m.Spec.LoggingArgs
+}
+
 // getServiceSpec returns the service spec with fallback logic
 func getServiceSpec(m *seaweedv1.Seaweed, topologySpec *seaweedv1.VolumeTopologySpec) *seaweedv1.ServiceSpec {
 	if topologySpec != nil && topologySpec.Service != nil {
@@ -343,4 +356,25 @@ func tlsConfigDirArg(m *seaweedv1.Seaweed) string {
 		return ""
 	}
 	return "-config_dir=" + securityConfigMountPath
+}
+
+// weedPreamble returns the `weed <logging args> [-config_dir=…] <subcommand>`
+// prefix common to every component startup script. loggingArgs comes from the
+// merged cluster/component LoggingArgs slice; when empty we fall back to the
+// historical `-logtostderr=true` default so existing CRs keep their behavior.
+// Once the user opts in, they own logging completely — passing both default
+// and overrides would produce duplicate-flag conflicts in fla9 and obscure
+// the user's intent.
+func weedPreamble(m *seaweedv1.Seaweed, loggingArgs []string, subcommand string) []string {
+	cmd := []string{"weed"}
+	if len(loggingArgs) > 0 {
+		cmd = append(cmd, loggingArgs...)
+	} else {
+		cmd = append(cmd, "-logtostderr=true")
+	}
+	if arg := tlsConfigDirArg(m); arg != "" {
+		cmd = append(cmd, arg)
+	}
+	cmd = append(cmd, subcommand)
+	return cmd
 }

--- a/internal/controller/logging_args_test.go
+++ b/internal/controller/logging_args_test.go
@@ -1,0 +1,257 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+)
+
+// TestWeedPreambleDefault confirms the historical -logtostderr=true default
+// is preserved when no LoggingArgs are set anywhere — existing CRs must not
+// silently change their log destination after upgrading the operator.
+func TestWeedPreambleDefault(t *testing.T) {
+	m := &seaweedv1.Seaweed{ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"}}
+	cmd := weedPreamble(m, nil, "master")
+	got := strings.Join(cmd, " ")
+	if got != "weed -logtostderr=true master" {
+		t.Fatalf("default preamble = %q, want %q", got, "weed -logtostderr=true master")
+	}
+}
+
+// TestWeedPreambleOverridesDefault verifies that supplying LoggingArgs
+// drops the default -logtostderr=true entirely, so users get exactly the
+// flags they asked for (no duplicate-flag conflicts in fla9).
+func TestWeedPreambleOverridesDefault(t *testing.T) {
+	m := &seaweedv1.Seaweed{ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"}}
+	cmd := weedPreamble(m, []string{"-logJson", "-v=2"}, "master")
+	got := strings.Join(cmd, " ")
+	if got != "weed -logJson -v=2 master" {
+		t.Fatalf("override preamble = %q, want %q", got, "weed -logJson -v=2 master")
+	}
+}
+
+// TestWeedPreambleOrdering pins down the position of logging args relative
+// to -config_dir and the subcommand: logging flags come right after `weed`,
+// -config_dir follows, and the subcommand always closes the prefix. fla9
+// rejects any of these flags placed after the subcommand, so the order is
+// load-bearing.
+func TestWeedPreambleOrdering(t *testing.T) {
+	enabled := true
+	m := &seaweedv1.Seaweed{
+		ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
+		Spec: seaweedv1.SeaweedSpec{
+			TLS: &seaweedv1.TLSSpec{Enabled: enabled},
+		},
+	}
+	cmd := weedPreamble(m, []string{"-logJson"}, "filer")
+	got := strings.Join(cmd, " ")
+	want := "weed -logJson -config_dir=/etc/sw-security filer"
+	if got != want {
+		t.Fatalf("preamble = %q, want %q", got, want)
+	}
+}
+
+// TestLoggingArgsClusterFallback covers the cluster→component inheritance
+// path on the accessor: a component with no LoggingArgs inherits the
+// cluster-level slice verbatim.
+func TestLoggingArgsClusterFallback(t *testing.T) {
+	m := &seaweedv1.Seaweed{
+		ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
+		Spec: seaweedv1.SeaweedSpec{
+			LoggingArgs: []string{"-logJson", "-v=1"},
+			Master:      &seaweedv1.MasterSpec{Replicas: 1},
+		},
+	}
+	got := m.BaseMasterSpec().LoggingArgs()
+	want := []string{"-logJson", "-v=1"}
+	if !equalSlices(got, want) {
+		t.Fatalf("master logging args = %v, want %v (should inherit cluster)", got, want)
+	}
+}
+
+// TestLoggingArgsComponentOverridesCluster: when both cluster and component
+// set LoggingArgs, the component fully replaces the cluster value (no
+// per-flag merge), matching how Tolerations and ExtraArgs work.
+func TestLoggingArgsComponentOverridesCluster(t *testing.T) {
+	m := &seaweedv1.Seaweed{
+		ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
+		Spec: seaweedv1.SeaweedSpec{
+			LoggingArgs: []string{"-logJson"},
+			Master: &seaweedv1.MasterSpec{
+				Replicas: 1,
+				ComponentSpec: seaweedv1.ComponentSpec{
+					LoggingArgs: []string{"-v=4"},
+				},
+			},
+		},
+	}
+	got := m.BaseMasterSpec().LoggingArgs()
+	want := []string{"-v=4"}
+	if !equalSlices(got, want) {
+		t.Fatalf("master logging args = %v, want %v (component should win)", got, want)
+	}
+}
+
+// TestBuildMasterStartupScriptWithLoggingArgs is an integration check: the
+// fully assembled master command must place the user's logging flags before
+// the `master` subcommand and after `weed`.
+func TestBuildMasterStartupScriptWithLoggingArgs(t *testing.T) {
+	m := &seaweedv1.Seaweed{
+		ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
+		Spec: seaweedv1.SeaweedSpec{
+			LoggingArgs: []string{"-logJson"},
+			Master:      &seaweedv1.MasterSpec{Replicas: 1},
+		},
+	}
+	got := buildMasterStartupScript(m, m.BaseMasterSpec().ExtraArgs()...)
+	if !strings.HasPrefix(got, "weed -logJson master ") {
+		t.Fatalf("expected master script to start with 'weed -logJson master ', got %q", got)
+	}
+	if strings.Contains(got, "-logtostderr=true") {
+		t.Fatalf("default -logtostderr=true should be dropped when LoggingArgs set, got %q", got)
+	}
+}
+
+// TestTopologyLoggingArgsFallback verifies the 3-tier precedence on
+// topology pods: topology > spec.volume > cluster. The flat-volume spec is
+// allowed to be nil here because topology-only deployments omit it.
+func TestTopologyLoggingArgsFallback(t *testing.T) {
+	cases := []struct {
+		name    string
+		cluster []string
+		volume  *seaweedv1.VolumeSpec
+		topo    *seaweedv1.VolumeTopologySpec
+		want    []string
+	}{
+		{
+			name:    "cluster only",
+			cluster: []string{"-logJson"},
+			topo:    &seaweedv1.VolumeTopologySpec{Rack: "r", DataCenter: "d"},
+			want:    []string{"-logJson"},
+		},
+		{
+			name:    "volume overrides cluster",
+			cluster: []string{"-logJson"},
+			volume: &seaweedv1.VolumeSpec{
+				VolumeServerConfig: seaweedv1.VolumeServerConfig{
+					ComponentSpec: seaweedv1.ComponentSpec{LoggingArgs: []string{"-v=2"}},
+				},
+			},
+			topo: &seaweedv1.VolumeTopologySpec{Rack: "r", DataCenter: "d"},
+			want: []string{"-v=2"},
+		},
+		{
+			name:    "topology overrides volume and cluster",
+			cluster: []string{"-logJson"},
+			volume: &seaweedv1.VolumeSpec{
+				VolumeServerConfig: seaweedv1.VolumeServerConfig{
+					ComponentSpec: seaweedv1.ComponentSpec{LoggingArgs: []string{"-v=2"}},
+				},
+			},
+			topo: &seaweedv1.VolumeTopologySpec{
+				VolumeServerConfig: seaweedv1.VolumeServerConfig{
+					ComponentSpec: seaweedv1.ComponentSpec{LoggingArgs: []string{"-v=4"}},
+				},
+				Rack:       "r",
+				DataCenter: "d",
+			},
+			want: []string{"-v=4"},
+		},
+		{
+			name: "nothing set returns nil",
+			topo: &seaweedv1.VolumeTopologySpec{Rack: "r", DataCenter: "d"},
+			want: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &seaweedv1.Seaweed{
+				ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
+				Spec: seaweedv1.SeaweedSpec{
+					LoggingArgs: tc.cluster,
+					Volume:      tc.volume,
+				},
+			}
+			got := topologyLoggingArgs(m, tc.topo)
+			if !equalSlices(got, tc.want) {
+				t.Fatalf("topologyLoggingArgs = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestComponentLoggingArgsAllSpecs is a smoke test covering every
+// ComponentSpec embedding so a future regression that wires LoggingArgs
+// into a new spec but forgets to plumb it through is caught here.
+func TestComponentLoggingArgsAllSpecs(t *testing.T) {
+	args := []string{"-logJson"}
+	m := &seaweedv1.Seaweed{
+		ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
+		Spec: seaweedv1.SeaweedSpec{
+			LoggingArgs: args,
+			Master:      &seaweedv1.MasterSpec{Replicas: 1},
+			Volume:      &seaweedv1.VolumeSpec{},
+			Filer:       &seaweedv1.FilerSpec{Replicas: 1},
+			Admin:       &seaweedv1.AdminSpec{},
+			Worker:      &seaweedv1.WorkerSpec{Replicas: 1},
+			S3:          &seaweedv1.S3GatewaySpec{Replicas: 1},
+			SFTP:        &seaweedv1.SFTPSpec{Replicas: 1},
+		},
+	}
+	accessors := map[string]func() []string{
+		"master": func() []string { return m.BaseMasterSpec().LoggingArgs() },
+		"volume": func() []string { return m.BaseVolumeSpec().LoggingArgs() },
+		"filer":  func() []string { return m.BaseFilerSpec().LoggingArgs() },
+		"admin":  func() []string { return m.BaseAdminSpec().LoggingArgs() },
+		"worker": func() []string { return m.BaseWorkerSpec().LoggingArgs() },
+		"s3":     func() []string { return m.BaseS3Spec().LoggingArgs() },
+		"sftp":   func() []string { return m.BaseSFTPSpec().LoggingArgs() },
+	}
+	for name, fn := range accessors {
+		if got := fn(); !equalSlices(got, args) {
+			t.Errorf("%s LoggingArgs = %v, want %v", name, got, args)
+		}
+	}
+}
+
+// adminStartupScript intentionally `exec`s weed, so the logging prefix is
+// preceded by `exec ` rather than starting the string. This test guards the
+// previously-pinned admin invariant against accidental drift.
+func TestBuildAdminStartupScriptWithLoggingArgs(t *testing.T) {
+	m := &seaweedv1.Seaweed{
+		ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
+		Spec: seaweedv1.SeaweedSpec{
+			LoggingArgs: []string{"-logJson"},
+			Master:      &seaweedv1.MasterSpec{Replicas: 1},
+			Admin: &seaweedv1.AdminSpec{
+				CredentialsSecret: &corev1.LocalObjectReference{Name: "creds"},
+			},
+		},
+	}
+	got := buildAdminStartupScript(m)
+	// `-config_dir` is always present for admin (see securityConfigNeeded),
+	// so the assertion locks in the logging-arg ordering rather than the
+	// exact full prefix.
+	if !strings.Contains(got, "exec weed -logJson -config_dir=") {
+		t.Fatalf("expected admin script to place -logJson directly after weed, got %q", got)
+	}
+	if strings.Contains(got, "-logtostderr=true") {
+		t.Fatalf("default -logtostderr=true should be dropped, got %q", got)
+	}
+}
+
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary
- Adds `LoggingArgs []string` on `SeaweedSpec` (cluster-wide) and on every `ComponentSpec` (per-component override) so users can finally enable `-logJson`, raise `-v`, or set `-log_dir` etc. seaweedfs's logging flags must appear *before* the `weed` subcommand and are rejected through `ExtraArgs` today, leaving no operator-supported way to configure logging.
- Default behavior is unchanged: when `LoggingArgs` is empty everywhere the operator keeps emitting `-logtostderr=true`, matching what existing CRs already get. As soon as a user opts in, their flags fully own the logging prefix — passing both would trigger duplicate-flag conflicts in fla9.
- Component-level fully replaces cluster-level (same shape as `Tolerations`/`ExtraArgs`). `VolumeTopology` pods follow the established `topology → spec.volume → cluster` precedence (matches `getMetricsPort`/`getServiceSpec`).

Closes #256.

## Example
```yaml
apiVersion: seaweed.seaweedfs.com/v1
kind: Seaweed
metadata:
  name: test-cluster
spec:
  loggingArgs:
    - -logJson
    - -v=2
  master:
    loggingArgs:
      - -v=4   # only masters get verbose logs
```

## Test plan
- [x] `go test ./internal/... ./api/... ./test/helm/...` — passes
- [x] `go vet ./...` — clean
- [x] `make manifests generate helm-crd-copy` regenerates the CRD and helm chart with the new field
- [x] New unit tests in `internal/controller/logging_args_test.go` cover:
  - default `-logtostderr=true` preservation
  - logging args replace the default when set
  - prefix ordering (`weed <loggingArgs> -config_dir=… <subcommand>`)
  - cluster→component inheritance and component override
  - topology three-tier precedence
  - all seven component accessors (master/volume/filer/admin/worker/s3/sftp)
- [ ] e2e (requires Kind) — not run locally; CI will verify