### PR TITLE
fix(iam): scope global IAM names against cross-namespace collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,17 @@ underlying IAM object. Set `reclaimPolicy: Retain` to opt out.
       - { kind: S3Identity, name: bob }
   ```
 
+IAM user and policy names are **global to the cluster** while these CRs
+are namespaced. When CRs in different namespaces claim the same IAM name
+on the same cluster, the oldest claim owns it and later claimants are
+marked `Failed` with a `Ready=False` / `reason: Conflict` condition naming
+the owning CR (set `spec.name` to give each namespace a distinct IAM
+name). `identityRef`, `policyRef`, and `subjects` name the referenced
+`S3Identity` / `S3Policy` **resource** in the same namespace and follow
+its effective IAM name, so a `spec.name` override stays transparent to
+referencing resources; a name with no matching resource is used as the
+IAM name directly (for objects not managed by a CR).
+
 `S3Credentials` and `S3PolicyBinding` wait (status `Pending`) until the
 identity / policy they reference exists, so apply order does not matter.
 As with `Bucket`, a cross-namespace `seaweedRef` (and the `S3Credentials`

--- a/README.md
+++ b/README.md
@@ -403,15 +403,22 @@ underlying IAM object. Set `reclaimPolicy: Retain` to opt out.
   ```
 
 IAM user and policy names are **global to the cluster** while these CRs
-are namespaced. When CRs in different namespaces claim the same IAM name
-on the same cluster, the oldest claim owns it and later claimants are
-marked `Failed` with a `Ready=False` / `reason: Conflict` condition naming
-the owning CR (set `spec.name` to give each namespace a distinct IAM
-name). `identityRef`, `policyRef`, and `subjects` name the referenced
-`S3Identity` / `S3Policy` **resource** in the same namespace and follow
-its effective IAM name, so a `spec.name` override stays transparent to
-referencing resources; a name with no matching resource is used as the
-IAM name directly (for objects not managed by a CR).
+are namespaced:
+
+- **Name conflicts** — when CRs in different namespaces claim the same
+  IAM name on the same cluster, the oldest claim owns it; later claimants
+  are marked `Failed` with a `Ready=False` / `reason: Conflict` condition
+  naming the owning CR. Set `spec.name` to give each namespace a distinct
+  IAM name.
+- **Reference resolution** — `identityRef`, `policyRef`, and `subjects`
+  name the referenced `S3Identity` / `S3Policy` **resource** in the same
+  namespace and follow its effective IAM name, so a `spec.name` override
+  stays transparent to referencing resources. A name with no matching
+  resource is used as the IAM name directly, which keeps references to
+  IAM objects not managed by any CR (and pre-existing manifests) working.
+  Once provisioned, the resolved name is pinned in status so a resource
+  created later under the same name cannot silently retarget the
+  credential or binding.
 
 `S3Credentials` and `S3PolicyBinding` wait (status `Pending`) until the
 identity / policy they reference exists, so apply order does not matter.

--- a/api/v1/s3credentials_types.go
+++ b/api/v1/s3credentials_types.go
@@ -21,10 +21,13 @@ import (
 )
 
 // S3IdentityRef references the IAM identity (user) that owns a credential.
