### PR TITLE
feat: allow referencing s3 credential secrets across namespaces

### DIFF
--- a/api/v1/s3credentials_types.go
+++ b/api/v1/s3credentials_types.go
@@ -31,8 +31,8 @@ type S3IdentityRef struct {
 }
 
 // S3SecretRef points at the Kubernetes Secret that stores the access key and
-// secret key. The Secret must live in the same namespace as the
-// S3Credentials resource.
+// secret key. The Secret defaults to the same namespace as the S3Credentials
+// resource; set Namespace to reference a Secret in another namespace.
 //
 // On first reconcile the controller reads the Secret: if both keys are
 // already present it adopts them (registering the access key on the IAM user
@@ -41,11 +41,24 @@ type S3IdentityRef struct {
 // removed together with the IAM access key when the CR is deleted with
 // reclaimPolicy: Delete. A pre-existing (user-managed) Secret is never
 // deleted by the controller.
+//
+// Cross-namespace references are allowed and are NOT gated by an
+// admission-time SubjectAccessReview — gate access with Kubernetes RBAC on
+// the S3Credentials CRD if you need to restrict which namespaces may read a
+// Secret in another namespace (same model as seaweedRef). When Namespace is
+// set to a different namespace the Secret must already exist; the controller
+// will not create Secrets in foreign namespaces.
 type S3SecretRef struct {
 	// Name of the Secret. Defaults to .metadata.name of the S3Credentials.
 	// +optional
 	// +kubebuilder:validation:MaxLength=253
 	Name string `json:"name,omitempty"`
+
+	// Namespace of the Secret. Defaults to the namespace of the S3Credentials
+	// resource. When set to a different namespace the Secret must already
+	// exist; the controller will not create Secrets in foreign namespaces.
+	// +optional
+	Namespace string `json:"namespace,omitempty"`
 
 	// AccessKeyField is the key under which the access key id is stored in
 	// the Secret. Defaults to "accessKey".

--- a/config/crd/bases/seaweed.seaweedfs.com_s3credentials.yaml
+++ b/config/crd/bases/seaweed.seaweedfs.com_s3credentials.yaml
@@ -86,6 +86,8 @@ spec:
                   name:
                     maxLength: 253
                     type: string
+                  namespace:
+                    type: string
                   secretKeyField:
                     default: secretKey
                     minLength: 1

--- a/deploy/helm/templates/crd-seaweed.yaml
+++ b/deploy/helm/templates/crd-seaweed.yaml
@@ -360,6 +360,8 @@ spec:
                     name:
                       maxLength: 253
                       type: string
+                    namespace:
+                      type: string
                     secretKeyField:
                       default: secretKey
                       minLength: 1

--- a/internal/controller/iam_controller_test.go
+++ b/internal/controller/iam_controller_test.go
@@ -467,6 +467,58 @@ func TestS3Credentials_CrossNamespaceSecret_MissingEntersPending(t *testing.T) {
 	}
 }
 
+func TestS3Credentials_CrossNamespaceSecret_DeleteDoesNotTouchForeignSecret(t *testing.T) {
+	scheme := iamTestScheme(t)
+	// A secret in a foreign namespace that happens to carry the managed annotation
+	// (e.g. it is owned by a different S3Credentials in that namespace).
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "shared-secret",
+			Namespace:   "secrets",
+			Annotations: map[string]string{s3CredentialsManagedAnnotation: "true"},
+		},
+		Data: map[string][]byte{
+			defaultAccessKeyField: []byte("AKIAXNAMESPACE"),
+			defaultSecretKeyField: []byte("xnssecretkey"),
+		},
+	}
+	cred := &seaweedv1.S3Credentials{
+		ObjectMeta: metav1.ObjectMeta{Name: "alice-creds", Namespace: "media"},
+		Spec: seaweedv1.S3CredentialsSpec{
+			SeaweedRef:  iamSeaweedRef(),
+			IdentityRef: seaweedv1.S3IdentityRef{Name: "alice"},
+			SecretRef:   seaweedv1.S3SecretRef{Name: "shared-secret", Namespace: "secrets"},
+		},
+	}
+	cli := iamTestClient(t, scheme, newTestSeaweed(), existing, cred)
+	fa := newFakeIAMAdmin()
+	fa.seedUser("alice")
+	r := &S3CredentialsReconciler{Client: cli, Log: logf.FromContext(context.Background()), Scheme: scheme}
+	r.AdminFactory = fakeIAMFactory(fa)
+
+	key := types.NamespacedName{Namespace: "media", Name: "alice-creds"}
+	reconcileStable(t, r, key, 5)
+
+	var live seaweedv1.S3Credentials
+	if err := cli.Get(context.Background(), key, &live); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if err := cli.Delete(context.Background(), &live); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	reconcileOnce(t, r, key)
+
+	// IAM key should be removed (reclaimPolicy: Delete by default).
+	if k := fa.userKeys("alice"); len(k) != 0 {
+		t.Errorf("expected access key removed, got %v", k)
+	}
+	// The foreign Secret must be untouched.
+	var secret corev1.Secret
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "secrets", Name: "shared-secret"}, &secret); err != nil {
+		t.Fatalf("cross-namespace secret must not be deleted: %v", err)
+	}
+}
+
 func TestS3Credentials_Delete_RemovesKeyAndManagedSecret(t *testing.T) {
 	scheme := iamTestScheme(t)
 	cred := &seaweedv1.S3Credentials{

--- a/internal/controller/iam_controller_test.go
+++ b/internal/controller/iam_controller_test.go
@@ -377,6 +377,96 @@ func TestS3Credentials_WaitsForIdentity(t *testing.T) {
 	}
 }
 
+func TestS3Credentials_CrossNamespaceSecret(t *testing.T) {
+	scheme := iamTestScheme(t)
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared-secret", Namespace: "secrets"},
+		Data: map[string][]byte{
+			defaultAccessKeyField: []byte("AKIAXNAMESPACE"),
+			defaultSecretKeyField: []byte("xnssecretkey"),
+		},
+	}
+	cred := &seaweedv1.S3Credentials{
+		ObjectMeta: metav1.ObjectMeta{Name: "alice-creds", Namespace: "media"},
+		Spec: seaweedv1.S3CredentialsSpec{
+			SeaweedRef:  iamSeaweedRef(),
+			IdentityRef: seaweedv1.S3IdentityRef{Name: "alice"},
+			SecretRef:   seaweedv1.S3SecretRef{Name: "shared-secret", Namespace: "secrets"},
+		},
+	}
+	cli := iamTestClient(t, scheme, newTestSeaweed(), existing, cred)
+	fa := newFakeIAMAdmin()
+	fa.seedUser("alice")
+	r := &S3CredentialsReconciler{Client: cli, Log: logf.FromContext(context.Background()), Scheme: scheme}
+	r.AdminFactory = fakeIAMFactory(fa)
+
+	key := types.NamespacedName{Namespace: "media", Name: "alice-creds"}
+	reconcileStable(t, r, key, 5)
+
+	// Key from the cross-namespace Secret should be registered on the identity.
+	if keys := fa.userKeys("alice"); len(keys) != 1 || keys[0] != "AKIAXNAMESPACE" {
+		t.Fatalf("expected adopted key AKIAXNAMESPACE, got %v", keys)
+	}
+
+	// The original Secret in the foreign namespace must not be deleted or modified.
+	var secret corev1.Secret
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "secrets", Name: "shared-secret"}, &secret); err != nil {
+		t.Fatalf("cross-namespace secret should still exist: %v", err)
+	}
+	if secret.Annotations[s3CredentialsManagedAnnotation] == "true" {
+		t.Error("cross-namespace secret must not be marked managed")
+	}
+
+	// Status should reflect the qualified namespace/name.
+	var got seaweedv1.S3Credentials
+	if err := cli.Get(context.Background(), key, &got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status.SecretName != "secrets/shared-secret" {
+		t.Errorf("status.secretName = %q, want %q", got.Status.SecretName, "secrets/shared-secret")
+	}
+	if got.Status.Phase != seaweedv1.S3PhaseReady {
+		t.Errorf("phase = %q, want Ready", got.Status.Phase)
+	}
+}
+
+func TestS3Credentials_CrossNamespaceSecret_MissingEntersPending(t *testing.T) {
+	scheme := iamTestScheme(t)
+	cred := &seaweedv1.S3Credentials{
+		ObjectMeta: metav1.ObjectMeta{Name: "alice-creds", Namespace: "media"},
+		Spec: seaweedv1.S3CredentialsSpec{
+			SeaweedRef:  iamSeaweedRef(),
+			IdentityRef: seaweedv1.S3IdentityRef{Name: "alice"},
+			SecretRef:   seaweedv1.S3SecretRef{Name: "shared-secret", Namespace: "secrets"},
+		},
+	}
+	cli := iamTestClient(t, scheme, newTestSeaweed(), cred)
+	fa := newFakeIAMAdmin()
+	fa.seedUser("alice")
+	r := &S3CredentialsReconciler{Client: cli, Log: logf.FromContext(context.Background()), Scheme: scheme}
+	r.AdminFactory = fakeIAMFactory(fa)
+
+	key := types.NamespacedName{Namespace: "media", Name: "alice-creds"}
+	reconcileOnce(t, r, key) // adds finalizer
+	res := reconcileOnce(t, r, key)
+	if res.RequeueAfter == 0 {
+		t.Fatal("expected requeue while waiting for cross-namespace secret")
+	}
+
+	// No IAM key should be provisioned.
+	if keys := fa.userKeys("alice"); len(keys) != 0 {
+		t.Errorf("no IAM key should be provisioned while secret is missing, got %v", keys)
+	}
+
+	var got seaweedv1.S3Credentials
+	if err := cli.Get(context.Background(), key, &got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status.Phase != seaweedv1.S3PhasePending {
+		t.Errorf("phase = %q, want Pending", got.Status.Phase)
+	}
+}
+
 func TestS3Credentials_Delete_RemovesKeyAndManagedSecret(t *testing.T) {
 	scheme := iamTestScheme(t)
 	cred := &seaweedv1.S3Credentials{

--- a/internal/controller/s3credentials_controller.go
+++ b/internal/controller/s3credentials_controller.go
@@ -76,6 +76,10 @@ func (r *S3CredentialsReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if secretName == "" {
 		secretName = cred.Name
 	}
+	secretNamespace := cred.Spec.SecretRef.Namespace
+	if secretNamespace == "" {
+		secretNamespace = cred.Namespace
+	}
 
 	filer, adminKey, found, err := resolveSeaweedFiler(ctx, r.Client, cred.Spec.SeaweedRef, cred.Namespace)
 	if err != nil {
@@ -92,7 +96,7 @@ func (r *S3CredentialsReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	if !cred.DeletionTimestamp.IsZero() {
-		return r.handleDeletion(ctx, &cred, user, secretName, admin)
+		return r.handleDeletion(ctx, &cred, user, secretName, secretNamespace, admin)
 	}
 
 	if !controllerutil.ContainsFinalizer(&cred, s3CredentialsFinalizer) {
@@ -112,19 +116,28 @@ func (r *S3CredentialsReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return r.fail(ctx, &cred, "IdentityLookupFailed", err.Error())
 	}
 
-	return r.reconcileKey(ctx, &cred, user, secretName, iamUser, admin)
+	return r.reconcileKey(ctx, &cred, user, secretName, secretNamespace, iamUser, admin)
 }
 
 // reconcileKey ensures the identity owns exactly the access key recorded in
 // the Secret. It adopts a user-populated Secret, generates and stores a fresh
 // key pair when the Secret is missing/incomplete, and removes a previously
 // generated key it is replacing.
-func (r *S3CredentialsReconciler) reconcileKey(ctx context.Context, cred *seaweedv1.S3Credentials, user, secretName string, iamUser *swadmin.IAMUser, admin IAMAdmin) (ctrl.Result, error) {
+func (r *S3CredentialsReconciler) reconcileKey(ctx context.Context, cred *seaweedv1.S3Credentials, user, secretName, secretNamespace string, iamUser *swadmin.IAMUser, admin IAMAdmin) (ctrl.Result, error) {
 	akField, skField := credentialFields(cred)
 
-	secret, secretFound, err := r.getSecret(ctx, cred.Namespace, secretName)
+	crossNamespace := secretNamespace != cred.Namespace
+
+	secret, secretFound, err := r.getSecret(ctx, secretNamespace, secretName)
 	if err != nil {
 		return ctrl.Result{}, err
+	}
+
+	// A cross-namespace Secret must already exist; the controller never creates
+	// Secrets in foreign namespaces (owner references are namespace-scoped).
+	if crossNamespace && !secretFound {
+		return r.pending(ctx, cred, "SecretNotFound",
+			fmt.Sprintf("cross-namespace Secret %s/%s does not exist", secretNamespace, secretName))
 	}
 
 	var existingAK, existingSK string
@@ -150,7 +163,7 @@ func (r *S3CredentialsReconciler) reconcileKey(ctx context.Context, cred *seawee
 	}
 
 	// Mirror the key pair into the Secret.
-	if err := r.writeSecret(ctx, cred, secret, secretFound, secretName, akField, skField, desiredAK, desiredSK); err != nil {
+	if err := r.writeSecret(ctx, cred, secret, secretFound, secretName, secretNamespace, akField, skField, desiredAK, desiredSK); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -162,7 +175,11 @@ func (r *S3CredentialsReconciler) reconcileKey(ctx context.Context, cred *seawee
 	}
 
 	cred.Status.AccessKey = desiredAK
-	cred.Status.SecretName = secretName
+	if secretNamespace != cred.Namespace {
+		cred.Status.SecretName = secretNamespace + "/" + secretName
+	} else {
+		cred.Status.SecretName = secretName
+	}
 	cred.Status.ObservedGeneration = cred.Generation
 	cred.Status.Phase = seaweedv1.S3PhaseReady
 	setIAMCondition(&cred.Status.Conditions, cred.Generation, seaweedv1.S3ConditionReady, metav1.ConditionTrue, "Reconciled", "")
@@ -175,12 +192,12 @@ func (r *S3CredentialsReconciler) reconcileKey(ctx context.Context, cred *seawee
 // writeSecret creates or updates the Secret holding the key pair. A Secret the
 // operator creates is annotated as managed so the finalizer can delete it; a
 // pre-existing Secret is updated in place but never marked managed.
-func (r *S3CredentialsReconciler) writeSecret(ctx context.Context, cred *seaweedv1.S3Credentials, secret *corev1.Secret, secretFound bool, secretName, akField, skField, ak, sk string) error {
+func (r *S3CredentialsReconciler) writeSecret(ctx context.Context, cred *seaweedv1.S3Credentials, secret *corev1.Secret, secretFound bool, secretName, secretNamespace, akField, skField, ak, sk string) error {
 	if !secretFound {
 		newSecret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        secretName,
-				Namespace:   cred.Namespace,
+				Namespace:   secretNamespace,
 				Annotations: map[string]string{s3CredentialsManagedAnnotation: "true"},
 			},
 			Type: corev1.SecretTypeOpaque,
@@ -206,7 +223,7 @@ func (r *S3CredentialsReconciler) writeSecret(ctx context.Context, cred *seaweed
 	return r.Update(ctx, secret)
 }
 
-func (r *S3CredentialsReconciler) handleDeletion(ctx context.Context, cred *seaweedv1.S3Credentials, user, secretName string, admin IAMAdmin) (ctrl.Result, error) {
+func (r *S3CredentialsReconciler) handleDeletion(ctx context.Context, cred *seaweedv1.S3Credentials, user, secretName, secretNamespace string, admin IAMAdmin) (ctrl.Result, error) {
 	if !controllerutil.ContainsFinalizer(cred, s3CredentialsFinalizer) {
 		return ctrl.Result{}, nil
 	}
@@ -223,7 +240,7 @@ func (r *S3CredentialsReconciler) handleDeletion(ctx context.Context, cred *seaw
 				return ctrl.Result{}, err
 			}
 		}
-		if err := r.deleteManagedSecret(ctx, cred.Namespace, secretName); err != nil {
+		if err := r.deleteManagedSecret(ctx, secretNamespace, secretName); err != nil {
 			return ctrl.Result{}, err
 		}
 	} else {
@@ -231,7 +248,7 @@ func (r *S3CredentialsReconciler) handleDeletion(ctx context.Context, cred *seaw
 		// reference, so removing the finalizer would let garbage collection
 		// delete it along with the access key we are deliberately keeping.
 		// Orphan it first so both the key and the Secret survive.
-		if err := r.orphanManagedSecret(ctx, cred.Namespace, secretName); err != nil {
+		if err := r.orphanManagedSecret(ctx, secretNamespace, secretName); err != nil {
 			return ctrl.Result{}, err
 		}
 	}

--- a/internal/controller/s3credentials_controller.go
+++ b/internal/controller/s3credentials_controller.go
@@ -240,16 +240,22 @@ func (r *S3CredentialsReconciler) handleDeletion(ctx context.Context, cred *seaw
 				return ctrl.Result{}, err
 			}
 		}
-		if err := r.deleteManagedSecret(ctx, secretNamespace, secretName); err != nil {
-			return ctrl.Result{}, err
+		// Never touch a Secret in a foreign namespace. The controller did not
+		// create it there and another S3Credentials may legitimately own it.
+		if secretNamespace == cred.Namespace {
+			if err := r.deleteManagedSecret(ctx, secretNamespace, secretName); err != nil {
+				return ctrl.Result{}, err
+			}
 		}
 	} else {
 		// Retain: an operator-created Secret carries a controller owner
 		// reference, so removing the finalizer would let garbage collection
 		// delete it along with the access key we are deliberately keeping.
 		// Orphan it first so both the key and the Secret survive.
-		if err := r.orphanManagedSecret(ctx, secretNamespace, secretName); err != nil {
-			return ctrl.Result{}, err
+		if secretNamespace == cred.Namespace {
+			if err := r.orphanManagedSecret(ctx, secretNamespace, secretName); err != nil {
+				return ctrl.Result{}, err
+			}
 		}
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * S3Credentials can reference Secrets in other namespaces; referenced Secrets must already exist. Status records cross-namespace secrets as "<namespace>/<name>".

* **Bug Fixes**
  * Controller will not modify or delete Secrets located in a foreign namespace during reconcile or deletion.

* **Documentation**
  * CRD schema updated to include an optional secretRef.namespace field.

* **Tests**
  * Added unit coverage for cross-namespace Secret handling and related status/reclaim behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->