### PR TITLE
fix(bucket): only delete the physical bucket a CR actually owns

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,9 @@ Supported per-bucket configuration:
   name and is not configurable.
 - `reclaimPolicy`: `Retain` (default) leaves data untouched on CR
   delete; `Delete` removes the bucket on CR delete (refused while
-  Object Lock retention applies).
+  Object Lock retention applies). `Delete` only removes a bucket this
+  CR actually created — a CR whose adoption was refused
+  (`BucketAlreadyExists`) never deletes a bucket another resource owns.
 - Cross-namespace `clusterRef` is **denied by default**: it resolves only
   when a [`ResourceReferenceGrant`](#cross-namespace-references-resourcereferencegrant)
   in the target `Seaweed`'s namespace permits it. The bucket stays

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -352,11 +352,8 @@ func (r *BucketReconciler) handleDeletion(ctx context.Context, bucket *seaweedv1
 
 	bucket.Status.Phase = seaweedv1.BucketPhaseTerminating
 
-	// Only delete the physical bucket this CR actually created. A CR that never
-	// owned one — Status.BucketName is empty, e.g. adoption was refused because
-	// another namespace's Bucket already resolved to the same name — must not
-	// delete a bucket it does not own (#272). The earlier rename guard ensures
-	// Status.BucketName is otherwise equal to bucketName here.
+	// Only delete the bucket this CR created: Status.BucketName is empty when
+	// adoption was refused, so such a CR must not delete a bucket it doesn't own.
 	if bucket.Spec.ReclaimPolicy == seaweedv1.BucketReclaimDelete && bucket.Status.BucketName == bucketName {
 		err := admin.DeleteBucket(ctx, bucketName)
 		switch {

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -352,7 +352,12 @@ func (r *BucketReconciler) handleDeletion(ctx context.Context, bucket *seaweedv1
 
 	bucket.Status.Phase = seaweedv1.BucketPhaseTerminating
 
-	if bucket.Spec.ReclaimPolicy == seaweedv1.BucketReclaimDelete {
+	// Only delete the physical bucket this CR actually created. A CR that never
+	// owned one — Status.BucketName is empty, e.g. adoption was refused because
+	// another namespace's Bucket already resolved to the same name — must not
+	// delete a bucket it does not own (#272). The earlier rename guard ensures
+	// Status.BucketName is otherwise equal to bucketName here.
+	if bucket.Spec.ReclaimPolicy == seaweedv1.BucketReclaimDelete && bucket.Status.BucketName == bucketName {
 		err := admin.DeleteBucket(ctx, bucketName)
 		switch {
 		case err == nil, errors.Is(err, ErrBucketNotFound):

--- a/internal/controller/bucket_controller_test.go
+++ b/internal/controller/bucket_controller_test.go
@@ -525,11 +525,9 @@ func TestReconcile_DeleteOnDelete_CallsDeleteBucket(t *testing.T) {
 	}
 }
 
-// TestReconcile_DeleteOnDelete_NonOwnerDoesNotDeleteForeignBucket pins #272: a
-// Bucket whose adoption was refused (the physical bucket exists but this CR
-// never created it, so Status.BucketName is empty) must not delete that bucket
-// on its own deletion — even with ReclaimPolicy=Delete — because another CR owns
-// it. It just drops the finalizer.
+// TestReconcile_DeleteOnDelete_NonOwnerDoesNotDeleteForeignBucket: a Bucket whose
+// adoption was refused (Status.BucketName empty) must not delete the existing
+// bucket on its own deletion under ReclaimPolicy=Delete; it just drops the finalizer.
 func TestReconcile_DeleteOnDelete_NonOwnerDoesNotDeleteForeignBucket(t *testing.T) {
 	now := metav1.Now()
 	bucket := newTestBucket("photos")

--- a/internal/controller/bucket_controller_test.go
+++ b/internal/controller/bucket_controller_test.go
@@ -525,6 +525,45 @@ func TestReconcile_DeleteOnDelete_CallsDeleteBucket(t *testing.T) {
 	}
 }
 
+// TestReconcile_DeleteOnDelete_NonOwnerDoesNotDeleteForeignBucket pins #272: a
+// Bucket whose adoption was refused (the physical bucket exists but this CR
+// never created it, so Status.BucketName is empty) must not delete that bucket
+// on its own deletion — even with ReclaimPolicy=Delete — because another CR owns
+// it. It just drops the finalizer.
+func TestReconcile_DeleteOnDelete_NonOwnerDoesNotDeleteForeignBucket(t *testing.T) {
+	now := metav1.Now()
+	bucket := newTestBucket("photos")
+	bucket.Spec.ReclaimPolicy = seaweedv1.BucketReclaimDelete
+	bucket.Status.BucketName = "" // adoption was refused; this CR owns nothing
+	bucket.Finalizers = []string{BucketFinalizer}
+	bucket.DeletionTimestamp = &now
+
+	fa := newFakeAdmin()
+	fa.existsResp["photos"] = true // the bucket exists, owned by another CR
+	r, cli := testReconciler(t, fa, newTestSeaweed(), bucket)
+	key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	for _, c := range fa.calls {
+		if strings.HasPrefix(c, "Delete:") {
+			t.Errorf("a non-owning Bucket must not call DeleteBucket, got: %s", c)
+		}
+	}
+	if _, ok := fa.existsResp["photos"]; !ok {
+		t.Error("the foreign bucket must survive deletion of a non-owning CR")
+	}
+	// The CR itself is reaped once the finalizer is removed.
+	got := &seaweedv1.Bucket{}
+	if err := cli.Get(context.Background(), key, got); err == nil {
+		t.Errorf("expected the CR to be deleted after finalizer removal; still present: %+v", got)
+	} else if !apierrors.IsNotFound(err) {
+		t.Errorf("unexpected error getting deleted CR: %v", err)
+	}
+}
+
 func TestReconcile_DeleteBlockedByRetention_KeepsFinalizer(t *testing.T) {
 	now := metav1.Now()
 	bucket := newTestBucket("photos")


### PR DESCRIPTION
Closes #272

## Problem

#272 reported that two `Bucket` CRs in different namespaces with the same `metadata.name` and no `spec.name` resolve to the **same physical S3 bucket**, with two impacts: (1) silent co-management (both reach `Ready`), and (2) deleting one CR under `reclaimPolicy: Delete` drops the shared bucket.

Impact (1) is already handled on `master`: a CR that resolves to an existing bucket it didn't create is **refused adoption** (`BucketConditionBucketAlreadyExists`, phase `Failed`) — see `TestReconcile_ExistingBucketRefusesAdoption`.

But impact (2) remained. A refused CR still gets the finalizer (added before the adoption check), and `handleDeletion` honored `reclaimPolicy: Delete` by deleting the **resolved name** with no ownership check. So deleting that `Failed`/non-owning CR under `Delete` would still call `DeleteBucket(...)` and drop the bucket the *other* CR owns.

## Fix

Guard the physical delete on ownership in `handleDeletion`: only call `DeleteBucket` when `Status.BucketName == bucketName` — i.e. this CR actually created the bucket. `Status.BucketName` is set only on a successful own-create, so it's empty for adoption-refused CRs. A non-owning CR now simply drops its finalizer and is reaped, leaving the foreign bucket intact.

The pre-existing rename guard already ensures `Status.BucketName` is either empty or equal to `bucketName` by the time `handleDeletion` runs, so the condition is exact.

## Tests

- `TestReconcile_DeleteOnDelete_NonOwnerDoesNotDeleteForeignBucket` (new): a refused CR (`Status.BucketName == ""`, `reclaimPolicy: Delete`) on deletion makes **no** `DeleteBucket` call, the foreign bucket survives, and the CR's finalizer is removed.
- `TestReconcile_DeleteOnDelete_CallsDeleteBucket` (existing): a real owner still deletes its bucket — confirms legitimate deletion is unaffected.

Full `internal/...` and `api/...` suites pass (incl. envtest). Also added a one-line note to the `reclaimPolicy` doc in the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified reclaim policy `Delete`: Object Lock can prevent deletion, deletions only affect buckets actually created by the resource, and adoption refusal will not trigger deletion of another resource’s bucket.

* **Bug Fixes**
  * Prevented accidental deletion of buckets not owned/created by the resource during cleanup.

* **Tests**
  * Added test covering deletion when a Bucket resource does not own the physical bucket.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->