### PR TITLE
fix(grpc): dial Seaweed clusters with their mTLS credentials

### DIFF
--- a/internal/controller/bucket_admin.go
+++ b/internal/controller/bucket_admin.go
@@ -28,6 +28,7 @@ import (
 	"sync"
 
 	"github.com/go-logr/logr"
+	"google.golang.org/grpc"
 
 	"github.com/seaweedfs/seaweedfs-operator/internal/controller/swadmin"
 )
@@ -77,8 +78,9 @@ type BucketCollectionStats struct {
 // BucketAdminFactory creates a BucketAdmin for a target Seaweed cluster.
 // signingKey is jwt.filer_signing.key from the cluster's security.toml
 // (nil/empty when the cluster does not require an admin Bearer token).
-// Replaceable in tests.
-type BucketAdminFactory func(masters, filer string, signingKey []byte, log logr.Logger) (BucketAdmin, error)
+// grpcDialOption carries the transport credentials for clusters with [grpc]
+// mTLS (nil to dial without TLS). Replaceable in tests.
+type BucketAdminFactory func(masters, filer string, signingKey []byte, grpcDialOption grpc.DialOption, log logr.Logger) (BucketAdmin, error)
 
 // Sentinel errors returned by BucketAdmin implementations.
 var (
@@ -114,10 +116,11 @@ type swadminBucketAdmin struct {
 // through the embedded `weed shell` (filer gRPC, unauthenticated). Access
 // grants go through swadmin.IAMClient instead: those hit the filer's IAM gRPC
 // service, which requires an admin Bearer token signed with signingKey
-// (jwt.filer_signing.key) once the cluster configures one.
-func NewSwadminBucketAdmin(masters, filer string, signingKey []byte, log logr.Logger) (BucketAdmin, error) {
-	sa := swadmin.NewSeaweedAdmin(masters, filer, io.Discard)
-	return &swadminBucketAdmin{sa: sa, iam: swadmin.NewIAMClient(filer, signingKey), log: log}, nil
+// (jwt.filer_signing.key) once the cluster configures one. Both clients dial
+// with grpcDialOption (nil for clusters without [grpc] mTLS).
+func NewSwadminBucketAdmin(masters, filer string, signingKey []byte, grpcDialOption grpc.DialOption, log logr.Logger) (BucketAdmin, error) {
+	sa := swadmin.NewSeaweedAdmin(masters, filer, grpcDialOption, io.Discard)
+	return &swadminBucketAdmin{sa: sa, iam: swadmin.NewIAMClient(filer, signingKey, grpcDialOption), log: log}, nil
 }
 
 func (a *swadminBucketAdmin) run(cmd string) (string, error) {

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"google.golang.org/grpc"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -159,7 +160,11 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	admin, err := r.getAdmin(seaweedNS, seaweed.Name, masters, filer, adminKey, log)
+	dialOption, tlsFingerprint, err := loadSeaweedGrpcDialOption(ctx, r.Client, &seaweed)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	admin, err := r.getAdmin(seaweedNS, seaweed.Name, masters, filer, adminKey, dialOption, tlsFingerprint, log)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -420,12 +425,13 @@ func (r *BucketReconciler) clearCondition(bucket *seaweedv1.Bucket, condType str
 }
 
 // getAdmin returns a cached BucketAdmin for the (Seaweed CR, masters, filer,
-// signing key) tuple. The signing-key fingerprint is part of the cache key so
-// rotating jwt.filer_signing.key (editing the security ConfigMap) yields a
-// fresh admin rather than a stale Bearer issuer. See the comment on adminCache
-// about the goroutine-leak trade-off.
-func (r *BucketReconciler) getAdmin(ns, name, masters, filer string, signingKey []byte, log logr.Logger) (BucketAdmin, error) {
-	key := ns + "/" + name + "@" + masters + "|" + filer + "|" + signingKeyFingerprint(signingKey)
+// signing key, TLS material) tuple. The signing-key and TLS fingerprints are
+// part of the cache key so rotating jwt.filer_signing.key (editing the
+// security ConfigMap) or the server certificate (cert-manager renewal) yields
+// a fresh admin rather than one holding stale credentials. See the comment on
+// adminCache about the goroutine-leak trade-off.
+func (r *BucketReconciler) getAdmin(ns, name, masters, filer string, signingKey []byte, dialOption grpc.DialOption, tlsFingerprint string, log logr.Logger) (BucketAdmin, error) {
+	key := ns + "/" + name + "@" + masters + "|" + filer + "|" + signingKeyFingerprint(signingKey) + "|" + tlsFingerprint
 	r.adminMu.Lock()
 	defer r.adminMu.Unlock()
 	if r.adminCache == nil {
@@ -434,7 +440,7 @@ func (r *BucketReconciler) getAdmin(ns, name, masters, filer string, signingKey 
 	if a, ok := r.adminCache[key]; ok {
 		return a, nil
 	}
-	a, err := r.AdminFactory(masters, filer, signingKey, log)
+	a, err := r.AdminFactory(masters, filer, signingKey, dialOption, log)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controller/bucket_controller_test.go
+++ b/internal/controller/bucket_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"google.golang.org/grpc"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -185,7 +186,7 @@ func testReconcilerNoGrants(t *testing.T, fa *fakeBucketAdmin, objs ...client.Ob
 		Client: cli,
 		Log:    logf.FromContext(context.Background()),
 		Scheme: scheme,
-		AdminFactory: func(_, _ string, _ []byte, _ logr.Logger) (BucketAdmin, error) {
+		AdminFactory: func(_, _ string, _ []byte, _ grpc.DialOption, _ logr.Logger) (BucketAdmin, error) {
 			return fa, nil
 		},
 	}
@@ -276,7 +277,7 @@ func TestReconcile_PassesAdminSigningKeyToFactory(t *testing.T) {
 
 	fa := newFakeAdmin()
 	var gotKey []byte
-	r, _ := testReconcilerWithFactory(t, func(_, _ string, key []byte, _ logr.Logger) (BucketAdmin, error) {
+	r, _ := testReconcilerWithFactory(t, func(_, _ string, key []byte, _ grpc.DialOption, _ logr.Logger) (BucketAdmin, error) {
 		gotKey = key
 		return fa, nil
 	}, sw, cm, bucket)
@@ -299,7 +300,7 @@ func TestReconcile_NoSecurityConfigPassesEmptyKey(t *testing.T) {
 
 	fa := newFakeAdmin()
 	gotKey := []byte("sentinel")
-	r, _ := testReconcilerWithFactory(t, func(_, _ string, key []byte, _ logr.Logger) (BucketAdmin, error) {
+	r, _ := testReconcilerWithFactory(t, func(_, _ string, key []byte, _ grpc.DialOption, _ logr.Logger) (BucketAdmin, error) {
 		gotKey = key
 		return fa, nil
 	}, sw, bucket)

--- a/internal/controller/bucket_usage.go
+++ b/internal/controller/bucket_usage.go
@@ -113,7 +113,12 @@ func (r *BucketReconciler) refreshClusterUsage(ctx context.Context, log logr.Log
 		log.Error(err, "load admin signing key for usage refresh", "seaweed", seaweedName)
 		return
 	}
-	admin, err := r.getAdmin(seaweedNS, seaweedName, masters, filer, adminKey, r.Log)
+	dialOption, tlsFingerprint, err := loadSeaweedGrpcDialOption(ctx, r.Client, &seaweed)
+	if err != nil {
+		log.Error(err, "load gRPC TLS credentials for usage refresh", "seaweed", seaweedName)
+		return
+	}
+	admin, err := r.getAdmin(seaweedNS, seaweedName, masters, filer, adminKey, dialOption, tlsFingerprint, r.Log)
 	if err != nil {
 		log.Error(err, "build admin for usage refresh", "seaweed", seaweedName)
 		return

--- a/internal/controller/grpc_dial_option_test.go
+++ b/internal/controller/grpc_dial_option_test.go
@@ -1,0 +1,180 @@
+package controller
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"google.golang.org/grpc"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+)
+
+// testTLSSecret builds a Secret shaped like the cert-manager output the
+// operator reads: ca.crt/tls.crt/tls.key under TLSServerSecretName(sw). A
+// single self-signed certificate serves as both CA and leaf — enough for
+// loadSeaweedGrpcDialOption to parse and build credentials from.
+func testTLSSecret(t *testing.T, sw *seaweedv1.Seaweed) *corev1.Secret {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test.seaweedfs"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: TLSServerSecretName(sw), Namespace: sw.Namespace},
+		Type:       corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			"ca.crt":  certPEM,
+			"tls.crt": certPEM,
+			"tls.key": keyPEM,
+		},
+	}
+}
+
+func TestLoadSeaweedGrpcDialOption(t *testing.T) {
+	scheme := iamTestScheme(t)
+	swTLS := newTestSeaweedWithFiler()
+	swTLS.Spec.TLS = &seaweedv1.TLSSpec{Enabled: true}
+	secret := testTLSSecret(t, swTLS)
+
+	t.Run("tls disabled", func(t *testing.T) {
+		sw := newTestSeaweedWithFiler()
+		cli := iamTestClient(t, scheme, sw)
+		opt, fp, err := loadSeaweedGrpcDialOption(context.Background(), cli, sw)
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if opt != nil || fp != "" {
+			t.Fatalf("expected no dial option for TLS-disabled cluster, got %v / %q", opt, fp)
+		}
+	})
+
+	t.Run("tls enabled but secret missing", func(t *testing.T) {
+		cli := iamTestClient(t, scheme, swTLS)
+		opt, fp, err := loadSeaweedGrpcDialOption(context.Background(), cli, swTLS)
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if opt != nil || fp != "" {
+			t.Fatalf("expected plaintext fallback while the server TLS Secret is absent, got %v / %q", opt, fp)
+		}
+	})
+
+	t.Run("tls enabled with incomplete secret", func(t *testing.T) {
+		partial := secret.DeepCopy()
+		delete(partial.Data, "ca.crt")
+		cli := iamTestClient(t, scheme, swTLS, partial)
+		opt, fp, err := loadSeaweedGrpcDialOption(context.Background(), cli, swTLS)
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if opt != nil || fp != "" {
+			t.Fatalf("expected plaintext fallback for incomplete Secret, got %v / %q", opt, fp)
+		}
+	})
+
+	t.Run("tls enabled with issued secret", func(t *testing.T) {
+		cli := iamTestClient(t, scheme, swTLS, secret)
+		opt, fp, err := loadSeaweedGrpcDialOption(context.Background(), cli, swTLS)
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if opt == nil {
+			t.Fatal("expected a TLS dial option")
+		}
+		if fp == "" {
+			t.Fatal("expected a TLS material fingerprint")
+		}
+	})
+}
+
+// TestS3Credentials_PassesTLSDialOptionToFactory pins the fix for IAM
+// reconciliation against a cluster with [grpc] mTLS: the reconciler must read
+// the cluster's server TLS Secret and hand transport credentials to the
+// IAMAdminFactory. Without them every IAM gRPC call dialed insecure and
+// failed the moment spec.tls was enabled.
+func TestS3Credentials_PassesTLSDialOptionToFactory(t *testing.T) {
+	scheme := iamTestScheme(t)
+	sw := newTestSeaweedWithFiler()
+	sw.Spec.TLS = &seaweedv1.TLSSpec{Enabled: true}
+	cred := &seaweedv1.S3Credentials{
+		ObjectMeta: metav1.ObjectMeta{Name: "alice-creds", Namespace: "media"},
+		Spec: seaweedv1.S3CredentialsSpec{
+			SeaweedRef:  iamSeaweedRef(),
+			IdentityRef: seaweedv1.S3IdentityRef{Name: "alice"},
+			SecretRef:   seaweedv1.S3SecretRef{Name: "alice-secret"},
+		},
+	}
+	cli := iamTestClient(t, scheme, sw, testTLSSecret(t, sw), cred)
+	fa := newFakeIAMAdmin()
+	fa.seedUser("alice")
+	r := &S3CredentialsReconciler{Client: cli, Log: logf.FromContext(context.Background()), Scheme: scheme}
+	var gotDialOption grpc.DialOption
+	r.AdminFactory = func(_ string, _ []byte, dialOption grpc.DialOption, _ logr.Logger) (IAMAdmin, error) {
+		gotDialOption = dialOption
+		return fa, nil
+	}
+
+	key := types.NamespacedName{Namespace: "media", Name: "alice-creds"}
+	reconcileStable(t, r, key, 5)
+
+	if gotDialOption == nil {
+		t.Fatal("IAMAdminFactory received no dial option for a TLS-enabled cluster")
+	}
+}
+
+// TestBucketReconcile_PassesTLSDialOptionToFactory is the bucket-side twin:
+// `weed shell` and IAM grant calls must also dial with the cluster's mTLS
+// credentials.
+func TestBucketReconcile_PassesTLSDialOptionToFactory(t *testing.T) {
+	sw := newTestSeaweedWithFiler()
+	sw.Spec.TLS = &seaweedv1.TLSSpec{Enabled: true}
+	bucket := newTestBucket("photos")
+	bucket.Finalizers = []string{BucketFinalizer}
+
+	fa := newFakeAdmin()
+	var gotDialOption grpc.DialOption
+	r, _ := testReconcilerWithFactory(t, func(_, _ string, _ []byte, dialOption grpc.DialOption, _ logr.Logger) (BucketAdmin, error) {
+		gotDialOption = dialOption
+		return fa, nil
+	}, sw, testTLSSecret(t, sw), bucket)
+
+	key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
+	reconcileUntilStable(t, r, key, 5)
+
+	if gotDialOption == nil {
+		t.Fatal("BucketAdminFactory received no dial option for a TLS-enabled cluster")
+	}
+}

--- a/internal/controller/iam_admin.go
+++ b/internal/controller/iam_admin.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 
 	"github.com/go-logr/logr"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -79,8 +80,9 @@ type IAMAdmin interface {
 // IAMAdminFactory creates an IAMAdmin for the IAM service on a target filer.
 // adminSigningKey is jwt.filer_signing.key from the cluster's security.toml
 // (nil/empty when the cluster does not require admin Bearer auth).
-// Replaceable in tests.
-type IAMAdminFactory func(filer string, adminSigningKey []byte, log logr.Logger) (IAMAdmin, error)
+// grpcDialOption carries the transport credentials for clusters with [grpc]
+// mTLS (nil to dial without TLS). Replaceable in tests.
+type IAMAdminFactory func(filer string, adminSigningKey []byte, grpcDialOption grpc.DialOption, log logr.Logger) (IAMAdmin, error)
 
 // Sentinel errors returned by IAMAdmin implementations.
 var (
@@ -103,9 +105,11 @@ type swadminIAMAdmin struct {
 // NewSwadminIAMAdmin returns an IAMAdmin that talks to the filer IAM gRPC API.
 // adminSigningKey is forwarded to the underlying IAMClient so it can sign
 // admin Bearer tokens; pass nil/empty when the cluster's security.toml does
-// not configure jwt.filer_signing.key.
-func NewSwadminIAMAdmin(filer string, adminSigningKey []byte, log logr.Logger) (IAMAdmin, error) {
-	return &swadminIAMAdmin{c: swadmin.NewIAMClient(filer, adminSigningKey), log: log}, nil
+// not configure jwt.filer_signing.key. grpcDialOption is forwarded as the
+// transport credentials; pass nil when the cluster's gRPC ports run without
+// TLS.
+func NewSwadminIAMAdmin(filer string, adminSigningKey []byte, grpcDialOption grpc.DialOption, log logr.Logger) (IAMAdmin, error) {
+	return &swadminIAMAdmin{c: swadmin.NewIAMClient(filer, adminSigningKey, grpcDialOption), log: log}, nil
 }
 
 func (a *swadminIAMAdmin) GetUser(ctx context.Context, name string) (*swadmin.IAMUser, error) {

--- a/internal/controller/iam_controller_common.go
+++ b/internal/controller/iam_controller_common.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -24,6 +25,7 @@ import (
 	"sync"
 
 	"github.com/go-logr/logr"
+	"google.golang.org/grpc"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -32,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+	"github.com/seaweedfs/seaweedfs-operator/internal/controller/swadmin"
 )
 
 // Finalizers protecting each IAM CR from deletion until the reconciler has
@@ -57,23 +60,24 @@ type iamAdminProvider struct {
 	mu    sync.Mutex
 }
 
-func (p *iamAdminProvider) getIAMAdmin(filer string, adminSigningKey []byte, log logr.Logger) (IAMAdmin, error) {
+func (p *iamAdminProvider) getIAMAdmin(target filerTarget, log logr.Logger) (IAMAdmin, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.cache == nil {
 		p.cache = make(map[string]IAMAdmin)
 	}
-	// Cache key folds in a hash of the signing key so that key rotation (a
-	// user editing the security.toml ConfigMap) invalidates the cached
-	// client instead of leaving a stale Bearer issuer behind.
-	cacheKey := filer + "\x00" + signingKeyFingerprint(adminSigningKey)
+	// Cache key folds in hashes of the signing key and TLS material so that
+	// rotating either (a user editing the security.toml ConfigMap,
+	// cert-manager renewing the server certificate) invalidates the cached
+	// client instead of leaving stale credentials behind.
+	cacheKey := target.address + "\x00" + signingKeyFingerprint(target.adminSigningKey) + "\x00" + target.tlsFingerprint
 	if a, ok := p.cache[cacheKey]; ok {
 		return a, nil
 	}
 	if p.AdminFactory == nil {
 		return nil, fmt.Errorf("iam admin factory is not configured")
 	}
-	a, err := p.AdminFactory(filer, adminSigningKey, log)
+	a, err := p.AdminFactory(target.address, target.adminSigningKey, target.grpcDialOption, log)
 	if err != nil {
 		return nil, err
 	}
@@ -89,11 +93,33 @@ func signingKeyFingerprint(key []byte) string {
 	return hex.EncodeToString(sum[:8])
 }
 
+// tlsMaterialFingerprint hashes the PEM material behind a TLS dial option so
+// admin caches can key on it.
+func tlsMaterialFingerprint(ca, cert, key []byte) string {
+	sum := sha256.Sum256(bytes.Join([][]byte{ca, cert, key}, []byte{0}))
+	return hex.EncodeToString(sum[:8])
+}
+
+// filerTarget bundles everything a gRPC client needs to reach a Seaweed
+// cluster's filer: the address, the admin Bearer signing key, and transport
+// credentials matching the cluster's [grpc] mTLS state.
+type filerTarget struct {
+	address         string
+	adminSigningKey []byte
+	// grpcDialOption is non-nil when the cluster's gRPC ports require mTLS;
+	// nil means dial without TLS.
+	grpcDialOption grpc.DialOption
+	// tlsFingerprint identifies the TLS material behind grpcDialOption so
+	// admin caches roll over when cert-manager renews the certificate.
+	tlsFingerprint string
+}
+
 // resolveSeaweedFiler looks up the Seaweed CR named by ref and returns its
 // filer address along with the admin signing key the operator rendered into
 // the cluster's security.toml ConfigMap (issue #257: the filer's IAM gRPC
 // service rejects unauthenticated calls when jwt.filer_signing.key is set, so
-// the operator must sign its own Bearer tokens with the same key). found is
+// the operator must sign its own Bearer tokens with the same key) and the
+// gRPC transport credentials matching the cluster's mTLS state. found is
 // false (with a nil error) when the Seaweed CR does not exist, so callers can
 // surface a transient "cluster not found" condition and requeue rather than
 // treating it as a hard error.
@@ -103,7 +129,7 @@ func signingKeyFingerprint(key []byte) string {
 // provisioned by this operator (no ConfigMap to read). In those cases the IAM
 // client falls back to unauthenticated calls, matching the cluster's likely
 // configuration.
-func resolveSeaweedFiler(ctx context.Context, c client.Client, ref seaweedv1.SeaweedReference, ownNamespace string) (filer string, adminSigningKey []byte, found bool, err error) {
+func resolveSeaweedFiler(ctx context.Context, c client.Client, ref seaweedv1.SeaweedReference, ownNamespace string) (target filerTarget, found bool, err error) {
 	ns := ref.Namespace
 	if ns == "" {
 		ns = ownNamespace
@@ -111,15 +137,24 @@ func resolveSeaweedFiler(ctx context.Context, c client.Client, ref seaweedv1.Sea
 	var sw seaweedv1.Seaweed
 	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: ref.Name}, &sw); err != nil {
 		if apierrors.IsNotFound(err) {
-			return "", nil, false, nil
+			return filerTarget{}, false, nil
 		}
-		return "", nil, false, err
+		return filerTarget{}, false, err
 	}
 	key, err := loadFilerAdminSigningKey(ctx, c, &sw)
 	if err != nil {
-		return "", nil, false, err
+		return filerTarget{}, false, err
 	}
-	return getFilerAddress(&sw), key, true, nil
+	dialOption, tlsFingerprint, err := loadSeaweedGrpcDialOption(ctx, c, &sw)
+	if err != nil {
+		return filerTarget{}, false, err
+	}
+	return filerTarget{
+		address:         getFilerAddress(&sw),
+		adminSigningKey: key,
+		grpcDialOption:  dialOption,
+		tlsFingerprint:  tlsFingerprint,
+	}, true, nil
 }
 
 // loadFilerAdminSigningKey reads jwt.filer_signing.key from the
@@ -144,6 +179,37 @@ func loadFilerAdminSigningKey(ctx context.Context, c client.Client, sw *seaweedv
 		return nil, nil
 	}
 	return []byte(raw), nil
+}
+
+// loadSeaweedGrpcDialOption returns the transport credentials the operator's
+// gRPC clients must use to reach sw's components, plus a fingerprint of the
+// TLS material for admin cache keys. Both are zero when the cluster's gRPC
+// ports run without TLS: spec.tls disabled, or the server TLS Secret not
+// issued (yet) — pods only mount the Secret once cert-manager has produced
+// it, so its absence means the cluster is (still) running plaintext gRPC and
+// dialing insecure matches. An incomplete Secret is treated the same way:
+// when ca.crt is missing the pods' own security.toml points at a missing
+// file and seaweedfs falls back to plaintext too.
+func loadSeaweedGrpcDialOption(ctx context.Context, c client.Client, sw *seaweedv1.Seaweed) (grpc.DialOption, string, error) {
+	if !tlsEnabled(sw) {
+		return nil, "", nil
+	}
+	var sec corev1.Secret
+	if err := c.Get(ctx, types.NamespacedName{Namespace: sw.Namespace, Name: TLSServerSecretName(sw)}, &sec); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, "", nil
+		}
+		return nil, "", err
+	}
+	ca, cert, key := sec.Data["ca.crt"], sec.Data["tls.crt"], sec.Data["tls.key"]
+	if len(ca) == 0 || len(cert) == 0 || len(key) == 0 {
+		return nil, "", nil
+	}
+	dialOption, err := swadmin.ClientTLSDialOption(ca, cert, key)
+	if err != nil {
+		return nil, "", fmt.Errorf("build gRPC TLS credentials from secret %s/%s: %w", sw.Namespace, TLSServerSecretName(sw), err)
+	}
+	return dialOption, tlsMaterialFingerprint(ca, cert, key), nil
 }
 
 // setIAMCondition upserts a condition on an IAM CR's condition list, stamping

--- a/internal/controller/iam_controller_test.go
+++ b/internal/controller/iam_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"google.golang.org/grpc"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -138,7 +139,7 @@ func reconcileOnce(t *testing.T, r reconcile.Reconciler, key types.NamespacedNam
 }
 
 func fakeIAMFactory(fa IAMAdmin) IAMAdminFactory {
-	return func(_ string, _ []byte, _ logr.Logger) (IAMAdmin, error) { return fa, nil }
+	return func(_ string, _ []byte, _ grpc.DialOption, _ logr.Logger) (IAMAdmin, error) { return fa, nil }
 }
 
 // --- S3Identity ---
@@ -808,18 +809,18 @@ func TestResolveSeaweedFiler_LoadsAdminSigningKey(t *testing.T) {
 	}
 	cli := iamTestClient(t, scheme, sw, cm)
 
-	filer, key, found, err := resolveSeaweedFiler(context.Background(), cli, iamSeaweedRef(), "media")
+	target, found, err := resolveSeaweedFiler(context.Background(), cli, iamSeaweedRef(), "media")
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
 	if !found {
 		t.Fatal("expected cluster to be found")
 	}
-	if filer == "" {
+	if target.address == "" {
 		t.Fatal("expected non-empty filer address")
 	}
-	if string(key) != "abc123==" {
-		t.Fatalf("admin signing key = %q, want %q", string(key), "abc123==")
+	if string(target.adminSigningKey) != "abc123==" {
+		t.Fatalf("admin signing key = %q, want %q", string(target.adminSigningKey), "abc123==")
 	}
 }
 
@@ -828,15 +829,15 @@ func TestResolveSeaweedFiler_MissingConfigMapReturnsEmptyKey(t *testing.T) {
 	sw := newTestSeaweedWithFiler()
 	cli := iamTestClient(t, scheme, sw)
 
-	_, key, found, err := resolveSeaweedFiler(context.Background(), cli, iamSeaweedRef(), "media")
+	target, found, err := resolveSeaweedFiler(context.Background(), cli, iamSeaweedRef(), "media")
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
 	if !found {
 		t.Fatal("expected cluster to be found")
 	}
-	if len(key) != 0 {
-		t.Fatalf("expected empty key when ConfigMap missing, got %q", string(key))
+	if len(target.adminSigningKey) != 0 {
+		t.Fatalf("expected empty key when ConfigMap missing, got %q", string(target.adminSigningKey))
 	}
 }
 

--- a/internal/controller/s3credentials_controller.go
+++ b/internal/controller/s3credentials_controller.go
@@ -95,7 +95,7 @@ func (r *S3CredentialsReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		clearIAMCondition(&cred.Status.Conditions, seaweedv1.S3ConditionReferenceGranted)
 	}
 
-	filer, adminKey, found, err := resolveSeaweedFiler(ctx, r.Client, cred.Spec.SeaweedRef, cred.Namespace)
+	target, found, err := resolveSeaweedFiler(ctx, r.Client, cred.Spec.SeaweedRef, cred.Namespace)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -104,7 +104,7 @@ func (r *S3CredentialsReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 	setIAMCondition(&cred.Status.Conditions, cred.Generation, seaweedv1.S3ConditionClusterReachable, metav1.ConditionTrue, "Reachable", "")
 
-	admin, err := r.getIAMAdmin(filer, adminKey, log)
+	admin, err := r.getIAMAdmin(target, log)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/s3identity_controller.go
+++ b/internal/controller/s3identity_controller.go
@@ -81,7 +81,7 @@ func (r *S3IdentityReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		clearIAMCondition(&identity.Status.Conditions, seaweedv1.S3ConditionReferenceGranted)
 	}
 
-	filer, adminKey, found, err := resolveSeaweedFiler(ctx, r.Client, identity.Spec.SeaweedRef, identity.Namespace)
+	target, found, err := resolveSeaweedFiler(ctx, r.Client, identity.Spec.SeaweedRef, identity.Namespace)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -90,7 +90,7 @@ func (r *S3IdentityReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 	setIAMCondition(&identity.Status.Conditions, identity.Generation, seaweedv1.S3ConditionClusterReachable, metav1.ConditionTrue, "Reachable", "")
 
-	admin, err := r.getIAMAdmin(filer, adminKey, log)
+	admin, err := r.getIAMAdmin(target, log)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/s3oidcprovider_controller.go
+++ b/internal/controller/s3oidcprovider_controller.go
@@ -71,7 +71,7 @@ func (r *S3OIDCProviderReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		clearIAMCondition(&provider.Status.Conditions, seaweedv1.S3ConditionReferenceGranted)
 	}
 
-	filer, adminKey, found, err := resolveSeaweedFiler(ctx, r.Client, provider.Spec.SeaweedRef, provider.Namespace)
+	target, found, err := resolveSeaweedFiler(ctx, r.Client, provider.Spec.SeaweedRef, provider.Namespace)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -89,7 +89,7 @@ func (r *S3OIDCProviderReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 	setIAMCondition(&provider.Status.Conditions, provider.Generation, seaweedv1.S3ConditionClusterReachable, metav1.ConditionTrue, "Reachable", "")
 
-	admin, err := r.getIAMAdmin(filer, adminKey, log)
+	admin, err := r.getIAMAdmin(target, log)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/s3policy_controller.go
+++ b/internal/controller/s3policy_controller.go
@@ -79,7 +79,7 @@ func (r *S3PolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		clearIAMCondition(&policy.Status.Conditions, seaweedv1.S3ConditionReferenceGranted)
 	}
 
-	filer, adminKey, found, err := resolveSeaweedFiler(ctx, r.Client, policy.Spec.SeaweedRef, policy.Namespace)
+	target, found, err := resolveSeaweedFiler(ctx, r.Client, policy.Spec.SeaweedRef, policy.Namespace)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -88,7 +88,7 @@ func (r *S3PolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 	setIAMCondition(&policy.Status.Conditions, policy.Generation, seaweedv1.S3ConditionClusterReachable, metav1.ConditionTrue, "Reachable", "")
 
-	admin, err := r.getIAMAdmin(filer, adminKey, log)
+	admin, err := r.getIAMAdmin(target, log)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/s3policybinding_controller.go
+++ b/internal/controller/s3policybinding_controller.go
@@ -72,7 +72,7 @@ func (r *S3PolicyBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		clearIAMCondition(&binding.Status.Conditions, seaweedv1.S3ConditionReferenceGranted)
 	}
 
-	filer, adminKey, found, err := resolveSeaweedFiler(ctx, r.Client, binding.Spec.SeaweedRef, binding.Namespace)
+	target, found, err := resolveSeaweedFiler(ctx, r.Client, binding.Spec.SeaweedRef, binding.Namespace)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -81,7 +81,7 @@ func (r *S3PolicyBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 	setIAMCondition(&binding.Status.Conditions, binding.Generation, seaweedv1.S3ConditionClusterReachable, metav1.ConditionTrue, "Reachable", "")
 
-	admin, err := r.getIAMAdmin(filer, adminKey, log)
+	admin, err := r.getIAMAdmin(target, log)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/seaweed_maintenance.go
+++ b/internal/controller/seaweed_maintenance.go
@@ -16,7 +16,7 @@ func (r *SeaweedReconciler) maintenance(m *seaweedv1.Seaweed) (done bool, result
 	r.Log.V(0).Info("wait to connect to masters", "masters", masters)
 
 	// this step blocks since the operator can not access the masters when running from outside of the k8s cluster
-	sa := swadmin.NewSeaweedAdmin(masters, "", ioutil.Discard)
+	sa := swadmin.NewSeaweedAdmin(masters, "", nil, ioutil.Discard)
 
 	// For now this is an example of the admin commands
 	// master by default has some maintenance commands already.

--- a/internal/controller/swadmin/client_tls.go
+++ b/internal/controller/swadmin/client_tls.go
@@ -1,0 +1,66 @@
+package swadmin
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+// ClientTLSDialOption builds mutual-TLS transport credentials for gRPC
+// connections to a Seaweed cluster, from in-memory PEM material. The operator
+// reads the material from the cluster's server TLS Secret via the Kubernetes
+// API rather than mounted files, so it cannot reuse
+// weed/security.LoadClientTLS directly; this mirrors its semantics instead:
+// the client presents cert/key, the server chain is verified against ca, and
+// hostname verification is skipped — SeaweedFS components share one
+// certificate that is not minted per dial target.
+func ClientTLSDialOption(ca, cert, key []byte) (grpc.DialOption, error) {
+	clientCert, err := tls.X509KeyPair(cert, key)
+	if err != nil {
+		return nil, fmt.Errorf("load client cert/key: %w", err)
+	}
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(ca) {
+		return nil, fmt.Errorf("no CA certificates parsed from ca.crt")
+	}
+	cfg := &tls.Config{
+		Certificates: []tls.Certificate{clientCert},
+		MinVersion:   tls.VersionTLS12,
+		// Chain verification happens in VerifyPeerCertificate so the
+		// hostname check can be skipped without skipping verification.
+		InsecureSkipVerify:    true,
+		VerifyPeerCertificate: verifyChainOnly(roots),
+	}
+	return grpc.WithTransportCredentials(credentials.NewTLS(cfg)), nil
+}
+
+// verifyChainOnly returns a VerifyPeerCertificate callback that verifies the
+// presented chain against roots without a DNSName constraint.
+func verifyChainOnly(roots *x509.CertPool) func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+	return func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+		if len(rawCerts) == 0 {
+			return fmt.Errorf("server presented no certificate")
+		}
+		certs := make([]*x509.Certificate, 0, len(rawCerts))
+		for _, raw := range rawCerts {
+			c, err := x509.ParseCertificate(raw)
+			if err != nil {
+				return fmt.Errorf("parse server certificate: %w", err)
+			}
+			certs = append(certs, c)
+		}
+		intermediates := x509.NewCertPool()
+		for _, c := range certs[1:] {
+			intermediates.AddCert(c)
+		}
+		_, err := certs[0].Verify(x509.VerifyOptions{
+			Roots:         roots,
+			Intermediates: intermediates,
+			KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		})
+		return err
+	}
+}

--- a/internal/controller/swadmin/client_tls_test.go
+++ b/internal/controller/swadmin/client_tls_test.go
@@ -1,0 +1,190 @@
+package swadmin
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/iam_pb"
+	"github.com/seaweedfs/seaweedfs/weed/security"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+// testPKI is an in-memory CA plus one leaf certificate signed by it, shaped
+// like the cert-manager Secret the operator reads: the same leaf serves as
+// server and client certificate, and its SAN list does NOT cover the
+// 127.0.0.1 address tests dial — mirroring production, where the shared
+// SeaweedFS certificate is not minted per dial target and hostname
+// verification must be skipped.
+type testPKI struct {
+	caPEM, certPEM, keyPEM []byte
+}
+
+func newTestPKI(t *testing.T) testPKI {
+	t.Helper()
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test SeaweedFS CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create CA cert: %v", err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("parse CA cert: %v", err)
+	}
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate leaf key: %v", err)
+	}
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "test.seaweedfs"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		DNSNames:     []string{"seaweed-test-filer"},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &leafKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create leaf cert: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(leafKey)
+	if err != nil {
+		t.Fatalf("marshal leaf key: %v", err)
+	}
+	return testPKI{
+		caPEM:   pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER}),
+		certPEM: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafDER}),
+		keyPEM:  pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}),
+	}
+}
+
+// serverCreds builds gRPC server credentials that require and verify a client
+// certificate against the test CA — the same posture a SeaweedFS filer takes
+// when security.toml configures [grpc] ca.
+func (p testPKI) serverCreds(t *testing.T) credentials.TransportCredentials {
+	t.Helper()
+	serverCert, err := tls.X509KeyPair(p.certPEM, p.keyPEM)
+	if err != nil {
+		t.Fatalf("server key pair: %v", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(p.caPEM) {
+		t.Fatal("append CA to pool")
+	}
+	return credentials.NewTLS(&tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		ClientCAs:    pool,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		MinVersion:   tls.VersionTLS12,
+	})
+}
+
+// startMTLSIAMServer runs an in-process IAM gRPC server behind mTLS and
+// returns the filer-style HTTP host:port IAMClient expects (gRPC port minus
+// the seaweedfs port delta).
+func startMTLSIAMServer(t *testing.T, pki testPKI, key []byte) string {
+	t.Helper()
+	srv := grpc.NewServer(grpc.Creds(pki.serverCreds(t)))
+	t.Cleanup(srv.Stop)
+	iam_pb.RegisterSeaweedIdentityAccessManagementServer(srv, &authRecordingIAM{adminSigningKey: security.SigningKey(key)})
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() { _ = srv.Serve(lis) }()
+
+	grpcPort := lis.Addr().(*net.TCPAddr).Port
+	if grpcPort < 10001 {
+		t.Skipf("ephemeral gRPC port %d too low to map to a valid HTTP port", grpcPort)
+	}
+	return net.JoinHostPort("127.0.0.1", strconv.Itoa(grpcPort-10000))
+}
+
+// TestIAMClient_MTLS_EndToEnd pins the fix for IAM reconciliation against a
+// cluster with [grpc] mTLS: an IAMClient built with ClientTLSDialOption must
+// complete the handshake (client cert presented, server chain verified, no
+// hostname check — the server cert's SANs deliberately exclude 127.0.0.1)
+// and still stamp the admin Bearer token. Before the fix the client dialed
+// with insecure credentials and every call failed once the filer required
+// TLS.
+func TestIAMClient_MTLS_EndToEnd(t *testing.T) {
+	pki := newTestPKI(t)
+	key := []byte("test-jwt-signing-key")
+	filer := startMTLSIAMServer(t, pki, key)
+
+	dialOption, err := ClientTLSDialOption(pki.caPEM, pki.certPEM, pki.keyPEM)
+	if err != nil {
+		t.Fatalf("ClientTLSDialOption: %v", err)
+	}
+	c := NewIAMClient(filer, key, dialOption)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	u, err := c.GetUser(ctx, "alice")
+	if err != nil {
+		t.Fatalf("GetUser over mTLS: %v", err)
+	}
+	if u == nil || u.Name != "alice" {
+		t.Fatalf("GetUser = %+v, want alice", u)
+	}
+}
+
+// TestIAMClient_MTLS_RejectsUnknownCA proves the dial option still verifies
+// the server chain: a server presenting a certificate from a different CA
+// must fail the handshake rather than being silently trusted.
+func TestIAMClient_MTLS_RejectsUnknownCA(t *testing.T) {
+	serverPKI := newTestPKI(t)
+	clientPKI := newTestPKI(t) // distinct CA
+	key := []byte("test-jwt-signing-key")
+	filer := startMTLSIAMServer(t, serverPKI, key)
+
+	dialOption, err := ClientTLSDialOption(clientPKI.caPEM, clientPKI.certPEM, clientPKI.keyPEM)
+	if err != nil {
+		t.Fatalf("ClientTLSDialOption: %v", err)
+	}
+	c := NewIAMClient(filer, key, dialOption)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := c.GetUser(ctx, "alice"); err == nil {
+		t.Fatal("GetUser succeeded against a server signed by an unknown CA")
+	}
+}
+
+// TestClientTLSDialOption_BadMaterial pins the error paths so a malformed
+// Secret surfaces as a build error instead of a confusing dial failure.
+func TestClientTLSDialOption_BadMaterial(t *testing.T) {
+	pki := newTestPKI(t)
+	if _, err := ClientTLSDialOption([]byte("not pem"), pki.certPEM, pki.keyPEM); err == nil {
+		t.Fatal("expected error for unparseable CA")
+	}
+	if _, err := ClientTLSDialOption(pki.caPEM, []byte("not pem"), pki.keyPEM); err == nil {
+		t.Fatal("expected error for unparseable cert")
+	}
+}

--- a/internal/controller/swadmin/iam_client.go
+++ b/internal/controller/swadmin/iam_client.go
@@ -62,8 +62,7 @@ var iamUserLocks = &keyedMutex{}
 // file-based policy I/O and stderr-only secret printing) so the operator can
 // run with a read-only root filesystem and capture every result.
 //
-// Like the bucket admin's master connection, this dials without TLS. When
-// adminSigningKey is non-empty (the operator reads it from the rendered
+// When adminSigningKey is non-empty (the operator reads it from the rendered
 // security.toml ConfigMap) every RPC is stamped with a freshly minted admin
 // Bearer token in the "authorization" metadata — matching the upstream
 // `weed shell` IAM client. When the key is empty the calls are
@@ -79,11 +78,16 @@ type IAMClient struct {
 // HTTP host:port (as returned by getFilerAddress); seaweedfs derives the gRPC
 // port from it internally. adminSigningKey is the jwt.filer_signing.key from
 // the cluster's security.toml; pass nil/empty when the cluster does not
-// require admin Bearer auth.
-func NewIAMClient(filer string, adminSigningKey []byte) *IAMClient {
+// require admin Bearer auth. dialOption carries the transport credentials for
+// clusters with [grpc] mTLS (see ClientTLSDialOption); pass nil to dial
+// without TLS.
+func NewIAMClient(filer string, adminSigningKey []byte, dialOption grpc.DialOption) *IAMClient {
+	if dialOption == nil {
+		dialOption = grpc.WithTransportCredentials(insecure.NewCredentials())
+	}
 	return &IAMClient{
 		filerGrpcAddress: pb.ServerAddress(filer).ToGrpcAddress(),
-		dialOption:       grpc.WithTransportCredentials(insecure.NewCredentials()),
+		dialOption:       dialOption,
 		adminSigningKey:  security.SigningKey(adminSigningKey),
 	}
 }

--- a/internal/controller/swadmin/iam_client_bucket_test.go
+++ b/internal/controller/swadmin/iam_client_bucket_test.go
@@ -29,7 +29,7 @@ func TestIAMClient_SetBucketAccess_SendsBearer(t *testing.T) {
 	srv := newBucketAccessIAM(key)
 	filer := startBucketAccessIAM(t, srv)
 
-	c := NewIAMClient(filer, key)
+	c := NewIAMClient(filer, key, nil)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -49,7 +49,7 @@ func TestIAMClient_SetBucketAccess_NoKeyUnauthenticated(t *testing.T) {
 	srv := newBucketAccessIAM([]byte("test-jwt-signing-key"))
 	filer := startBucketAccessIAM(t, srv)
 
-	c := NewIAMClient(filer, nil) // no signing key wired
+	c := NewIAMClient(filer, nil, nil) // no signing key wired
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -78,7 +78,7 @@ func TestIAMClient_SetBucketAccess_PreservesOtherGrants(t *testing.T) {
 	})
 	filer := startBucketAccessIAM(t, srv)
 
-	c := NewIAMClient(filer, key)
+	c := NewIAMClient(filer, key, nil)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 

--- a/internal/controller/swadmin/iam_client_test.go
+++ b/internal/controller/swadmin/iam_client_test.go
@@ -24,7 +24,7 @@ import (
 // failed with "Unauthenticated desc = missing authorization metadata".
 func TestIAMClient_AuthContext_AppendsBearerWhenKeySet(t *testing.T) {
 	key := []byte("test-jwt-signing-key")
-	c := NewIAMClient("seaweed-filer.invalid:8888", key)
+	c := NewIAMClient("seaweed-filer.invalid:8888", key, nil)
 
 	ctx := c.authContext(context.Background())
 	md, ok := metadata.FromOutgoingContext(ctx)
@@ -57,7 +57,7 @@ func TestIAMClient_AuthContext_AppendsBearerWhenKeySet(t *testing.T) {
 // path so clusters whose security.toml has no jwt.filer_signing.key keep
 // working — matching the filer's checkAdminAuth no-op branch.
 func TestIAMClient_AuthContext_NoMetadataWhenKeyEmpty(t *testing.T) {
-	c := NewIAMClient("seaweed-filer.invalid:8888", nil)
+	c := NewIAMClient("seaweed-filer.invalid:8888", nil, nil)
 	ctx := c.authContext(context.Background())
 	md, ok := metadata.FromOutgoingContext(ctx)
 	if ok && len(md.Get("authorization")) > 0 {
@@ -92,7 +92,7 @@ func TestIAMClient_GetUser_SendsBearer(t *testing.T) {
 		t.Skipf("ephemeral gRPC port %d too low to map to a valid HTTP port", grpcPort)
 	}
 	httpPort := grpcPort - 10000
-	c := NewIAMClient(net.JoinHostPort("127.0.0.1", strconv.Itoa(httpPort)), key)
+	c := NewIAMClient(net.JoinHostPort("127.0.0.1", strconv.Itoa(httpPort)), key, nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/internal/controller/swadmin/seaweed_admin.go
+++ b/internal/controller/swadmin/seaweed_admin.go
@@ -35,10 +35,15 @@ type SeaweedAdmin struct {
 
 // NewSeaweedAdmin builds a SeaweedAdmin that mirrors `weed shell`. filer is
 // required for s3.bucket.* / fs.* callers; master-only callers (volume.list,
-// volume.balance) may pass "".
-func NewSeaweedAdmin(masters, filer string, output io.Writer) *SeaweedAdmin {
+// volume.balance) may pass "". dialOption carries the transport credentials
+// for clusters with [grpc] mTLS (see ClientTLSDialOption); pass nil to dial
+// without TLS.
+func NewSeaweedAdmin(masters, filer string, dialOption grpc.DialOption, output io.Writer) *SeaweedAdmin {
+	if dialOption == nil {
+		dialOption = grpc.WithTransportCredentials(insecure.NewCredentials())
+	}
 	var shellOptions shell.ShellOptions
-	shellOptions.GrpcDialOption = grpc.WithTransportCredentials(insecure.NewCredentials())
+	shellOptions.GrpcDialOption = dialOption
 	shellOptions.Masters = &masters
 	shellOptions.FilerAddress = pb.ServerAddress(filer)
 	// shell.NewCommandEnv unconditionally dereferences FilerGroup; leaving

--- a/internal/controller/swadmin/seaweed_admin_test.go
+++ b/internal/controller/swadmin/seaweed_admin_test.go
@@ -13,7 +13,7 @@ import (
 // shell.ShellOptions.FilerGroup nil panicked inside shell.NewCommandEnv the
 // moment any Bucket reached the reconciler.
 func TestNewSeaweedAdmin_DoesNotPanic(t *testing.T) {
-	sa := NewSeaweedAdmin("seaweed-master.invalid:9333", "seaweed-filer.invalid:8888", io.Discard)
+	sa := NewSeaweedAdmin("seaweed-master.invalid:9333", "seaweed-filer.invalid:8888", nil, io.Discard)
 	if sa == nil {
 		t.Fatal("NewSeaweedAdmin returned nil")
 	}
@@ -27,7 +27,7 @@ func TestNewSeaweedAdmin_DoesNotPanic(t *testing.T) {
 // ShellOptions.FilerAddress was never set so every s3.bucket.* command
 // dialed gRPC with an empty target.
 func TestNewSeaweedAdmin_FilerAddressWired(t *testing.T) {
-	sa := NewSeaweedAdmin("seaweed-master.invalid:9333", "seaweed-filer.invalid:8888", io.Discard)
+	sa := NewSeaweedAdmin("seaweed-master.invalid:9333", "seaweed-filer.invalid:8888", nil, io.Discard)
 	err := sa.commandEnv.WithFilerClient(false, func(filer_pb.SeaweedFilerClient) error {
 		return nil
 	})


### PR DESCRIPTION
Fixes #276

## Problem

When `spec.tls` is enabled, every SeaweedFS component requires mutual TLS on its gRPC port, but the operator's own gRPC clients always dialed with `insecure.NewCredentials()`:

- `swadmin.IAMClient` (behind the S3Identity / S3Credentials / S3Policy / S3PolicyBinding / S3OIDCProvider reconcilers)
- `swadmin.SeaweedAdmin` (the embedded `weed shell` behind the Bucket reconciler and the usage refresher)

So IAM and bucket reconciliation failed against any TLS-enabled cluster, e.g.:

```
s3credentials reconcile failed
reason: IdentityLookupFailed
message: rpc error: code = Canceled desc = grpc: the client connection is closing
```

## Fix

The operator already provisions the cluster's server TLS Secret (`{name}-server-tls`, with `server auth` + `client auth` usages). It now reads that Secret and builds client transport credentials from it:

- New `swadmin.ClientTLSDialOption(ca, cert, key)` mirrors `weed/security.LoadClientTLS` semantics from in-memory PEM (the operator reads the Secret via the API, not mounted files): client cert presented, server chain verified against `ca.crt`, hostname verification skipped — the shared SeaweedFS certificate is not minted per dial target, matching upstream's `advancedtls` client setup.
- `resolveSeaweedFiler` (IAM reconcilers), the Bucket reconciler, and the usage refresher load the dial option per cluster and hand it to the admin factories; `NewIAMClient` / `NewSeaweedAdmin` accept it (nil keeps the previous insecure dial).
- The TLS material is fingerprinted into the admin cache keys, so a cert-manager renewal rolls cached clients over instead of leaving stale certificates behind — same pattern as the existing signing-key fingerprint.

Clusters without TLS — or whose Secret has not been issued yet (cert-manager absent or cert pending; pods only mount the Secret once issued) — keep dialing plaintext, preserving the soft-degrade contract documented on `TLSSpec`.

## Tests

- `TestIAMClient_MTLS_EndToEnd`: in-process IAM gRPC server requiring client certs; an `IAMClient` built with `ClientTLSDialOption` completes the handshake (server SANs deliberately exclude the dialed address) and still stamps the admin Bearer token. Fails with the old insecure dial.
- `TestIAMClient_MTLS_RejectsUnknownCA`: chain verification is still enforced.
- `TestLoadSeaweedGrpcDialOption`: plaintext fallbacks (TLS disabled / Secret missing / Secret incomplete) and the issued-Secret path.
- `TestS3Credentials_PassesTLSDialOptionToFactory` / `TestBucketReconcile_PassesTLSDialOptionToFactory`: the reconcilers hand transport credentials to their factories for a TLS-enabled cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring gRPC mutual TLS (mTLS) for secure cluster communication
  * Implemented automatic certificate rotation handling to ensure fresh connections when TLS materials are updated

* **Tests**
  * Added comprehensive mTLS configuration and connection validation tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->