-// The Name is the IAM user name, which equals the target S3Identity's
-// resolved name (its spec.name, or metadata.name when spec.name is unset).
+// The Name resolves to an S3Identity of that name in the same namespace
+// (using its effective IAM user name, so a spec.name override is
+// transparent); when no such S3Identity exists, Name is taken as the IAM
+// user name itself.
 type S3IdentityRef struct {
-	// Name is the IAM user name the credential belongs to.
+	// Name of the S3Identity in the same namespace, or the IAM user name
+	// for an identity not managed by an S3Identity resource.
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
 	Name string `json:"name"`
@@ -123,6 +126,10 @@ type S3CredentialsStatus struct {
 	// referenced Secret.
 	// +optional
 	AccessKey string `json:"accessKey,omitempty"`
+
+	// IdentityName is the IAM user name the identityRef resolved to.
+	// +optional
+	IdentityName string `json:"identityName,omitempty"`
 
 	// SecretName is the resolved name of the Secret holding the key pair.
 	// +optional

--- a/api/v1/s3identity_types.go
+++ b/api/v1/s3identity_types.go
@@ -46,7 +46,9 @@ type S3IdentitySpec struct {
 
 	// Name is the IAM user name. Defaults to .metadata.name. Immutable once
 	// set — IAM user renames are not supported, recreate the resource to
-	// change the name.
+	// change the name. IAM user names are global to the cluster: the oldest
+	// CR claiming a name owns it, and later claimants are marked Failed
+	// with a Conflict condition.
 	// +optional
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256

--- a/api/v1/s3policy_types.go
+++ b/api/v1/s3policy_types.go
@@ -73,7 +73,9 @@ type S3PolicySpec struct {
 	SeaweedRef SeaweedReference `json:"seaweedRef"`
 
 	// Name is the IAM policy name. Defaults to .metadata.name. Immutable
-	// once set.
+	// once set. IAM policy names are global to the cluster: the oldest CR
+	// claiming a name owns it, and later claimants are marked Failed with
+	// a Conflict condition.
 	// +optional
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=128

--- a/api/v1/s3policybinding_types.go
+++ b/api/v1/s3policybinding_types.go
@@ -20,10 +20,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// S3PolicyRef references the IAM policy to attach. The Name is the IAM policy
-// name, which equals the target S3Policy's resolved name.
+// S3PolicyRef references the IAM policy to attach. The Name resolves to an
+// S3Policy of that name in the same namespace (using its effective IAM policy
+// name, so a spec.name override is transparent); when no such S3Policy
+// exists, Name is taken as the IAM policy name itself.
 type S3PolicyRef struct {
-	// Name is the IAM policy name.
+	// Name of the S3Policy in the same namespace, or the IAM policy name
+	// for a policy not managed by an S3Policy resource.
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=128
 	Name string `json:"name"`
@@ -46,8 +49,8 @@ type S3Subject struct {
 	// +kubebuilder:default:=S3Identity
 	Kind S3SubjectKind `json:"kind,omitempty"`
 
-	// Name is the IAM user name of the subject. This equals the target
-	// S3Identity's resolved name.
+	// Name of the S3Identity in the same namespace, or the IAM user name
+	// for an identity not managed by an S3Identity resource.
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
 	Name string `json:"name"`
@@ -109,6 +112,10 @@ type S3PolicyBindingStatus struct {
 	// +optional
 	// +listType=atomic
 	AttachedSubjects []string `json:"attachedSubjects,omitempty"`
+
+	// PolicyName is the IAM policy name the policyRef resolved to.
+	// +optional
+	PolicyName string `json:"policyName,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/seaweed.seaweedfs.com_s3credentials.yaml
+++ b/config/crd/bases/seaweed.seaweedfs.com_s3credentials.yaml
@@ -140,6 +140,8 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              identityName:
+                type: string
               observedGeneration:
                 format: int64
                 type: integer

--- a/config/crd/bases/seaweed.seaweedfs.com_s3policybindings.yaml
+++ b/config/crd/bases/seaweed.seaweedfs.com_s3policybindings.yaml
@@ -152,6 +152,8 @@ spec:
                 - Failed
                 - Terminating
                 type: string
+              policyName:
+                type: string
             type: object
         type: object
     served: true

--- a/deploy/helm/templates/crd-seaweed.yaml
+++ b/deploy/helm/templates/crd-seaweed.yaml
@@ -536,6 +536,8 @@ spec:
                   x-kubernetes-list-map-keys:
                     - type
                   x-kubernetes-list-type: map
+                identityName:
+                  type: string
                 observedGeneration:
                   format: int64
                   type: integer
@@ -1164,6 +1166,8 @@ spec:
                     - Ready
                     - Failed
                     - Terminating
+                  type: string
+                policyName:
                   type: string
               type: object
           type: object

--- a/internal/controller/iam_name_claim.go
+++ b/internal/controller/iam_name_claim.go
@@ -1,0 +1,196 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+)
+
+// IAM user and policy names are global per Seaweed cluster while the CRs
+// managing them are namespaced, so two CRs can claim the same IAM name. The
+// helpers here serialize such claims: the oldest CR owns the name and later
+// claimants are surfaced as conflicts instead of silently fighting over one
+// IAM object.
+
+func identityIAMName(id *seaweedv1.S3Identity) string {
+	if id.Spec.Name != "" {
+		return id.Spec.Name
+	}
+	return id.Name
+}
+
+func policyIAMName(p *seaweedv1.S3Policy) string {
+	if p.Spec.Name != "" {
+		return p.Spec.Name
+	}
+	return p.Name
+}
+
+// seaweedRefKey identifies the referenced cluster with the namespace default
+// applied.
+func seaweedRefKey(ref seaweedv1.SeaweedReference, ownNamespace string) string {
+	ns := ref.Namespace
+	if ns == "" {
+		ns = ownNamespace
+	}
+	return ns + "/" + ref.Name
+}
+
+// claimPrecedes reports whether a outranks b for a contested IAM name: older
+// creationTimestamp first, namespace/name as the deterministic tiebreaker.
+func claimPrecedes(a, b metav1.Object) bool {
+	at, bt := a.GetCreationTimestamp(), b.GetCreationTimestamp()
+	if !at.Equal(&bt) {
+		return at.Before(&bt)
+	}
+	if a.GetNamespace() != b.GetNamespace() {
+		return a.GetNamespace() < b.GetNamespace()
+	}
+	return a.GetName() < b.GetName()
+}
+
+// identityClaimants returns the other live S3Identities claiming the same IAM
+// user name on the same cluster as self.
+func identityClaimants(ctx context.Context, c client.Client, self *seaweedv1.S3Identity, name string) ([]*seaweedv1.S3Identity, error) {
+	var list seaweedv1.S3IdentityList
+	if err := c.List(ctx, &list); err != nil {
+		return nil, err
+	}
+	cluster := seaweedRefKey(self.Spec.SeaweedRef, self.Namespace)
+	var out []*seaweedv1.S3Identity
+	for i := range list.Items {
+		peer := &list.Items[i]
+		if peer.Namespace == self.Namespace && peer.Name == self.Name {
+			continue
+		}
+		if !peer.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if identityIAMName(peer) != name || seaweedRefKey(peer.Spec.SeaweedRef, peer.Namespace) != cluster {
+			continue
+		}
+		out = append(out, peer)
+	}
+	return out, nil
+}
+
+// identityConflict returns the claimant that outranks self for the contested
+// IAM user name, or nil when self owns it.
+func identityConflict(ctx context.Context, c client.Client, self *seaweedv1.S3Identity, name string) (*seaweedv1.S3Identity, error) {
+	peers, err := identityClaimants(ctx, c, self, name)
+	if err != nil {
+		return nil, err
+	}
+	var winner *seaweedv1.S3Identity
+	for _, peer := range peers {
+		if winner == nil || claimPrecedes(peer, winner) {
+			winner = peer
+		}
+	}
+	if winner == nil || claimPrecedes(self, winner) {
+		return nil, nil
+	}
+	return winner, nil
+}
+
+// policyClaimants returns the other live S3Policies claiming the same IAM
+// policy name on the same cluster as self.
+func policyClaimants(ctx context.Context, c client.Client, self *seaweedv1.S3Policy, name string) ([]*seaweedv1.S3Policy, error) {
+	var list seaweedv1.S3PolicyList
+	if err := c.List(ctx, &list); err != nil {
+		return nil, err
+	}
+	cluster := seaweedRefKey(self.Spec.SeaweedRef, self.Namespace)
+	var out []*seaweedv1.S3Policy
+	for i := range list.Items {
+		peer := &list.Items[i]
+		if peer.Namespace == self.Namespace && peer.Name == self.Name {
+			continue
+		}
+		if !peer.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if policyIAMName(peer) != name || seaweedRefKey(peer.Spec.SeaweedRef, peer.Namespace) != cluster {
+			continue
+		}
+		out = append(out, peer)
+	}
+	return out, nil
+}
+
+// policyConflict returns the claimant that outranks self for the contested
+// IAM policy name, or nil when self owns it.
+func policyConflict(ctx context.Context, c client.Client, self *seaweedv1.S3Policy, name string) (*seaweedv1.S3Policy, error) {
+	peers, err := policyClaimants(ctx, c, self, name)
+	if err != nil {
+		return nil, err
+	}
+	var winner *seaweedv1.S3Policy
+	for _, peer := range peers {
+		if winner == nil || claimPrecedes(peer, winner) {
+			winner = peer
+		}
+	}
+	if winner == nil || claimPrecedes(self, winner) {
+		return nil, nil
+	}
+	return winner, nil
+}
+
+// resolveIdentityIAMName maps an identityRef/subject name to an IAM user
+// name. A same-namespace S3Identity of that resource name targeting the same
+// cluster resolves to its effective IAM name; otherwise the reference is the
+// IAM name itself (an identity not managed by a CR).
+func resolveIdentityIAMName(ctx context.Context, c client.Client, namespace, ref, clusterKey string) (string, error) {
+	var id seaweedv1.S3Identity
+	err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: ref}, &id)
+	switch {
+	case err == nil:
+		if seaweedRefKey(id.Spec.SeaweedRef, id.Namespace) == clusterKey {
+			return identityIAMName(&id), nil
+		}
+		return ref, nil
+	case apierrors.IsNotFound(err):
+		return ref, nil
+	default:
+		return "", err
+	}
+}
+
+// resolvePolicyIAMName is resolveIdentityIAMName for policyRef.
+func resolvePolicyIAMName(ctx context.Context, c client.Client, namespace, ref, clusterKey string) (string, error) {
+	var p seaweedv1.S3Policy
+	err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: ref}, &p)
+	switch {
+	case err == nil:
+		if seaweedRefKey(p.Spec.SeaweedRef, p.Namespace) == clusterKey {
+			return policyIAMName(&p), nil
+		}
+		return ref, nil
+	case apierrors.IsNotFound(err):
+		return ref, nil
+	default:
+		return "", err
+	}
+}

--- a/internal/controller/iam_name_claim_test.go
+++ b/internal/controller/iam_name_claim_test.go
@@ -214,6 +214,20 @@ func TestS3Policy_SameNameAcrossNamespaces_OldestWins(t *testing.T) {
 	}
 }
 
+func TestS3Identity_MapToNameClaimants_EnqueuesPeers(t *testing.T) {
+	scheme := iamTestScheme(t)
+	older := identityAt("media", "myapp", 2*time.Hour)
+	newer := identityAt("staging", "myapp", time.Hour)
+	unrelated := identityAt("media", "other", time.Hour)
+	cli := iamTestClient(t, scheme, newTestSeaweed(), stagingRefGrant(), older, newer, unrelated)
+	r := &S3IdentityReconciler{Client: cli, Log: logf.FromContext(context.Background()), Scheme: scheme}
+
+	reqs := r.mapToNameClaimants(context.Background(), older)
+	if len(reqs) != 1 || reqs[0].NamespacedName != (types.NamespacedName{Namespace: "staging", Name: "myapp"}) {
+		t.Errorf("requests = %v, want only staging/myapp", reqs)
+	}
+}
+
 func TestS3Credentials_IdentityRefResolvesResourceName(t *testing.T) {
 	scheme := iamTestScheme(t)
 	id := identityAt("media", "myapp", time.Hour)

--- a/internal/controller/iam_name_claim_test.go
+++ b/internal/controller/iam_name_claim_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -98,6 +99,35 @@ func TestS3Identity_SameNameAcrossNamespaces_OldestWins(t *testing.T) {
 	cond := meta.FindStatusCondition(loser.Status.Conditions, seaweedv1.S3ConditionReady)
 	if cond == nil || cond.Reason != "Conflict" {
 		t.Errorf("loser Ready condition = %+v, want reason Conflict", cond)
+	}
+}
+
+func TestS3Identity_EqualTimestamps_NamespaceTiebreak(t *testing.T) {
+	scheme := iamTestScheme(t)
+	first := identityAt("media", "myapp", time.Hour)
+	second := identityAt("staging", "myapp", time.Hour)
+	second.CreationTimestamp = first.CreationTimestamp
+	cli := iamTestClient(t, scheme, newTestSeaweed(), stagingRefGrant(), first, second)
+	fa := newFakeIAMAdmin()
+	r := &S3IdentityReconciler{Client: cli, Log: logf.FromContext(context.Background()), Scheme: scheme}
+	r.AdminFactory = fakeIAMFactory(fa)
+
+	reconcileStable(t, r, types.NamespacedName{Namespace: "media", Name: "myapp"}, 5)
+	reconcileOnce(t, r, types.NamespacedName{Namespace: "staging", Name: "myapp"})
+
+	var winner seaweedv1.S3Identity
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "media", Name: "myapp"}, &winner); err != nil {
+		t.Fatalf("get winner: %v", err)
+	}
+	if winner.Status.Phase != seaweedv1.S3PhaseReady {
+		t.Errorf("winner phase = %q, want Ready (media precedes staging)", winner.Status.Phase)
+	}
+	var loser seaweedv1.S3Identity
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "staging", Name: "myapp"}, &loser); err != nil {
+		t.Fatalf("get loser: %v", err)
+	}
+	if loser.Status.Phase != seaweedv1.S3PhaseFailed {
+		t.Errorf("loser phase = %q, want Failed", loser.Status.Phase)
 	}
 }
 
@@ -330,6 +360,164 @@ func TestS3Credentials_Delete_CleansUpResolvedIdentity(t *testing.T) {
 	}
 	if len(user.AccessKeys) != 0 {
 		t.Errorf("access keys = %v, want the provisioned key removed", user.AccessKeys)
+	}
+}
+
+func TestS3Credentials_PinnedIdentitySurvivesShadowingResource(t *testing.T) {
+	scheme := iamTestScheme(t)
+	// Provisioned under the literal name "external"; an S3Identity of that
+	// resource name appears later with a different IAM name.
+	shadow := identityAt("media", "external", time.Hour)
+	shadow.Spec.Name = "external-media"
+	cred := &seaweedv1.S3Credentials{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "ext-creds",
+			Namespace:  "media",
+			Finalizers: []string{s3CredentialsFinalizer},
+		},
+		Spec: seaweedv1.S3CredentialsSpec{
+			SeaweedRef:  iamSeaweedRef(),
+			IdentityRef: seaweedv1.S3IdentityRef{Name: "external"},
+		},
+		Status: seaweedv1.S3CredentialsStatus{AccessKey: "AKIA123", IdentityName: "external"},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "ext-creds", Namespace: "media"},
+		Data:       map[string][]byte{"accessKey": []byte("AKIA123"), "secretKey": []byte("sk")},
+	}
+	cli := iamTestClient(t, scheme, newTestSeaweed(), shadow, cred, secret)
+	fa := newFakeIAMAdmin()
+	fa.seedUser("external")
+	fa.seedUser("external-media")
+	if err := fa.CreateAccessKey(context.Background(), "external", "AKIA123", "sk"); err != nil {
+		t.Fatalf("seed key: %v", err)
+	}
+	r := &S3CredentialsReconciler{Client: cli, Log: logf.FromContext(context.Background()), Scheme: scheme}
+	r.AdminFactory = fakeIAMFactory(fa)
+
+	key := types.NamespacedName{Namespace: "media", Name: "ext-creds"}
+	reconcileStable(t, r, key, 5)
+
+	var got seaweedv1.S3Credentials
+	if err := cli.Get(context.Background(), key, &got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status.IdentityName != "external" {
+		t.Errorf("status.identityName = %q, want the pinned external", got.Status.IdentityName)
+	}
+	shadowUser, err := fa.GetUser(context.Background(), "external-media")
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if len(shadowUser.AccessKeys) != 0 {
+		t.Errorf("keys on external-media = %v, want none (key must not move)", shadowUser.AccessKeys)
+	}
+}
+
+func TestS3PolicyBinding_PinnedPolicySurvivesShadowingResource(t *testing.T) {
+	scheme := iamTestScheme(t)
+	shadow := policyAt("media", "rw", time.Hour, `{"Version":"2012-10-17","Statement":[]}`)
+	shadow.Spec.Name = "rw-media"
+	binding := &seaweedv1.S3PolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "bob-rw",
+			Namespace:  "media",
+			Finalizers: []string{s3PolicyBindingFinalizer},
+		},
+		Spec: seaweedv1.S3PolicyBindingSpec{
+			SeaweedRef: iamSeaweedRef(),
+			PolicyRef:  seaweedv1.S3PolicyRef{Name: "rw"},
+			Subjects:   []seaweedv1.S3Subject{{Kind: seaweedv1.S3SubjectKindIdentity, Name: "bob"}},
+		},
+		Status: seaweedv1.S3PolicyBindingStatus{PolicyName: "rw", AttachedSubjects: []string{"bob"}},
+	}
+	cli := iamTestClient(t, scheme, newTestSeaweed(), shadow, binding)
+	fa := newFakeIAMAdmin()
+	fa.seedUser("bob")
+	fa.policies["rw"] = `{}`
+	fa.policies["rw-media"] = `{}`
+	if err := fa.AttachPolicy(context.Background(), "bob", "rw"); err != nil {
+		t.Fatalf("seed attach: %v", err)
+	}
+	r := &S3PolicyBindingReconciler{Client: cli, Log: logf.FromContext(context.Background()), Scheme: scheme}
+	r.AdminFactory = fakeIAMFactory(fa)
+
+	key := types.NamespacedName{Namespace: "media", Name: "bob-rw"}
+	reconcileStable(t, r, key, 5)
+
+	var got seaweedv1.S3PolicyBinding
+	if err := cli.Get(context.Background(), key, &got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status.PolicyName != "rw" {
+		t.Errorf("status.policyName = %q, want the pinned rw", got.Status.PolicyName)
+	}
+	user, err := fa.GetUser(context.Background(), "bob")
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if len(user.PolicyNames) != 1 || user.PolicyNames[0] != "rw" {
+		t.Errorf("policies on bob = %v, want [rw] (attachment must not move)", user.PolicyNames)
+	}
+}
+
+func TestS3PolicyBinding_PendingBindingFollowsResolution(t *testing.T) {
+	scheme := iamTestScheme(t)
+	binding := &seaweedv1.S3PolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "bob-rw", Namespace: "media"},
+		Spec: seaweedv1.S3PolicyBindingSpec{
+			SeaweedRef: iamSeaweedRef(),
+			PolicyRef:  seaweedv1.S3PolicyRef{Name: "rw"},
+			Subjects:   []seaweedv1.S3Subject{{Kind: seaweedv1.S3SubjectKindIdentity, Name: "bob"}},
+		},
+	}
+	cli := iamTestClient(t, scheme, newTestSeaweed(), binding)
+	fa := newFakeIAMAdmin()
+	fa.seedUser("bob")
+	r := &S3PolicyBindingReconciler{Client: cli, Log: logf.FromContext(context.Background()), Scheme: scheme}
+	r.AdminFactory = fakeIAMFactory(fa)
+
+	key := types.NamespacedName{Namespace: "media", Name: "bob-rw"}
+	reconcileOnce(t, r, key) // finalizer
+	reconcileOnce(t, r, key) // pending: policy missing
+
+	var pendingState seaweedv1.S3PolicyBinding
+	if err := cli.Get(context.Background(), key, &pendingState); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if pendingState.Status.Phase != seaweedv1.S3PhasePending {
+		t.Fatalf("phase = %q, want Pending while the policy is missing", pendingState.Status.Phase)
+	}
+	if pendingState.Status.PolicyName != "" {
+		t.Fatalf("status.policyName = %q, want unpinned while pending", pendingState.Status.PolicyName)
+	}
+
+	// The S3Policy arrives late with an IAM name override; the waiting
+	// binding must follow the resource-backed resolution.
+	pol := policyAt("media", "rw", time.Hour, `{}`)
+	pol.Spec.Name = "rw-media"
+	if err := cli.Create(context.Background(), pol); err != nil {
+		t.Fatalf("create policy: %v", err)
+	}
+	fa.policies["rw-media"] = `{}`
+
+	reconcileStable(t, r, key, 5)
+	var got seaweedv1.S3PolicyBinding
+	if err := cli.Get(context.Background(), key, &got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status.Phase != seaweedv1.S3PhaseReady {
+		t.Fatalf("phase = %q, want Ready", got.Status.Phase)
+	}
+	if got.Status.PolicyName != "rw-media" {
+		t.Errorf("status.policyName = %q, want rw-media", got.Status.PolicyName)
+	}
+	user, err := fa.GetUser(context.Background(), "bob")
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if len(user.PolicyNames) != 1 || user.PolicyNames[0] != "rw-media" {
+		t.Errorf("policies on bob = %v, want [rw-media]", user.PolicyNames)
 	}
 }
 

--- a/internal/controller/iam_name_claim_test.go
+++ b/internal/controller/iam_name_claim_test.go
@@ -1,0 +1,387 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+)
+
+// stagingRefGrant authorizes IAM CRs in "staging" to reference the test
+// Seaweed cluster, mirroring the default grant for "media".
+func stagingRefGrant() *seaweedv1.ResourceReferenceGrant {
+	return &seaweedv1.ResourceReferenceGrant{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-allow-staging", Namespace: "seaweedfs"},
+		Spec: seaweedv1.ResourceReferenceGrantSpec{
+			From: []seaweedv1.ReferenceGrantFrom{
+				{Group: groupSeaweed, Kind: kindS3Identity, Namespace: "staging"},
+				{Group: groupSeaweed, Kind: kindS3Policy, Namespace: "staging"},
+			},
+			To: []seaweedv1.ReferenceGrantTo{{Group: groupSeaweed, Kind: kindSeaweed}},
+		},
+	}
+}
+
+func identityAt(namespace, name string, age time.Duration) *seaweedv1.S3Identity {
+	return &seaweedv1.S3Identity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-age)),
+		},
+		Spec: seaweedv1.S3IdentitySpec{SeaweedRef: iamSeaweedRef()},
+	}
+}
+
+func policyAt(namespace, name string, age time.Duration, doc string) *seaweedv1.S3Policy {
+	return &seaweedv1.S3Policy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-age)),
+		},
+		Spec: seaweedv1.S3PolicySpec{SeaweedRef: iamSeaweedRef(), PolicyDocument: doc},
+	}
+}
+
+func TestS3Identity_SameNameAcrossNamespaces_OldestWins(t *testing.T) {
+	scheme := iamTestScheme(t)
+	older := identityAt("media", "myapp", 2*time.Hour)
+	newer := identityAt("staging", "myapp", time.Hour)
+	cli := iamTestClient(t, scheme, newTestSeaweed(), stagingRefGrant(), older, newer)
+	fa := newFakeIAMAdmin()
+	r := &S3IdentityReconciler{Client: cli, Log: logf.FromContext(context.Background()), Scheme: scheme}
+	r.AdminFactory = fakeIAMFactory(fa)
+
+	olderKey := types.NamespacedName{Namespace: "media", Name: "myapp"}
+	newerKey := types.NamespacedName{Namespace: "staging", Name: "myapp"}
+	reconcileStable(t, r, olderKey, 5)
+	reconcileOnce(t, r, newerKey)
+
+	var winner seaweedv1.S3Identity
+	if err := cli.Get(context.Background(), olderKey, &winner); err != nil {
+		t.Fatalf("get winner: %v", err)
+	}
+	if winner.Status.Phase != seaweedv1.S3PhaseReady {
+		t.Errorf("winner phase = %q, want Ready", winner.Status.Phase)
+	}
+
+	var loser seaweedv1.S3Identity
+	if err := cli.Get(context.Background(), newerKey, &loser); err != nil {
+		t.Fatalf("get loser: %v", err)
+	}
+	if loser.Status.Phase != seaweedv1.S3PhaseFailed {
+		t.Errorf("loser phase = %q, want Failed", loser.Status.Phase)
+	}
+	cond := meta.FindStatusCondition(loser.Status.Conditions, seaweedv1.S3ConditionReady)
+	if cond == nil || cond.Reason != "Conflict" {
+		t.Errorf("loser Ready condition = %+v, want reason Conflict", cond)
+	}
+}
+
+func TestS3Identity_SameNameDifferentClusters_NoConflict(t *testing.T) {
+	scheme := iamTestScheme(t)
+	second := newTestSeaweed()
+	second.Name = "prod2"
+	older := identityAt("media", "myapp", 2*time.Hour)
+	newer := identityAt("staging", "myapp", time.Hour)
+	newer.Spec.SeaweedRef = seaweedv1.SeaweedReference{Name: "prod2", Namespace: "seaweedfs"}
+	cli := iamTestClient(t, scheme, newTestSeaweed(), second, stagingRefGrant(), older, newer)
+	fa := newFakeIAMAdmin()
+	r := &S3IdentityReconciler{Client: cli, Log: logf.FromContext(context.Background()), Scheme: scheme}
+	r.AdminFactory = fakeIAMFactory(fa)
+
+	reconcileStable(t, r, types.NamespacedName{Namespace: "media", Name: "myapp"}, 5)
+	reconcileStable(t, r, types.NamespacedName{Namespace: "staging", Name: "myapp"}, 5)
+
+	var got seaweedv1.S3Identity
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "staging", Name: "myapp"}, &got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status.Phase != seaweedv1.S3PhaseReady {
+		t.Errorf("phase = %q, want Ready (different clusters do not conflict)", got.Status.Phase)
+	}
+}
+
+func TestS3Identity_ConflictLoserDelete_LeavesUserIntact(t *testing.T) {
+	scheme := iamTestScheme(t)
+	older := identityAt("media", "myapp", 2*time.Hour)
+	newer := identityAt("staging", "myapp", time.Hour)
+	newer.Finalizers = []string{s3IdentityFinalizer}
+	cli := iamTestClient(t, scheme, newTestSeaweed(), stagingRefGrant(), older, newer)
+	fa := newFakeIAMAdmin()
+	fa.seedUser("myapp")
+	r := &S3IdentityReconciler{Client: cli, Log: logf.FromContext(context.Background()), Scheme: scheme}
+	r.AdminFactory = fakeIAMFactory(fa)
+
+	if err := cli.Delete(context.Background(), newer); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	reconcileOnce(t, r, types.NamespacedName{Namespace: "staging", Name: "myapp"})
+
+	if _, err := fa.GetUser(context.Background(), "myapp"); err != nil {
+		t.Fatalf("user myapp should survive deletion of the conflicting CR, got %v", err)
+	}
+}
+
+func TestS3Identity_WinnerDelete_PromotesLoser(t *testing.T) {
+	scheme := iamTestScheme(t)
+	older := identityAt("media", "myapp", 2*time.Hour)
+	older.Finalizers = []string{s3IdentityFinalizer}
+	newer := identityAt("staging", "myapp", time.Hour)
+	cli := iamTestClient(t, scheme, newTestSeaweed(), stagingRefGrant(), older, newer)
+	fa := newFakeIAMAdmin()
+	fa.seedUser("myapp")
+	r := &S3IdentityReconciler{Client: cli, Log: logf.FromContext(context.Background()), Scheme: scheme}
+	r.AdminFactory = fakeIAMFactory(fa)
+
+	olderKey := types.NamespacedName{Namespace: "media", Name: "myapp"}
+	newerKey := types.NamespacedName{Namespace: "staging", Name: "myapp"}
+	reconcileOnce(t, r, newerKey)
+
+	if err := cli.Delete(context.Background(), older); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	reconcileOnce(t, r, olderKey)
+
+	// The departing winner hands the user over to the surviving claimant.
+	if _, err := fa.GetUser(context.Background(), "myapp"); err != nil {
+		t.Fatalf("user myapp should be handed over, got %v", err)
+	}
+
+	reconcileStable(t, r, newerKey, 5)
+	var got seaweedv1.S3Identity
+	if err := cli.Get(context.Background(), newerKey, &got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status.Phase != seaweedv1.S3PhaseReady {
+		t.Errorf("phase = %q, want Ready after winner removal", got.Status.Phase)
+	}
+}
+
+func TestS3Policy_SameNameAcrossNamespaces_OldestWins(t *testing.T) {
+	scheme := iamTestScheme(t)
+	older := policyAt("media", "rw", 2*time.Hour, `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:*"],"Resource":["arn:aws:s3:::media/*"]}]}`)
+	newer := policyAt("staging", "rw", time.Hour, `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:*"],"Resource":["arn:aws:s3:::staging/*"]}]}`)
+	cli := iamTestClient(t, scheme, newTestSeaweed(), stagingRefGrant(), older, newer)
+	fa := newFakeIAMAdmin()
+	r := &S3PolicyReconciler{Client: cli, Log: logf.FromContext(context.Background()), Scheme: scheme}
+	r.AdminFactory = fakeIAMFactory(fa)
+
+	reconcileStable(t, r, types.NamespacedName{Namespace: "media", Name: "rw"}, 5)
+	reconcileOnce(t, r, types.NamespacedName{Namespace: "staging", Name: "rw"})
+
+	var loser seaweedv1.S3Policy
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "staging", Name: "rw"}, &loser); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if loser.Status.Phase != seaweedv1.S3PhaseFailed {
+		t.Errorf("loser phase = %q, want Failed", loser.Status.Phase)
+	}
+	cond := meta.FindStatusCondition(loser.Status.Conditions, seaweedv1.S3ConditionReady)
+	if cond == nil || cond.Reason != "Conflict" {
+		t.Errorf("loser Ready condition = %+v, want reason Conflict", cond)
+	}
+
+	doc, err := fa.GetPolicy(context.Background(), "rw")
+	if err != nil {
+		t.Fatalf("get policy: %v", err)
+	}
+	if doc != older.Spec.PolicyDocument {
+		t.Errorf("policy document was overwritten by the losing CR")
+	}
+}
+
+func TestS3Credentials_IdentityRefResolvesResourceName(t *testing.T) {
+	scheme := iamTestScheme(t)
+	id := identityAt("media", "myapp", time.Hour)
+	id.Spec.Name = "myapp-media"
+	cred := &seaweedv1.S3Credentials{
+		ObjectMeta: metav1.ObjectMeta{Name: "myapp-creds", Namespace: "media"},
+		Spec: seaweedv1.S3CredentialsSpec{
+			SeaweedRef:  iamSeaweedRef(),
+			IdentityRef: seaweedv1.S3IdentityRef{Name: "myapp"},
+		},
+	}
+	cli := iamTestClient(t, scheme, newTestSeaweed(), id, cred)
+	fa := newFakeIAMAdmin()
+	fa.seedUser("myapp-media")
+	r := &S3CredentialsReconciler{Client: cli, Log: logf.FromContext(context.Background()), Scheme: scheme}
+	r.AdminFactory = fakeIAMFactory(fa)
+
+	key := types.NamespacedName{Namespace: "media", Name: "myapp-creds"}
+	reconcileStable(t, r, key, 5)
+
+	var got seaweedv1.S3Credentials
+	if err := cli.Get(context.Background(), key, &got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status.Phase != seaweedv1.S3PhaseReady {
+		t.Fatalf("phase = %q, want Ready", got.Status.Phase)
+	}
+	if got.Status.IdentityName != "myapp-media" {
+		t.Errorf("status.identityName = %q, want myapp-media", got.Status.IdentityName)
+	}
+	user, err := fa.GetUser(context.Background(), "myapp-media")
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if len(user.AccessKeys) != 1 || user.AccessKeys[0] != got.Status.AccessKey {
+		t.Errorf("access keys on myapp-media = %v, want [%s]", user.AccessKeys, got.Status.AccessKey)
+	}
+}
+
+func TestS3Credentials_IdentityRefFallsBackToIAMName(t *testing.T) {
+	scheme := iamTestScheme(t)
+	cred := &seaweedv1.S3Credentials{
+		ObjectMeta: metav1.ObjectMeta{Name: "ext-creds", Namespace: "media"},
+		Spec: seaweedv1.S3CredentialsSpec{
+			SeaweedRef:  iamSeaweedRef(),
+			IdentityRef: seaweedv1.S3IdentityRef{Name: "external"},
+		},
+	}
+	cli := iamTestClient(t, scheme, newTestSeaweed(), cred)
+	fa := newFakeIAMAdmin()
+	fa.seedUser("external")
+	r := &S3CredentialsReconciler{Client: cli, Log: logf.FromContext(context.Background()), Scheme: scheme}
+	r.AdminFactory = fakeIAMFactory(fa)
+
+	key := types.NamespacedName{Namespace: "media", Name: "ext-creds"}
+	reconcileStable(t, r, key, 5)
+
+	user, err := fa.GetUser(context.Background(), "external")
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if len(user.AccessKeys) != 1 {
+		t.Errorf("access keys on external = %v, want one key", user.AccessKeys)
+	}
+}
+
+func TestS3Credentials_Delete_CleansUpResolvedIdentity(t *testing.T) {
+	scheme := iamTestScheme(t)
+	cred := &seaweedv1.S3Credentials{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "myapp-creds",
+			Namespace:  "media",
+			Finalizers: []string{s3CredentialsFinalizer},
+		},
+		Spec: seaweedv1.S3CredentialsSpec{
+			SeaweedRef:  iamSeaweedRef(),
+			IdentityRef: seaweedv1.S3IdentityRef{Name: "myapp"},
+		},
+		Status: seaweedv1.S3CredentialsStatus{AccessKey: "AKIA123", IdentityName: "myapp-media"},
+	}
+	cli := iamTestClient(t, scheme, newTestSeaweed(), cred)
+	fa := newFakeIAMAdmin()
+	fa.seedUser("myapp-media")
+	if err := fa.CreateAccessKey(context.Background(), "myapp-media", "AKIA123", "secret"); err != nil {
+		t.Fatalf("seed key: %v", err)
+	}
+	r := &S3CredentialsReconciler{Client: cli, Log: logf.FromContext(context.Background()), Scheme: scheme}
+	r.AdminFactory = fakeIAMFactory(fa)
+
+	// The S3Identity that resolved "myapp" to "myapp-media" is already gone;
+	// status carries the resolved name.
+	if err := cli.Delete(context.Background(), cred); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	reconcileOnce(t, r, types.NamespacedName{Namespace: "media", Name: "myapp-creds"})
+
+	user, err := fa.GetUser(context.Background(), "myapp-media")
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if len(user.AccessKeys) != 0 {
+		t.Errorf("access keys = %v, want the provisioned key removed", user.AccessKeys)
+	}
+}
+
+func TestS3PolicyBinding_RefsResolveResourceNames(t *testing.T) {
+	scheme := iamTestScheme(t)
+	id := identityAt("media", "myapp", time.Hour)
+	id.Spec.Name = "myapp-media"
+	pol := policyAt("media", "rw", time.Hour, `{"Version":"2012-10-17","Statement":[]}`)
+	pol.Spec.Name = "rw-media"
+	binding := &seaweedv1.S3PolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "myapp-rw", Namespace: "media"},
+		Spec: seaweedv1.S3PolicyBindingSpec{
+			SeaweedRef: iamSeaweedRef(),
+			PolicyRef:  seaweedv1.S3PolicyRef{Name: "rw"},
+			Subjects:   []seaweedv1.S3Subject{{Kind: seaweedv1.S3SubjectKindIdentity, Name: "myapp"}},
+		},
+	}
+	cli := iamTestClient(t, scheme, newTestSeaweed(), id, pol, binding)
+	fa := newFakeIAMAdmin()
+	fa.seedUser("myapp-media")
+	fa.policies["rw-media"] = pol.Spec.PolicyDocument
+	r := &S3PolicyBindingReconciler{Client: cli, Log: logf.FromContext(context.Background()), Scheme: scheme}
+	r.AdminFactory = fakeIAMFactory(fa)
+
+	key := types.NamespacedName{Namespace: "media", Name: "myapp-rw"}
+	reconcileStable(t, r, key, 5)
+
+	var got seaweedv1.S3PolicyBinding
+	if err := cli.Get(context.Background(), key, &got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status.Phase != seaweedv1.S3PhaseReady {
+		t.Fatalf("phase = %q, want Ready", got.Status.Phase)
+	}
+	if got.Status.PolicyName != "rw-media" {
+		t.Errorf("status.policyName = %q, want rw-media", got.Status.PolicyName)
+	}
+	if len(got.Status.AttachedSubjects) != 1 || got.Status.AttachedSubjects[0] != "myapp-media" {
+		t.Errorf("attachedSubjects = %v, want [myapp-media]", got.Status.AttachedSubjects)
+	}
+	user, err := fa.GetUser(context.Background(), "myapp-media")
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if len(user.PolicyNames) != 1 || user.PolicyNames[0] != "rw-media" {
+		t.Errorf("policies on myapp-media = %v, want [rw-media]", user.PolicyNames)
+	}
+}
+
+func TestS3Policy_ConflictLoserDelete_LeavesPolicyIntact(t *testing.T) {
+	scheme := iamTestScheme(t)
+	older := policyAt("media", "rw", 2*time.Hour, `{"Version":"2012-10-17","Statement":[]}`)
+	newer := policyAt("staging", "rw", time.Hour, `{"Version":"2012-10-17","Statement":[]}`)
+	newer.Finalizers = []string{s3PolicyFinalizer}
+	cli := iamTestClient(t, scheme, newTestSeaweed(), stagingRefGrant(), older, newer)
+	fa := newFakeIAMAdmin()
+	fa.policies["rw"] = older.Spec.PolicyDocument
+	r := &S3PolicyReconciler{Client: cli, Log: logf.FromContext(context.Background()), Scheme: scheme}
+	r.AdminFactory = fakeIAMFactory(fa)
+
+	if err := cli.Delete(context.Background(), newer); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	reconcileOnce(t, r, types.NamespacedName{Namespace: "staging", Name: "rw"})
+
+	if _, err := fa.GetPolicy(context.Background(), "rw"); err != nil {
+		t.Fatalf("policy rw should survive deletion of the conflicting CR, got %v", err)
+	}
+}

--- a/internal/controller/s3credentials_controller.go
+++ b/internal/controller/s3credentials_controller.go
@@ -72,12 +72,17 @@ func (r *S3CredentialsReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	// Deletion cleans up the key on the identity it was provisioned for, even
-	// if the referenced S3Identity is already gone.
+	// Once a key is provisioned the credential is pinned to the IAM user it
+	// was provisioned for, so a later resource change cannot silently move
+	// the key to another user. A key recorded without an identity name
+	// predates pinning and was provisioned under the literal reference name.
 	var user string
-	if !cred.DeletionTimestamp.IsZero() && cred.Status.IdentityName != "" {
+	switch {
+	case cred.Status.IdentityName != "":
 		user = cred.Status.IdentityName
-	} else {
+	case cred.Status.AccessKey != "":
+		user = cred.Spec.IdentityRef.Name
+	default:
 		var err error
 		user, err = resolveIdentityIAMName(ctx, r.Client, cred.Namespace, cred.Spec.IdentityRef.Name,
 			seaweedRefKey(cred.Spec.SeaweedRef, cred.Namespace))

--- a/internal/controller/s3credentials_controller.go
+++ b/internal/controller/s3credentials_controller.go
@@ -72,15 +72,18 @@ func (r *S3CredentialsReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	user, err := resolveIdentityIAMName(ctx, r.Client, cred.Namespace, cred.Spec.IdentityRef.Name,
-		seaweedRefKey(cred.Spec.SeaweedRef, cred.Namespace))
-	if err != nil {
-		return ctrl.Result{}, err
-	}
 	// Deletion cleans up the key on the identity it was provisioned for, even
 	// if the referenced S3Identity is already gone.
+	var user string
 	if !cred.DeletionTimestamp.IsZero() && cred.Status.IdentityName != "" {
 		user = cred.Status.IdentityName
+	} else {
+		var err error
+		user, err = resolveIdentityIAMName(ctx, r.Client, cred.Namespace, cred.Spec.IdentityRef.Name,
+			seaweedRefKey(cred.Spec.SeaweedRef, cred.Namespace))
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 	secretName := cred.Spec.SecretRef.Name
 	if secretName == "" {

--- a/internal/controller/s3credentials_controller.go
+++ b/internal/controller/s3credentials_controller.go
@@ -59,6 +59,7 @@ type S3CredentialsReconciler struct {
 // +kubebuilder:rbac:groups=seaweed.seaweedfs.com,resources=s3credentials,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=seaweed.seaweedfs.com,resources=s3credentials/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=seaweed.seaweedfs.com,resources=s3credentials/finalizers,verbs=update
+// +kubebuilder:rbac:groups=seaweed.seaweedfs.com,resources=s3identities,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile drives an S3Credentials so the identity owns the access key held
@@ -71,7 +72,16 @@ func (r *S3CredentialsReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	user := cred.Spec.IdentityRef.Name
+	user, err := resolveIdentityIAMName(ctx, r.Client, cred.Namespace, cred.Spec.IdentityRef.Name,
+		seaweedRefKey(cred.Spec.SeaweedRef, cred.Namespace))
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	// Deletion cleans up the key on the identity it was provisioned for, even
+	// if the referenced S3Identity is already gone.
+	if !cred.DeletionTimestamp.IsZero() && cred.Status.IdentityName != "" {
+		user = cred.Status.IdentityName
+	}
 	secretName := cred.Spec.SecretRef.Name
 	if secretName == "" {
 		secretName = cred.Name
@@ -200,6 +210,7 @@ func (r *S3CredentialsReconciler) reconcileKey(ctx context.Context, cred *seawee
 	}
 
 	cred.Status.AccessKey = desiredAK
+	cred.Status.IdentityName = user
 	if secretNamespace != cred.Namespace {
 		cred.Status.SecretName = secretNamespace + "/" + secretName
 	} else {

--- a/internal/controller/s3identity_controller.go
+++ b/internal/controller/s3identity_controller.go
@@ -28,6 +28,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
 	"github.com/seaweedfs/seaweedfs-operator/internal/controller/swadmin"
@@ -226,6 +228,25 @@ func userStateDiffers(user *swadmin.IAMUser, displayName, email string, disabled
 	return user.DisplayName != displayName || user.Email != email || user.Disabled != disabled
 }
 
+// mapToNameClaimants enqueues the other claimants of an identity's IAM name
+// so a conflicted CR is promoted as soon as the owning CR changes or goes
+// away, instead of waiting for its periodic requeue.
+func (r *S3IdentityReconciler) mapToNameClaimants(ctx context.Context, obj client.Object) []reconcile.Request {
+	id, ok := obj.(*seaweedv1.S3Identity)
+	if !ok {
+		return nil
+	}
+	peers, err := identityClaimants(ctx, r.Client, id, identityIAMName(id))
+	if err != nil {
+		return nil
+	}
+	reqs := make([]reconcile.Request, 0, len(peers))
+	for _, p := range peers {
+		reqs = append(reqs, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(p)})
+	}
+	return reqs
+}
+
 // SetupWithManager wires the reconciler into the manager.
 func (r *S3IdentityReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.AdminFactory == nil {
@@ -233,5 +254,6 @@ func (r *S3IdentityReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&seaweedv1.S3Identity{}).
+		Watches(&seaweedv1.S3Identity{}, handler.EnqueueRequestsFromMapFunc(r.mapToNameClaimants)).
 		Complete(r)
 }

--- a/internal/controller/s3identity_controller.go
+++ b/internal/controller/s3identity_controller.go
@@ -79,6 +79,18 @@ func (r *S3IdentityReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return r.refForbidden(ctx, &identity, seaweedRefDeniedMessage(identity.Spec.SeaweedRef, kindS3Identity, identity.Namespace))
 		}
 		clearIAMCondition(&identity.Status.Conditions, seaweedv1.S3ConditionReferenceGranted)
+
+		// IAM user names are global per cluster: the oldest CR claiming a
+		// name owns it, later claimants conflict instead of co-managing it.
+		owner, err := identityConflict(ctx, r.Client, &identity, name)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if owner != nil {
+			return r.fail(ctx, &identity, "Conflict",
+				fmt.Sprintf("IAM user %q on Seaweed %s is already managed by S3Identity %s/%s",
+					name, seaweedRefKey(identity.Spec.SeaweedRef, identity.Namespace), owner.Namespace, owner.Name))
+		}
 	}
 
 	target, found, err := resolveSeaweedFiler(ctx, r.Client, identity.Spec.SeaweedRef, identity.Namespace)
@@ -148,7 +160,14 @@ func (r *S3IdentityReconciler) handleDeletion(ctx context.Context, identity *sea
 	}
 	identity.Status.Phase = seaweedv1.S3PhaseTerminating
 
-	if identity.Spec.ReclaimPolicy != seaweedv1.S3ReclaimRetain {
+	// A surviving claimant takes the user over instead of having it deleted
+	// out from under it.
+	claimants, err := identityClaimants(ctx, r.Client, identity, name)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if identity.Spec.ReclaimPolicy != seaweedv1.S3ReclaimRetain && len(claimants) == 0 {
 		// Idempotent: a user already gone (deleted out-of-band) must not
 		// block finalizer removal.
 		if err := admin.DeleteUser(ctx, name); err != nil && !errors.Is(err, ErrIAMNotFound) {

--- a/internal/controller/s3policy_controller.go
+++ b/internal/controller/s3policy_controller.go
@@ -77,6 +77,18 @@ func (r *S3PolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			return r.refForbidden(ctx, &policy, seaweedRefDeniedMessage(policy.Spec.SeaweedRef, kindS3Policy, policy.Namespace))
 		}
 		clearIAMCondition(&policy.Status.Conditions, seaweedv1.S3ConditionReferenceGranted)
+
+		// IAM policy names are global per cluster: the oldest CR claiming a
+		// name owns it, later claimants conflict instead of co-managing it.
+		owner, err := policyConflict(ctx, r.Client, &policy, name)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if owner != nil {
+			return r.fail(ctx, &policy, "Conflict",
+				fmt.Sprintf("IAM policy %q on Seaweed %s is already managed by S3Policy %s/%s",
+					name, seaweedRefKey(policy.Spec.SeaweedRef, policy.Namespace), owner.Namespace, owner.Name))
+		}
 	}
 
 	target, found, err := resolveSeaweedFiler(ctx, r.Client, policy.Spec.SeaweedRef, policy.Namespace)
@@ -130,7 +142,14 @@ func (r *S3PolicyReconciler) handleDeletion(ctx context.Context, policy *seaweed
 	}
 	policy.Status.Phase = seaweedv1.S3PhaseTerminating
 
-	if policy.Spec.ReclaimPolicy != seaweedv1.S3ReclaimRetain {
+	// A surviving claimant takes the policy over instead of having it deleted
+	// out from under it.
+	claimants, err := policyClaimants(ctx, r.Client, policy, name)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if policy.Spec.ReclaimPolicy != seaweedv1.S3ReclaimRetain && len(claimants) == 0 {
 		// Idempotent: a policy already gone must not block finalizer removal.
 		if err := admin.DeletePolicy(ctx, name); err != nil && !errors.Is(err, ErrIAMNotFound) {
 			setIAMCondition(&policy.Status.Conditions, policy.Generation, seaweedv1.S3ConditionReady, metav1.ConditionFalse, "DeleteFailed", err.Error())

--- a/internal/controller/s3policy_controller.go
+++ b/internal/controller/s3policy_controller.go
@@ -28,6 +28,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
 )
@@ -198,6 +200,25 @@ func (r *S3PolicyReconciler) fail(ctx context.Context, policy *seaweedv1.S3Polic
 	return ctrl.Result{RequeueAfter: requeueAfterTransient}, nil
 }
 
+// mapToNameClaimants enqueues the other claimants of a policy's IAM name so a
+// conflicted CR is promoted as soon as the owning CR changes or goes away,
+// instead of waiting for its periodic requeue.
+func (r *S3PolicyReconciler) mapToNameClaimants(ctx context.Context, obj client.Object) []reconcile.Request {
+	p, ok := obj.(*seaweedv1.S3Policy)
+	if !ok {
+		return nil
+	}
+	peers, err := policyClaimants(ctx, r.Client, p, policyIAMName(p))
+	if err != nil {
+		return nil
+	}
+	reqs := make([]reconcile.Request, 0, len(peers))
+	for _, peer := range peers {
+		reqs = append(reqs, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(peer)})
+	}
+	return reqs
+}
+
 // SetupWithManager wires the reconciler into the manager.
 func (r *S3PolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.AdminFactory == nil {
@@ -205,5 +226,6 @@ func (r *S3PolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&seaweedv1.S3Policy{}).
+		Watches(&seaweedv1.S3Policy{}, handler.EnqueueRequestsFromMapFunc(r.mapToNameClaimants)).
 		Complete(r)
 }

--- a/internal/controller/s3policybinding_controller.go
+++ b/internal/controller/s3policybinding_controller.go
@@ -47,6 +47,7 @@ type S3PolicyBindingReconciler struct {
 // +kubebuilder:rbac:groups=seaweed.seaweedfs.com,resources=s3policybindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=seaweed.seaweedfs.com,resources=s3policybindings/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=seaweed.seaweedfs.com,resources=s3policybindings/finalizers,verbs=update
+// +kubebuilder:rbac:groups=seaweed.seaweedfs.com,resources=s3policies;s3identities,verbs=get;list;watch
 
 // Reconcile drives an S3PolicyBinding so the policy is attached to exactly the
 // listed subjects.
@@ -58,7 +59,16 @@ func (r *S3PolicyBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	policyName := binding.Spec.PolicyRef.Name
+	policyName, err := resolvePolicyIAMName(ctx, r.Client, binding.Namespace, binding.Spec.PolicyRef.Name,
+		seaweedRefKey(binding.Spec.SeaweedRef, binding.Namespace))
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	// Deletion detaches the policy it attached, even if the referenced
+	// S3Policy is already gone.
+	if !binding.DeletionTimestamp.IsZero() && binding.Status.PolicyName != "" {
+		policyName = binding.Status.PolicyName
+	}
 
 	// Cross-namespace seaweedRef needs a grant; skip on deletion to not block cleanup.
 	if binding.DeletionTimestamp.IsZero() {
@@ -98,6 +108,8 @@ func (r *S3PolicyBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{Requeue: true}, nil
 	}
 
+	binding.Status.PolicyName = policyName
+
 	// Wait for the policy to exist before attaching it to anyone.
 	if _, err := admin.GetPolicy(ctx, policyName); err != nil {
 		if errors.Is(err, ErrIAMNotFound) {
@@ -107,7 +119,10 @@ func (r *S3PolicyBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return r.fail(ctx, &binding, "PolicyLookupFailed", err.Error())
 	}
 
-	desired := desiredSubjects(binding.Spec.Subjects)
+	desired, err := resolveSubjects(ctx, r.Client, &binding)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 
 	// Detach subjects no longer listed (compared against the last applied set).
 	desiredSet := map[string]struct{}{}
@@ -223,20 +238,25 @@ func (r *S3PolicyBindingReconciler) fail(ctx context.Context, binding *seaweedv1
 	return ctrl.Result{RequeueAfter: requeueAfterTransient}, nil
 }
 
-// desiredSubjects returns the deduplicated, sorted list of IAM user names from
-// the binding's subjects.
-func desiredSubjects(subjects []seaweedv1.S3Subject) []string {
+// resolveSubjects returns the deduplicated, sorted list of IAM user names the
+// binding's subjects resolve to.
+func resolveSubjects(ctx context.Context, c client.Client, binding *seaweedv1.S3PolicyBinding) ([]string, error) {
+	clusterKey := seaweedRefKey(binding.Spec.SeaweedRef, binding.Namespace)
 	seen := map[string]struct{}{}
-	out := make([]string, 0, len(subjects))
-	for _, s := range subjects {
-		if _, dup := seen[s.Name]; dup {
+	out := make([]string, 0, len(binding.Spec.Subjects))
+	for _, s := range binding.Spec.Subjects {
+		name, err := resolveIdentityIAMName(ctx, c, binding.Namespace, s.Name, clusterKey)
+		if err != nil {
+			return nil, err
+		}
+		if _, dup := seen[name]; dup {
 			continue
 		}
-		seen[s.Name] = struct{}{}
-		out = append(out, s.Name)
+		seen[name] = struct{}{}
+		out = append(out, name)
 	}
 	sort.Strings(out)
-	return out
+	return out, nil
 }
 
 // SetupWithManager wires the reconciler into the manager.

--- a/internal/controller/s3policybinding_controller.go
+++ b/internal/controller/s3policybinding_controller.go
@@ -59,15 +59,18 @@ func (r *S3PolicyBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	policyName, err := resolvePolicyIAMName(ctx, r.Client, binding.Namespace, binding.Spec.PolicyRef.Name,
-		seaweedRefKey(binding.Spec.SeaweedRef, binding.Namespace))
-	if err != nil {
-		return ctrl.Result{}, err
-	}
 	// Deletion detaches the policy it attached, even if the referenced
 	// S3Policy is already gone.
+	var policyName string
 	if !binding.DeletionTimestamp.IsZero() && binding.Status.PolicyName != "" {
 		policyName = binding.Status.PolicyName
+	} else {
+		var err error
+		policyName, err = resolvePolicyIAMName(ctx, r.Client, binding.Namespace, binding.Spec.PolicyRef.Name,
+			seaweedRefKey(binding.Spec.SeaweedRef, binding.Namespace))
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	// Cross-namespace seaweedRef needs a grant; skip on deletion to not block cleanup.

--- a/internal/controller/s3policybinding_controller.go
+++ b/internal/controller/s3policybinding_controller.go
@@ -59,12 +59,17 @@ func (r *S3PolicyBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	// Deletion detaches the policy it attached, even if the referenced
-	// S3Policy is already gone.
+	// Once attached the binding is pinned to the IAM policy it attached, so a
+	// later resource change cannot silently retarget it. Attached subjects
+	// recorded without a policy name predate pinning and used the literal
+	// reference name.
 	var policyName string
-	if !binding.DeletionTimestamp.IsZero() && binding.Status.PolicyName != "" {
+	switch {
+	case binding.Status.PolicyName != "":
 		policyName = binding.Status.PolicyName
-	} else {
+	case len(binding.Status.AttachedSubjects) > 0:
+		policyName = binding.Spec.PolicyRef.Name
+	default:
 		var err error
 		policyName, err = resolvePolicyIAMName(ctx, r.Client, binding.Namespace, binding.Spec.PolicyRef.Name,
 			seaweedRefKey(binding.Spec.SeaweedRef, binding.Namespace))
@@ -111,9 +116,9 @@ func (r *S3PolicyBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	binding.Status.PolicyName = policyName
-
-	// Wait for the policy to exist before attaching it to anyone.
+	// Wait for the policy to exist before attaching it to anyone. The pin is
+	// recorded only past this point, so a binding still waiting on its policy
+	// keeps following resolution changes.
 	if _, err := admin.GetPolicy(ctx, policyName); err != nil {
 		if errors.Is(err, ErrIAMNotFound) {
 			return r.pending(ctx, &binding, "PolicyMissing",
@@ -121,6 +126,7 @@ func (r *S3PolicyBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 		return r.fail(ctx, &binding, "PolicyLookupFailed", err.Error())
 	}
+	binding.Status.PolicyName = policyName
 
 	desired, err := resolveSubjects(ctx, r.Client, &binding)
 	if err != nil {


### PR DESCRIPTION
## Problem

`S3Identity` and `S3Policy` are namespaced CRs that manage cluster-global IAM names. CRs with the same effective name in different namespaces silently co-managed one IAM user/policy: access keys drifted, policy documents were overwritten by whichever CR reconciled last, and every CR still reported `Ready`. Deleting any one of them deleted the shared IAM object out from under the others.

On top of that, `identityRef` / `policyRef` / `subjects` were matched against IAM names rather than resource names, so a `spec.name` override leaked into every referencing resource.

## Changes

**Name claims (oldest CR wins)**
- The oldest CR claiming an IAM user/policy name on a cluster owns it (creationTimestamp, namespace/name tiebreak). Later claimants are marked `Failed` with a `Ready=False` / `reason: Conflict` condition naming the owning CR, and converge automatically once the owner is gone.
- CRs targeting different clusters never conflict.
- On deletion with `reclaimPolicy: Delete`, the IAM object is handed over to a surviving claimant instead of being deleted out from under it (mirrors the bucket deletion ownership guard).

**Reference resolution by resource name**
- `S3Credentials.identityRef`, `S3PolicyBinding.policyRef`, and `subjects` now resolve a same-namespace `S3Identity` / `S3Policy` of that resource name first, following its effective IAM name — a `spec.name` override no longer leaks into referencing resources.
- A name with no matching resource (or one targeting a different cluster) is still used as the literal IAM name, so existing manifests and identities not managed by a CR keep working.
- The resolved names are recorded in `status.identityName` / `status.policyName` so deletion cleans up the right IAM objects even after the referenced CR is gone.

**Docs**
- README and field docs now state that IAM names are global per cluster and how contested names behave.

## Testing

- New controller tests reproduce the collision (both CRs `Ready`, shared user/policy destroyed by deleting either CR) and verify the new behavior: oldest-wins conflict marking, no conflict across clusters, handover on deletion, promotion of the surviving claimant, and ref resolution incl. fallback and cleanup-after-CR-removal.
- `make test` (envtest + helm drift) passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Status fields expose resolved IAM names (`identityName` in S3Credentials, `policyName` in S3PolicyBinding).
  * Controllers resolve references to effective IAM names, persist them, and use them for reliable cleanup.
  * Cross-namespace name claimant tracking and peer-watch enqueuing to coordinate ownership changes.

* **Behavior**
  * IAM name conflict arbitration: oldest resource wins; later claimants surface `Conflict` and `Ready=False`.
  * Deletion now preserves IAM objects when other claimants exist and promotes survivors when appropriate.

* **Documentation**
  * Clarified global IAM name semantics, conflict resolution, and name-override/reference behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->