### PR TITLE
fix(swadmin): pass context to pb.WithGrpcClient

### DIFF
--- a/internal/controller/swadmin/iam_client.go
+++ b/internal/controller/swadmin/iam_client.go
@@ -93,7 +93,7 @@ func NewIAMClient(filer string, adminSigningKey []byte) *IAMClient {
 // and invokes fn. Errors are returned verbatim so callers can classify gRPC
 // status codes.
 func (c *IAMClient) withClient(ctx context.Context, fn func(ctx context.Context, client iam_pb.SeaweedIdentityAccessManagementClient) error) error {
-	return pb.WithGrpcClient(false, 0, func(conn *grpc.ClientConn) error {
+	return pb.WithGrpcClient(ctx, false, 0, func(conn *grpc.ClientConn) error {
 		callCtx, cancel := context.WithTimeout(c.authContext(ctx), iamRequestTimeout)
 		defer cancel()
 		return fn(callCtx, iam_pb.NewSeaweedIdentityAccessManagementClient(conn))


### PR DESCRIPTION
## Problem

The `Create and publish Docker image` workflow on `master` is failing in the `go build` step ([run 27121649317](https://github.com/seaweedfs/seaweedfs-operator/actions/runs/27121649317/job/80039997127)) with a compile error:

```
internal/controller/swadmin/iam_client.go:96:27: cannot use false (constant of type bool) as context.Context value in argument to pb.WithGrpcClient: bool does not implement context.Context (missing method Deadline)
```

## Root cause

The pinned SeaweedFS dependency (`v0.0.0-20260608063757-78da9572aee7`) changed `pb.WithGrpcClient` to take a `context.Context` as its **first** parameter:

```go
// before
func WithGrpcClient(streamingMode bool, signature int32, fn func(*grpc.ClientConn) error, address string, waitForReady bool, opts ...grpc.DialOption) error
// after
func WithGrpcClient(ctx context.Context, streamingMode bool, signature int32, fn func(*grpc.ClientConn) error, address string, waitForReady bool, opts ...grpc.DialOption) error
```

Every argument shifted one position, producing the cascade of type-mismatch errors at lines 96 and 100.

## Fix

Pass the already-available reconcile `ctx` as the new first argument. `WithGrpcClient` is the only affected call site in the repo.

## Verification

- `CGO_ENABLED=0 go build ./...` — clean
- `CGO_ENABLED=0 GOOS=linux go build -o manager cmd/main.go` (the exact Dockerfile command) — OK
- `go vet ./internal/controller/swadmin/` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal gRPC client connection handling to ensure proper context propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->