### PR TITLE
fix(bucket): sign admin Bearer tokens so Bucket CRDs reconcile on secured clusters

### DIFF
--- a/internal/controller/bucket_admin.go
+++ b/internal/controller/bucket_admin.go
@@ -75,8 +75,10 @@ type BucketCollectionStats struct {
 }
 
 // BucketAdminFactory creates a BucketAdmin for a target Seaweed cluster.
+// signingKey is jwt.filer_signing.key from the cluster's security.toml
+// (nil/empty when the cluster does not require an admin Bearer token).
 // Replaceable in tests.
-type BucketAdminFactory func(masters, filer string, log logr.Logger) (BucketAdmin, error)
+type BucketAdminFactory func(masters, filer string, signingKey []byte, log logr.Logger) (BucketAdmin, error)
 
 // Sentinel errors returned by BucketAdmin implementations.
 var (
@@ -103,14 +105,19 @@ var (
 // per-bucket reconciles don't fan out further than the worker count.
 type swadminBucketAdmin struct {
 	sa  *swadmin.SeaweedAdmin
+	iam *swadmin.IAMClient
 	log logr.Logger
 	mu  sync.Mutex
 }
 
-// NewSwadminBucketAdmin returns a BucketAdmin that runs `weed shell` commands.
-func NewSwadminBucketAdmin(masters, filer string, log logr.Logger) (BucketAdmin, error) {
+// NewSwadminBucketAdmin returns a BucketAdmin. Bucket lifecycle commands run
+// through the embedded `weed shell` (filer gRPC, unauthenticated). Access
+// grants go through swadmin.IAMClient instead: those hit the filer's IAM gRPC
+// service, which requires an admin Bearer token signed with signingKey
+// (jwt.filer_signing.key) once the cluster configures one.
+func NewSwadminBucketAdmin(masters, filer string, signingKey []byte, log logr.Logger) (BucketAdmin, error) {
 	sa := swadmin.NewSeaweedAdmin(masters, filer, io.Discard)
-	return &swadminBucketAdmin{sa: sa, log: log}, nil
+	return &swadminBucketAdmin{sa: sa, iam: swadmin.NewIAMClient(filer, signingKey), log: log}, nil
 }
 
 func (a *swadminBucketAdmin) run(cmd string) (string, error) {
@@ -220,8 +227,7 @@ func (a *swadminBucketAdmin) SetAccess(ctx context.Context, name, user, actions 
 	if actions == "" {
 		actions = "none"
 	}
-	_, err := a.run(fmt.Sprintf("s3.bucket.access -name %s -user %s -access %s", name, user, actions))
-	return err
+	return a.iam.SetBucketAccess(ctx, name, user, actions)
 }
 
 func (a *swadminBucketAdmin) Configure(ctx context.Context, prefix string, args []string) error {

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -155,7 +155,11 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	masters := getMasterPeersString(&seaweed)
 	filer := getFilerAddress(&seaweed)
-	admin, err := r.getAdmin(seaweedNS, seaweed.Name, masters, filer, log)
+	adminKey, err := loadFilerAdminSigningKey(ctx, r.Client, &seaweed)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	admin, err := r.getAdmin(seaweedNS, seaweed.Name, masters, filer, adminKey, log)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -413,10 +417,13 @@ func (r *BucketReconciler) clearCondition(bucket *seaweedv1.Bucket, condType str
 	meta.RemoveStatusCondition(&bucket.Status.Conditions, condType)
 }
 
-// getAdmin returns a cached BucketAdmin for the (Seaweed CR, masters, filer)
-// tuple. See the comment on adminCache about the goroutine-leak trade-off.
-func (r *BucketReconciler) getAdmin(ns, name, masters, filer string, log logr.Logger) (BucketAdmin, error) {
-	key := ns + "/" + name + "@" + masters + "|" + filer
+// getAdmin returns a cached BucketAdmin for the (Seaweed CR, masters, filer,
+// signing key) tuple. The signing-key fingerprint is part of the cache key so
+// rotating jwt.filer_signing.key (editing the security ConfigMap) yields a
+// fresh admin rather than a stale Bearer issuer. See the comment on adminCache
+// about the goroutine-leak trade-off.
+func (r *BucketReconciler) getAdmin(ns, name, masters, filer string, signingKey []byte, log logr.Logger) (BucketAdmin, error) {
+	key := ns + "/" + name + "@" + masters + "|" + filer + "|" + signingKeyFingerprint(signingKey)
 	r.adminMu.Lock()
 	defer r.adminMu.Unlock()
 	if r.adminCache == nil {
@@ -425,7 +432,7 @@ func (r *BucketReconciler) getAdmin(ns, name, masters, filer string, log logr.Lo
 	if a, ok := r.adminCache[key]; ok {
 		return a, nil
 	}
-	a, err := r.AdminFactory(masters, filer, log)
+	a, err := r.AdminFactory(masters, filer, signingKey, log)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controller/bucket_controller_test.go
+++ b/internal/controller/bucket_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -184,9 +185,34 @@ func testReconcilerNoGrants(t *testing.T, fa *fakeBucketAdmin, objs ...client.Ob
 		Client: cli,
 		Log:    logf.FromContext(context.Background()),
 		Scheme: scheme,
-		AdminFactory: func(_, _ string, _ logr.Logger) (BucketAdmin, error) {
+		AdminFactory: func(_, _ string, _ []byte, _ logr.Logger) (BucketAdmin, error) {
 			return fa, nil
 		},
+	}
+	return r, cli
+}
+
+// testReconcilerWithFactory is testReconciler with a caller-supplied admin
+// factory, so a test can observe the arguments the reconciler passes to it.
+func testReconcilerWithFactory(t *testing.T, factory BucketAdminFactory, objs ...client.Object) (*BucketReconciler, client.Client) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("clientgoscheme: %v", err)
+	}
+	if err := seaweedv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("seaweedv1: %v", err)
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(append(defaultTestRefGrants(), objs...)...).
+		WithStatusSubresource(&seaweedv1.Bucket{}).
+		Build()
+	r := &BucketReconciler{
+		Client:       cli,
+		Log:          logf.FromContext(context.Background()),
+		Scheme:       scheme,
+		AdminFactory: factory,
 	}
 	return r, cli
 }
@@ -231,6 +257,58 @@ func newTestBucket(name string) *seaweedv1.Bucket {
 			ReclaimPolicy: seaweedv1.BucketReclaimRetain,
 			Versioning:    seaweedv1.VersioningOff,
 		},
+	}
+}
+
+// TestReconcile_PassesAdminSigningKeyToFactory pins the issue #265 fix: the
+// reconciler must read jwt.filer_signing.key from the cluster's rendered
+// security ConfigMap and hand it to the BucketAdminFactory. Without it,
+// s3.bucket.access (and every filer IAM call) is sent unauthenticated and the
+// bucket stays Failed with reason AccessFailed.
+func TestReconcile_PassesAdminSigningKeyToFactory(t *testing.T) {
+	sw := newTestSeaweedWithFiler()
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: SecurityConfigMapName(sw), Namespace: sw.Namespace},
+		Data:       map[string]string{"security.toml": "[jwt.filer_signing]\nkey = \"abc123==\"\n"},
+	}
+	bucket := newTestBucket("photos")
+	bucket.Finalizers = []string{BucketFinalizer}
+
+	fa := newFakeAdmin()
+	var gotKey []byte
+	r, _ := testReconcilerWithFactory(t, func(_, _ string, key []byte, _ logr.Logger) (BucketAdmin, error) {
+		gotKey = key
+		return fa, nil
+	}, sw, cm, bucket)
+
+	key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
+	reconcileUntilStable(t, r, key, 5)
+
+	if string(gotKey) != "abc123==" {
+		t.Fatalf("admin signing key passed to factory = %q, want %q", string(gotKey), "abc123==")
+	}
+}
+
+// TestReconcile_NoSecurityConfigPassesEmptyKey pins the unauthenticated path:
+// a cluster with no rendered security ConfigMap hands the factory an empty key
+// so the filer IAM calls stay unauthenticated, matching its no-key branch.
+func TestReconcile_NoSecurityConfigPassesEmptyKey(t *testing.T) {
+	sw := newTestSeaweedWithFiler() // filer present, but no security ConfigMap seeded
+	bucket := newTestBucket("photos")
+	bucket.Finalizers = []string{BucketFinalizer}
+
+	fa := newFakeAdmin()
+	gotKey := []byte("sentinel")
+	r, _ := testReconcilerWithFactory(t, func(_, _ string, key []byte, _ logr.Logger) (BucketAdmin, error) {
+		gotKey = key
+		return fa, nil
+	}, sw, bucket)
+
+	key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
+	reconcileUntilStable(t, r, key, 5)
+
+	if len(gotKey) != 0 {
+		t.Fatalf("expected empty key when no security ConfigMap, got %q", string(gotKey))
 	}
 }
 

--- a/internal/controller/bucket_usage.go
+++ b/internal/controller/bucket_usage.go
@@ -108,7 +108,12 @@ func (r *BucketReconciler) refreshClusterUsage(ctx context.Context, log logr.Log
 	}
 	masters := getMasterPeersString(&seaweed)
 	filer := getFilerAddress(&seaweed)
-	admin, err := r.getAdmin(seaweedNS, seaweedName, masters, filer, r.Log)
+	adminKey, err := loadFilerAdminSigningKey(ctx, r.Client, &seaweed)
+	if err != nil {
+		log.Error(err, "load admin signing key for usage refresh", "seaweed", seaweedName)
+		return
+	}
+	admin, err := r.getAdmin(seaweedNS, seaweedName, masters, filer, adminKey, r.Log)
 	if err != nil {
 		log.Error(err, "build admin for usage refresh", "seaweed", seaweedName)
 		return

--- a/internal/controller/swadmin/iam_client.go
+++ b/internal/controller/swadmin/iam_client.go
@@ -3,6 +3,7 @@ package swadmin
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -11,8 +12,10 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/pb/iam_pb"
 	"github.com/seaweedfs/seaweedfs/weed/security"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 // iamRequestTimeout caps every IAM gRPC call so a reconcile can't hang on an
@@ -278,6 +281,62 @@ func (c *IAMClient) DetachPolicy(ctx context.Context, user, policy string) error
 		_, err = client.UpdateUser(ctx, &iam_pb.UpdateUserRequest{Username: user, Identity: id})
 		return err
 	})
+}
+
+// SetBucketAccess grants user the comma-separated actions on bucket, mirroring
+// `weed shell s3.bucket.access`. Bucket grants are stored on the identity as
+// "Action:bucket" entries; passing "none" (or an empty string) strips the
+// user's grants on this bucket without deleting the identity or its other
+// grants. The user is auto-created when absent. Going through IAMClient (rather
+// than the shell) means the call carries the admin Bearer token, which the
+// filer's IAM service requires once jwt.filer_signing.key is set.
+func (c *IAMClient) SetBucketAccess(ctx context.Context, bucket, user, actions string) error {
+	defer c.lockUser(user)()
+	return c.withClient(ctx, func(ctx context.Context, client iam_pb.SeaweedIdentityAccessManagementClient) error {
+		resp, err := client.GetUser(ctx, &iam_pb.GetUserRequest{Username: user})
+		isNewUser := false
+		if err != nil {
+			if st, ok := status.FromError(err); !ok || st.Code() != codes.NotFound {
+				return err
+			}
+			isNewUser = true
+		}
+		id := resp.GetIdentity()
+		if isNewUser || id == nil {
+			id = &iam_pb.Identity{Name: user}
+			isNewUser = true
+		}
+		setBucketActions(id, bucket, actions)
+		if isNewUser {
+			_, err = client.CreateUser(ctx, &iam_pb.CreateUserRequest{Identity: id})
+			return err
+		}
+		_, err = client.UpdateUser(ctx, &iam_pb.UpdateUserRequest{Username: user, Identity: id})
+		return err
+	})
+}
+
+// setBucketActions rewrites id's bucket-scoped actions: it drops existing
+// "X:bucket" entries and appends one per requested action, leaving grants on
+// other buckets untouched. An empty or "none" actions string only strips.
+// Mirrors weed/shell updateBucketActions; the CRD enum constrains actions to
+// the canonical set so no casing fixup is needed here.
+func setBucketActions(id *iam_pb.Identity, bucket, actions string) {
+	suffix := ":" + bucket
+	kept := make([]string, 0, len(id.Actions))
+	for _, a := range id.Actions {
+		if !strings.HasSuffix(a, suffix) {
+			kept = append(kept, a)
+		}
+	}
+	if actions != "" && !strings.EqualFold(actions, "none") {
+		for _, a := range strings.Split(actions, ",") {
+			if a = strings.TrimSpace(a); a != "" {
+				kept = append(kept, a+suffix)
+			}
+		}
+	}
+	id.Actions = kept
 }
 
 // PutPolicy creates or replaces a named policy with the given AWS-style JSON

--- a/internal/controller/swadmin/iam_client_bucket_test.go
+++ b/internal/controller/swadmin/iam_client_bucket_test.go
@@ -1,0 +1,227 @@
+package swadmin
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/iam_pb"
+	"github.com/seaweedfs/seaweedfs/weed/security"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// TestIAMClient_SetBucketAccess_SendsBearer reproduces
+// https://github.com/seaweedfs/seaweedfs-operator/issues/265 end to end:
+// granting bucket access hits the filer's IAM gRPC service, which rejects
+// unauthenticated calls once jwt.filer_signing.key is set. With the key wired,
+// SetBucketAccess presents a valid admin Bearer token and the grant lands. The
+// previous bucket controller sent none, so every access reconcile failed and
+// Bucket CRDs stuck in Failed with reason AccessFailed.
+func TestIAMClient_SetBucketAccess_SendsBearer(t *testing.T) {
+	key := []byte("test-jwt-signing-key")
+	srv := newBucketAccessIAM(key)
+	filer := startBucketAccessIAM(t, srv)
+
+	c := NewIAMClient(filer, key)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := c.SetBucketAccess(ctx, "photos", "uploader", "Read,Write"); err != nil {
+		t.Fatalf("SetBucketAccess: %v", err)
+	}
+	if !srv.authSeen {
+		t.Fatal("filer IAM service never saw a valid Bearer token")
+	}
+	assertActions(t, srv.actions("uploader"), "Read:photos", "Write:photos")
+}
+
+// TestIAMClient_SetBucketAccess_NoKeyUnauthenticated pins the failing path the
+// fix repairs: with no signing key the call carries no Bearer token and the
+// filer rejects it — the AccessFailed symptom on secured clusters.
+func TestIAMClient_SetBucketAccess_NoKeyUnauthenticated(t *testing.T) {
+	srv := newBucketAccessIAM([]byte("test-jwt-signing-key"))
+	filer := startBucketAccessIAM(t, srv)
+
+	c := NewIAMClient(filer, nil) // no signing key wired
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := c.SetBucketAccess(ctx, "photos", "uploader", "Read,Write")
+	if err == nil {
+		t.Fatal("expected SetBucketAccess to fail without a signing key")
+	}
+	if st, _ := status.FromError(err); st.Code() != codes.Unauthenticated {
+		t.Fatalf("expected codes.Unauthenticated, got: %v", err)
+	}
+	if srv.authSeen {
+		t.Fatal("filer should not have seen a valid Bearer token")
+	}
+}
+
+// TestIAMClient_SetBucketAccess_PreservesOtherGrants confirms the
+// read-modify-write only rewrites the target bucket's actions: grants on other
+// buckets and attached policies survive a set, and "none" strips just this
+// bucket. Mirrors `weed shell s3.bucket.access`.
+func TestIAMClient_SetBucketAccess_PreservesOtherGrants(t *testing.T) {
+	key := []byte("test-jwt-signing-key")
+	srv := newBucketAccessIAM(key, &iam_pb.Identity{
+		Name:        "uploader",
+		Actions:     []string{"Read:other", "Admin:photos"},
+		PolicyNames: []string{"p1"},
+	})
+	filer := startBucketAccessIAM(t, srv)
+
+	c := NewIAMClient(filer, key)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := c.SetBucketAccess(ctx, "photos", "uploader", "List"); err != nil {
+		t.Fatalf("SetBucketAccess set: %v", err)
+	}
+	assertActions(t, srv.actions("uploader"), "Read:other", "List:photos")
+
+	if err := c.SetBucketAccess(ctx, "photos", "uploader", "none"); err != nil {
+		t.Fatalf("SetBucketAccess none: %v", err)
+	}
+	assertActions(t, srv.actions("uploader"), "Read:other")
+	if got := srv.policies("uploader"); len(got) != 1 || got[0] != "p1" {
+		t.Fatalf("attached policies clobbered: %v", got)
+	}
+}
+
+func assertActions(t *testing.T, got []string, want ...string) {
+	t.Helper()
+	w := make(map[string]bool, len(want))
+	for _, a := range want {
+		w[a] = true
+	}
+	if len(got) != len(w) {
+		t.Fatalf("actions = %v, want %v", got, want)
+	}
+	for _, a := range got {
+		if !w[a] {
+			t.Fatalf("unexpected action %q in %v", a, got)
+		}
+	}
+}
+
+// startBucketAccessIAM serves srv on an ephemeral port and returns the filer
+// HTTP host:port the operator passes to NewIAMClient (seaweedfs derives the
+// gRPC port as +10000).
+func startBucketAccessIAM(t *testing.T, srv *bucketAccessIAM) string {
+	t.Helper()
+	gsrv := grpc.NewServer()
+	iam_pb.RegisterSeaweedIdentityAccessManagementServer(gsrv, srv)
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(gsrv.Stop)
+	go func() { _ = gsrv.Serve(lis) }()
+	grpcPort := lis.Addr().(*net.TCPAddr).Port
+	if grpcPort < 10001 {
+		t.Skipf("ephemeral gRPC port %d too low to map to a valid HTTP port", grpcPort)
+	}
+	return net.JoinHostPort("127.0.0.1", strconv.Itoa(grpcPort-10000))
+}
+
+// bucketAccessIAM is an in-process IAM gRPC server that rejects any call
+// lacking a valid admin Bearer token (mirroring the filer's checkAdminAuth when
+// jwt.filer_signing.key is set) and keeps identities in memory, so the
+// GetUser→mutate→Create/Update sequence in SetBucketAccess can be asserted.
+type bucketAccessIAM struct {
+	iam_pb.UnimplementedSeaweedIdentityAccessManagementServer
+	key security.SigningKey
+
+	mu       sync.Mutex
+	users    map[string]*iam_pb.Identity
+	authSeen bool
+	authErr  error
+}
+
+func newBucketAccessIAM(key []byte, seed ...*iam_pb.Identity) *bucketAccessIAM {
+	s := &bucketAccessIAM{key: security.SigningKey(key), users: map[string]*iam_pb.Identity{}}
+	for _, id := range seed {
+		s.users[id.Name] = id
+	}
+	return s
+}
+
+func (s *bucketAccessIAM) auth(ctx context.Context) error {
+	md, _ := metadata.FromIncomingContext(ctx)
+	hdr := md.Get("authorization")
+	if len(hdr) == 0 {
+		s.authErr = status.Error(codes.Unauthenticated, "missing authorization metadata")
+		return s.authErr
+	}
+	parts := strings.Fields(hdr[0])
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+		s.authErr = status.Error(codes.Unauthenticated, "authorization header must use Bearer scheme")
+		return s.authErr
+	}
+	parsed, err := security.DecodeJwt(s.key, security.EncodedJwt(parts[1]), &security.SeaweedFilerAdminClaims{})
+	if err != nil || parsed == nil || !parsed.Valid {
+		s.authErr = status.Error(codes.Unauthenticated, "invalid admin token")
+		return s.authErr
+	}
+	s.authSeen = true
+	return nil
+}
+
+func (s *bucketAccessIAM) GetUser(ctx context.Context, req *iam_pb.GetUserRequest) (*iam_pb.GetUserResponse, error) {
+	if err := s.auth(ctx); err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	id, ok := s.users[req.Username]
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "user %s not found", req.Username)
+	}
+	return &iam_pb.GetUserResponse{Identity: id}, nil
+}
+
+func (s *bucketAccessIAM) CreateUser(ctx context.Context, req *iam_pb.CreateUserRequest) (*iam_pb.CreateUserResponse, error) {
+	if err := s.auth(ctx); err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.users[req.Identity.Name] = req.Identity
+	return &iam_pb.CreateUserResponse{}, nil
+}
+
+func (s *bucketAccessIAM) UpdateUser(ctx context.Context, req *iam_pb.UpdateUserRequest) (*iam_pb.UpdateUserResponse, error) {
+	if err := s.auth(ctx); err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.users[req.Username] = req.Identity
+	return &iam_pb.UpdateUserResponse{}, nil
+}
+
+func (s *bucketAccessIAM) actions(user string) []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if id, ok := s.users[user]; ok {
+		return append([]string(nil), id.Actions...)
+	}
+	return nil
+}
+
+func (s *bucketAccessIAM) policies(user string) []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if id, ok := s.users[user]; ok {
+		return append([]string(nil), id.PolicyNames...)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Same root cause as #257 (fixed for IAM controllers in #259) — the `Bucket` controller was never covered by that fix.

The operator renders `jwt.filer_signing.key` into the `seaweedfs-security-config` ConfigMap whenever `spec.filer` is set, and the filer's IAM gRPC service (`checkAdminAuth`) then rejects unauthenticated calls. Bucket access grants were applied via the embedded shell's `s3.bucket.access`, which sent no Bearer token — so any `Bucket` with `spec.access` entries stuck in `Failed` with reason `AccessFailed` and `Unauthenticated desc = missing authorization metadata`.

## Fix

- Route bucket access grants through `swadmin.IAMClient.SetBucketAccess` instead of the embedded shell. `IAMClient` is the same authenticated `GetUser`/`CreateUser`/`UpdateUser` path the IAM controllers already use (added in #259); it stamps a freshly minted admin Bearer token onto each call's **context metadata**. `SetBucketAccess` reproduces `s3.bucket.access`'s read-modify-write on the identity's `Action:bucket` entries, so behavior matches the shell command.
- The reconciler reads the signing key from the security ConfigMap via the existing `loadFilerAdminSigningKey` helper and threads it through `BucketAdminFactory` (mirrors `IAMAdminFactory` in #259). The key fingerprint joins the admin cache key so rotating the key invalidates the cached admin.

### Why context metadata rather than viper or per-RPC dial credentials

The first revision published the key into the process-global `viper` config so the shell's own `iamAdminAuthContext` would mint the token. As review pointed out, mutating the global `viper` map at reconcile time risks a concurrent map read/write panic. Per-call context metadata (what `IAMClient` already does) avoids global state entirely. It is also immune to seaweedfs's shared, per-address gRPC connection cache — a dial-time `grpc.WithPerRPCCredentials` would be silently dropped whenever an IAM controller dialed the same filer first.

## Tests

- `swadmin`: `TestIAMClient_SetBucketAccess_SendsBearer` / `_NoKeyUnauthenticated` reproduce the bug end to end against an in-process IAM gRPC service that requires a valid admin Bearer token — with the key the grant lands, without it the call fails `Unauthenticated` (the `AccessFailed` symptom). `_PreservesOtherGrants` checks the read-modify-write only rewrites the target bucket and leaves other grants/policies intact.
- `internal/controller`: `TestReconcile_PassesAdminSigningKeyToFactory` / `_NoSecurityConfigPassesEmptyKey` pin the ConfigMap → factory plumbing.
- `go test ./internal/controller/...` green (`-race` clean).

Fixes #265

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Bucket access control now uses JWT-authenticated IAM operations for improved security.

* **Bug Fixes**
  * Admin operations now properly support signing key rotation by including key fingerprint in configuration caching.

* **Tests**
  * Added comprehensive test coverage for JWT signing key management and bucket access control workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->