### PR TITLE
recover gRPC clients after Seaweed rollouts

### DIFF
--- a/internal/controller/bucket_admin.go
+++ b/internal/controller/bucket_admin.go
@@ -98,13 +98,7 @@ var (
 )
 
 // swadminBucketAdmin is the default BucketAdmin, backed by swadmin.SeaweedAdmin.
-//
-// Reconcile goroutines (one per Bucket worker, plus the periodic
-// usage-stats loop) share a single instance via the reconciler's admin
-// cache, so concurrent ProcessCommand calls would race on the embedded
-// SeaweedAdmin's Output writer. The mu serializes every command in this
-// admin's lifetime — coarse but sufficient: shell commands are short and
-// per-bucket reconciles don't fan out further than the worker count.
+// mu serializes command execution (which swaps the shared Output writer) and Close.
 type swadminBucketAdmin struct {
 	sa  *swadmin.SeaweedAdmin
 	iam *swadmin.IAMClient
@@ -123,12 +117,19 @@ func NewSwadminBucketAdmin(masters, filer string, signingKey []byte, grpcDialOpt
 	return &swadminBucketAdmin{sa: sa, iam: swadmin.NewIAMClient(filer, signingKey, grpcDialOption), log: log}, nil
 }
 
-func (a *swadminBucketAdmin) run(cmd string) (string, error) {
+// Close stops the embedded shell's background master connection.
+func (a *swadminBucketAdmin) Close() error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.sa.Close()
+}
+
+func (a *swadminBucketAdmin) run(ctx context.Context, cmd string) (string, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	var buf bytes.Buffer
 	a.sa.Output = &buf
-	err := a.sa.ProcessCommand(cmd)
+	err := a.sa.ProcessCommand(ctx, cmd)
 	if err != nil {
 		a.log.V(2).Info("swadmin command failed", "cmd", cmd, "stdout", buf.String(), "err", err.Error())
 	} else {
@@ -141,7 +142,7 @@ func (a *swadminBucketAdmin) run(cmd string) (string, error) {
 // no other flags — a read-only call that returns the current state when the
 // bucket is present and an explicit "lookup bucket" error when it is not.
 func (a *swadminBucketAdmin) BucketExists(ctx context.Context, name string) (bool, error) {
-	_, err := a.run(fmt.Sprintf("s3.bucket.versioning -name %s", name))
+	_, err := a.run(ctx, fmt.Sprintf("s3.bucket.versioning -name %s", name))
 	if err == nil {
 		return true, nil
 	}
@@ -159,7 +160,7 @@ func (a *swadminBucketAdmin) CreateBucket(ctx context.Context, name, owner strin
 	if withLock {
 		parts = append(parts, "-withLock")
 	}
-	_, err := a.run(strings.Join(parts, " "))
+	_, err := a.run(ctx, strings.Join(parts, " "))
 	if err == nil {
 		return nil
 	}
@@ -170,7 +171,7 @@ func (a *swadminBucketAdmin) CreateBucket(ctx context.Context, name, owner strin
 }
 
 func (a *swadminBucketAdmin) DeleteBucket(ctx context.Context, name string) error {
-	_, err := a.run(fmt.Sprintf("s3.bucket.delete -name %s", name))
+	_, err := a.run(ctx, fmt.Sprintf("s3.bucket.delete -name %s", name))
 	if err == nil {
 		return nil
 	}
@@ -184,7 +185,7 @@ func (a *swadminBucketAdmin) DeleteBucket(ctx context.Context, name string) erro
 }
 
 func (a *swadminBucketAdmin) SetVersioning(ctx context.Context, name, status string) error {
-	_, err := a.run(fmt.Sprintf("s3.bucket.versioning -name %s -status %s", name, status))
+	_, err := a.run(ctx, fmt.Sprintf("s3.bucket.versioning -name %s -status %s", name, status))
 	if err == nil {
 		return nil
 	}
@@ -195,34 +196,34 @@ func (a *swadminBucketAdmin) SetVersioning(ctx context.Context, name, status str
 }
 
 func (a *swadminBucketAdmin) EnableObjectLock(ctx context.Context, name string) error {
-	_, err := a.run(fmt.Sprintf("s3.bucket.lock -name %s -enable", name))
+	_, err := a.run(ctx, fmt.Sprintf("s3.bucket.lock -name %s -enable", name))
 	return err
 }
 
 func (a *swadminBucketAdmin) SetQuota(ctx context.Context, name string, sizeMiB int64, enforce bool) error {
-	if _, err := a.run(fmt.Sprintf("s3.bucket.quota -name %s -op set -sizeMB %d", name, sizeMiB)); err != nil {
+	if _, err := a.run(ctx, fmt.Sprintf("s3.bucket.quota -name %s -op set -sizeMB %d", name, sizeMiB)); err != nil {
 		return err
 	}
 	op := "enable"
 	if !enforce {
 		op = "disable"
 	}
-	_, err := a.run(fmt.Sprintf("s3.bucket.quota -name %s -op %s", name, op))
+	_, err := a.run(ctx, fmt.Sprintf("s3.bucket.quota -name %s -op %s", name, op))
 	return err
 }
 
 func (a *swadminBucketAdmin) RemoveQuota(ctx context.Context, name string) error {
-	_, err := a.run(fmt.Sprintf("s3.bucket.quota -name %s -op remove", name))
+	_, err := a.run(ctx, fmt.Sprintf("s3.bucket.quota -name %s -op remove", name))
 	return err
 }
 
 func (a *swadminBucketAdmin) SetOwner(ctx context.Context, name, owner string) error {
-	_, err := a.run(fmt.Sprintf("s3.bucket.owner -name %s -owner %s", name, owner))
+	_, err := a.run(ctx, fmt.Sprintf("s3.bucket.owner -name %s -owner %s", name, owner))
 	return err
 }
 
 func (a *swadminBucketAdmin) RemoveOwner(ctx context.Context, name string) error {
-	_, err := a.run(fmt.Sprintf("s3.bucket.owner -name %s -delete", name))
+	_, err := a.run(ctx, fmt.Sprintf("s3.bucket.owner -name %s -delete", name))
 	return err
 }
 
@@ -237,12 +238,12 @@ func (a *swadminBucketAdmin) Configure(ctx context.Context, prefix string, args 
 	parts := []string{"fs.configure", "-locationPrefix=" + prefix}
 	parts = append(parts, args...)
 	parts = append(parts, "-apply")
-	_, err := a.run(strings.Join(parts, " "))
+	_, err := a.run(ctx, strings.Join(parts, " "))
 	return err
 }
 
 func (a *swadminBucketAdmin) ListCollectionStats(ctx context.Context) (map[string]BucketCollectionStats, error) {
-	out, err := a.run("collection.list")
+	out, err := a.run(ctx, "collection.list")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -22,11 +22,9 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
-	"google.golang.org/grpc"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -76,18 +74,6 @@ type BucketReconciler struct {
 	// loop. Zero disables the loop entirely; the default in main.go is
 	// DefaultUsageRefreshInterval (5 minutes).
 	UsageRefreshInterval time.Duration
-
-	// adminCache holds one BucketAdmin per (Seaweed CR identity, masters
-	// string). swadmin.NewSeaweedAdmin spawns a background goroutine that
-	// keeps a master connection alive, so caching avoids leaking one
-	// goroutine per Reconcile. Entries are not actively evicted; if the
-	// underlying Seaweed CR's master replica count changes, the next
-	// Reconcile inserts a new entry under a different key and the old
-	// connection lingers until operator restart. That is consistent with
-	// the existing seaweed_maintenance.go pattern; a follow-up can plumb
-	// a cancelable context through swadmin.SeaweedAdmin to do better.
-	adminCache map[string]BucketAdmin
-	adminMu    sync.Mutex
 }
 
 // +kubebuilder:rbac:groups=seaweed.seaweedfs.com,resources=buckets,verbs=get;list;watch;create;update;patch;delete
@@ -160,14 +146,17 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	dialOption, tlsFingerprint, err := loadSeaweedGrpcDialOption(ctx, r.Client, &seaweed)
+	dialOption, _, err := loadSeaweedGrpcDialOption(ctx, r.Client, &seaweed)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	admin, err := r.getAdmin(seaweedNS, seaweed.Name, masters, filer, adminKey, dialOption, tlsFingerprint, log)
+	// One admin per pass: a cached weed-shell client can pin its master
+	// connection to a pod IP that vanished during a Seaweed rollout.
+	admin, err := r.AdminFactory(masters, filer, adminKey, dialOption, log)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+	defer closeBucketAdmin(admin, log)
 
 	// Deletion path.
 	if !bucket.DeletionTimestamp.IsZero() {
@@ -424,28 +413,14 @@ func (r *BucketReconciler) clearCondition(bucket *seaweedv1.Bucket, condType str
 	meta.RemoveStatusCondition(&bucket.Status.Conditions, condType)
 }
 
-// getAdmin returns a cached BucketAdmin for the (Seaweed CR, masters, filer,
-// signing key, TLS material) tuple. The signing-key and TLS fingerprints are
-// part of the cache key so rotating jwt.filer_signing.key (editing the
-// security ConfigMap) or the server certificate (cert-manager renewal) yields
-// a fresh admin rather than one holding stale credentials. See the comment on
-// adminCache about the goroutine-leak trade-off.
-func (r *BucketReconciler) getAdmin(ns, name, masters, filer string, signingKey []byte, dialOption grpc.DialOption, tlsFingerprint string, log logr.Logger) (BucketAdmin, error) {
-	key := ns + "/" + name + "@" + masters + "|" + filer + "|" + signingKeyFingerprint(signingKey) + "|" + tlsFingerprint
-	r.adminMu.Lock()
-	defer r.adminMu.Unlock()
-	if r.adminCache == nil {
-		r.adminCache = make(map[string]BucketAdmin)
+func closeBucketAdmin(admin BucketAdmin, log logr.Logger) {
+	closer, ok := admin.(interface{ Close() error })
+	if !ok {
+		return
 	}
-	if a, ok := r.adminCache[key]; ok {
-		return a, nil
+	if err := closer.Close(); err != nil {
+		log.Error(err, "close bucket admin")
 	}
-	a, err := r.AdminFactory(masters, filer, signingKey, dialOption, log)
-	if err != nil {
-		return nil, err
-	}
-	r.adminCache[key] = a
-	return a, nil
 }
 
 // SetupWithManager wires the reconciler into the controller-runtime manager.

--- a/internal/controller/bucket_controller_test.go
+++ b/internal/controller/bucket_controller_test.go
@@ -61,6 +61,16 @@ type fakeBucketAdmin struct {
 	collectionErr   error
 }
 
+type closingFakeBucketAdmin struct {
+	*fakeBucketAdmin
+	closeCalls *int
+}
+
+func (f *closingFakeBucketAdmin) Close() error {
+	(*f.closeCalls)++
+	return nil
+}
+
 func newFakeAdmin() *fakeBucketAdmin {
 	return &fakeBucketAdmin{existsResp: map[string]bool{}}
 }
@@ -310,6 +320,32 @@ func TestReconcile_NoSecurityConfigPassesEmptyKey(t *testing.T) {
 
 	if len(gotKey) != 0 {
 		t.Fatalf("expected empty key when no security ConfigMap, got %q", string(gotKey))
+	}
+}
+
+func TestReconcile_ClosesAdminAfterPass(t *testing.T) {
+	bucket := newTestBucket("photos")
+	bucket.Finalizers = []string{BucketFinalizer}
+	bucket.Status.BucketName = "photos"
+
+	closeCalls := 0
+	factoryCalls := 0
+	r, _ := testReconcilerWithFactory(t, func(_, _ string, _ []byte, _ grpc.DialOption, _ logr.Logger) (BucketAdmin, error) {
+		factoryCalls++
+		fa := newFakeAdmin()
+		fa.existsResp["photos"] = true
+		return &closingFakeBucketAdmin{fakeBucketAdmin: fa, closeCalls: &closeCalls}, nil
+	}, newTestSeaweed(), bucket)
+
+	key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if factoryCalls != 1 {
+		t.Fatalf("factory calls = %d, want 1", factoryCalls)
+	}
+	if closeCalls != 1 {
+		t.Fatalf("close calls = %d, want 1", closeCalls)
 	}
 }
 

--- a/internal/controller/bucket_usage.go
+++ b/internal/controller/bucket_usage.go
@@ -113,16 +113,17 @@ func (r *BucketReconciler) refreshClusterUsage(ctx context.Context, log logr.Log
 		log.Error(err, "load admin signing key for usage refresh", "seaweed", seaweedName)
 		return
 	}
-	dialOption, tlsFingerprint, err := loadSeaweedGrpcDialOption(ctx, r.Client, &seaweed)
+	dialOption, _, err := loadSeaweedGrpcDialOption(ctx, r.Client, &seaweed)
 	if err != nil {
 		log.Error(err, "load gRPC TLS credentials for usage refresh", "seaweed", seaweedName)
 		return
 	}
-	admin, err := r.getAdmin(seaweedNS, seaweedName, masters, filer, adminKey, dialOption, tlsFingerprint, r.Log)
+	admin, err := r.AdminFactory(masters, filer, adminKey, dialOption, r.Log)
 	if err != nil {
 		log.Error(err, "build admin for usage refresh", "seaweed", seaweedName)
 		return
 	}
+	defer closeBucketAdmin(admin, log)
 
 	stats, err := admin.ListCollectionStats(ctx)
 	if err != nil {

--- a/internal/controller/seaweed_maintenance.go
+++ b/internal/controller/seaweed_maintenance.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 
@@ -17,20 +18,22 @@ func (r *SeaweedReconciler) maintenance(m *seaweedv1.Seaweed) (done bool, result
 
 	// this step blocks since the operator can not access the masters when running from outside of the k8s cluster
 	sa := swadmin.NewSeaweedAdmin(masters, "", nil, ioutil.Discard)
+	defer sa.Close()
+	ctx := context.Background()
 
 	// For now this is an example of the admin commands
 	// master by default has some maintenance commands already.
 	r.Log.V(0).Info("volume.list")
 	sa.Output = os.Stdout
-	if err := sa.ProcessCommand("volume.list"); err != nil {
+	if err := sa.ProcessCommand(ctx, "volume.list"); err != nil {
 		r.Log.V(0).Info("volume.list", "error", err)
 	}
 
-	sa.ProcessCommand("lock")
-	if err := sa.ProcessCommand("volume.balance -force"); err != nil {
+	sa.ProcessCommand(ctx, "lock")
+	if err := sa.ProcessCommand(ctx, "volume.balance -force"); err != nil {
 		r.Log.V(0).Info("volume.balance", "error", err)
 	}
-	sa.ProcessCommand("unlock")
+	sa.ProcessCommand(ctx, "unlock")
 
 	return ReconcileResult(nil)
 

--- a/internal/controller/swadmin/iam_client.go
+++ b/internal/controller/swadmin/iam_client.go
@@ -92,16 +92,21 @@ func NewIAMClient(filer string, adminSigningKey []byte, dialOption grpc.DialOpti
 	}
 }
 
-// withClient opens a short-lived connection to the filer IAM service, applies
-// the request timeout, attaches an admin Bearer token when one is configured,
-// and invokes fn. Errors are returned verbatim so callers can classify gRPC
+// withClient runs fn against the filer IAM service on a fresh, short-lived
+// connection. Dialing per call instead of through seaweedfs' process-global
+// gRPC cache keeps the operator from pinning to a filer IP that moved during a
+// Seaweed rollout. Errors are returned verbatim so callers can classify gRPC
 // status codes.
 func (c *IAMClient) withClient(ctx context.Context, fn func(ctx context.Context, client iam_pb.SeaweedIdentityAccessManagementClient) error) error {
-	return pb.WithGrpcClient(ctx, false, 0, func(conn *grpc.ClientConn) error {
-		callCtx, cancel := context.WithTimeout(c.authContext(ctx), iamRequestTimeout)
-		defer cancel()
-		return fn(callCtx, iam_pb.NewSeaweedIdentityAccessManagementClient(conn))
-	}, c.filerGrpcAddress, false, c.dialOption)
+	conn, err := grpc.NewClient(c.filerGrpcAddress, c.dialOption)
+	if err != nil {
+		return fmt.Errorf("dial IAM service %s: %w", c.filerGrpcAddress, err)
+	}
+	defer conn.Close()
+
+	callCtx, cancel := context.WithTimeout(c.authContext(ctx), iamRequestTimeout)
+	defer cancel()
+	return fn(callCtx, iam_pb.NewSeaweedIdentityAccessManagementClient(conn))
 }
 
 // authContext returns ctx with an admin Bearer token appended to the outgoing

--- a/internal/controller/swadmin/iam_client_test.go
+++ b/internal/controller/swadmin/iam_client_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -69,7 +70,7 @@ func TestIAMClient_AuthContext_NoMetadataWhenKeyEmpty(t *testing.T) {
 // reaches the filer's IAM gRPC server by spinning up an in-process gRPC
 // server that asserts the incoming metadata. This is the regression test the
 // previous fake-IAMAdmin tests could never catch: it exercises the actual
-// withClient → pb.WithGrpcClient → unary call path.
+// withClient -> gRPC unary call path.
 func TestIAMClient_GetUser_SendsBearer(t *testing.T) {
 	key := []byte("test-jwt-signing-key")
 
@@ -106,6 +107,57 @@ func TestIAMClient_GetUser_SendsBearer(t *testing.T) {
 	if rec.authErr != nil {
 		t.Fatalf("filer rejected the token: %v", rec.authErr)
 	}
+}
+
+// TestIAMClient_GetUser_DialsFreshConnectionPerCall asserts each call dials a
+// new transport: seaweedfs' shared gRPC cache could otherwise pin the operator
+// to a filer that changed IP, so two calls must produce two accepted conns.
+func TestIAMClient_GetUser_DialsFreshConnectionPerCall(t *testing.T) {
+	key := []byte("test-jwt-signing-key")
+
+	srv := grpc.NewServer()
+	t.Cleanup(srv.Stop)
+	rec := &authRecordingIAM{adminSigningKey: security.SigningKey(key)}
+	iam_pb.RegisterSeaweedIdentityAccessManagementServer(srv, rec)
+
+	baseListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	lis := &countingListener{Listener: baseListener}
+	go func() { _ = srv.Serve(lis) }()
+
+	grpcPort := baseListener.Addr().(*net.TCPAddr).Port
+	if grpcPort < 10001 {
+		t.Skipf("ephemeral gRPC port %d too low to map to a valid HTTP port", grpcPort)
+	}
+	httpPort := grpcPort - 10000
+	c := NewIAMClient(net.JoinHostPort("127.0.0.1", strconv.Itoa(httpPort)), key, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	for i := 0; i < 2; i++ {
+		if _, err := c.GetUser(ctx, "alice"); err != nil {
+			t.Fatalf("GetUser call %d: %v", i+1, err)
+		}
+	}
+
+	if got := lis.accepts.Load(); got < 2 {
+		t.Fatalf("accepted connections = %d, want at least 2 fresh connections", got)
+	}
+}
+
+type countingListener struct {
+	net.Listener
+	accepts atomic.Int32
+}
+
+func (l *countingListener) Accept() (net.Conn, error) {
+	conn, err := l.Listener.Accept()
+	if err == nil {
+		l.accepts.Add(1)
+	}
+	return conn, err
 }
 
 // authRecordingIAM is a minimal IAM gRPC server stand-in that records whether

--- a/internal/controller/swadmin/seaweed_admin.go
+++ b/internal/controller/swadmin/seaweed_admin.go
@@ -6,13 +6,15 @@ import (
 	"io"
 	"regexp"
 	"strings"
+	"sync"
+	"time"
 
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/shell"
 	"github.com/seaweedfs/seaweedfs/weed/util/fla9"
-	"google.golang.org/grpc"
 )
 
 func init() {
@@ -31,7 +33,11 @@ type SeaweedAdmin struct {
 	commandReg *regexp.Regexp
 	commandEnv *shell.CommandEnv
 	Output     io.Writer
+	cancel     context.CancelFunc
+	closeOnce  sync.Once
 }
+
+const masterConnectionTimeout = 30 * time.Second
 
 // NewSeaweedAdmin builds a SeaweedAdmin that mirrors `weed shell`. filer is
 // required for s3.bucket.* / fs.* callers; master-only callers (volume.list,
@@ -54,27 +60,36 @@ func NewSeaweedAdmin(masters, filer string, dialOption grpc.DialOption, output i
 	commandEnv := shell.NewCommandEnv(&shellOptions)
 	reg, _ := regexp.Compile(`'.*?'|".*?"|\S+`)
 
-	go commandEnv.MasterClient.KeepConnectedToMaster(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	go commandEnv.MasterClient.KeepConnectedToMaster(ctx)
 
 	return &SeaweedAdmin{
 		commandEnv: commandEnv,
 		commandReg: reg,
 		Output:     output,
+		cancel:     cancel,
 	}
 }
 
-// ProcessCommands cmds can be semi-colon separated commands
-func (sa *SeaweedAdmin) ProcessCommands(cmds string) error {
+// Close stops the background master connection loop.
+func (sa *SeaweedAdmin) Close() error {
+	sa.closeOnce.Do(sa.cancel)
+	return nil
+}
+
+// ProcessCommands runs semicolon-separated commands in order.
+func (sa *SeaweedAdmin) ProcessCommands(ctx context.Context, cmds string) error {
 	for _, c := range strings.Split(cmds, ";") {
-		if err := sa.ProcessCommand(c); err != nil {
+		if err := sa.ProcessCommand(ctx, c); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (sa *SeaweedAdmin) ProcessCommand(cmd string) error {
-	sa.commandEnv.MasterClient.WaitUntilConnected(context.Background())
+// ProcessCommand runs one shell command, capping the wait for a master
+// connection at masterConnectionTimeout and observing ctx.
+func (sa *SeaweedAdmin) ProcessCommand(ctx context.Context, cmd string) error {
 	cmds := sa.commandReg.FindAllString(cmd, -1)
 	if len(cmds) == 0 {
 		return nil
@@ -88,6 +103,13 @@ func (sa *SeaweedAdmin) ProcessCommand(cmd string) error {
 
 	for _, c := range shell.Commands {
 		if c.Name() == cmds[0] || c.Name() == "fs."+cmds[0] {
+			waitCtx, cancel := context.WithTimeout(ctx, masterConnectionTimeout)
+			defer cancel()
+			// Trust the resolved master, not waitCtx.Err(): a connection that
+			// lands as the deadline fires must not read as a timeout.
+			if sa.commandEnv.MasterClient.GetMaster(waitCtx) == "" {
+				return fmt.Errorf("wait for master connection: %w", waitCtx.Err())
+			}
 			return c.Do(args, sa.commandEnv, sa.Output)
 		}
 	}

--- a/internal/controller/swadmin/seaweed_admin_test.go
+++ b/internal/controller/swadmin/seaweed_admin_test.go
@@ -1,9 +1,12 @@
 package swadmin
 
 import (
+	"context"
+	"errors"
 	"io"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 )
@@ -14,6 +17,7 @@ import (
 // moment any Bucket reached the reconciler.
 func TestNewSeaweedAdmin_DoesNotPanic(t *testing.T) {
 	sa := NewSeaweedAdmin("seaweed-master.invalid:9333", "seaweed-filer.invalid:8888", nil, io.Discard)
+	t.Cleanup(func() { _ = sa.Close() })
 	if sa == nil {
 		t.Fatal("NewSeaweedAdmin returned nil")
 	}
@@ -28,10 +32,27 @@ func TestNewSeaweedAdmin_DoesNotPanic(t *testing.T) {
 // dialed gRPC with an empty target.
 func TestNewSeaweedAdmin_FilerAddressWired(t *testing.T) {
 	sa := NewSeaweedAdmin("seaweed-master.invalid:9333", "seaweed-filer.invalid:8888", nil, io.Discard)
+	t.Cleanup(func() { _ = sa.Close() })
 	err := sa.commandEnv.WithFilerClient(false, func(filer_pb.SeaweedFilerClient) error {
 		return nil
 	})
 	if err != nil && strings.Contains(err.Error(), "received empty target") {
 		t.Fatalf("regression of issue #237: empty target leaked through despite non-empty filer arg: %v", err)
+	}
+}
+
+func TestSeaweedAdmin_ProcessCommand_CanceledWhileWaiting(t *testing.T) {
+	sa := NewSeaweedAdmin("seaweed-master.invalid:9333", "", nil, io.Discard)
+	t.Cleanup(func() { _ = sa.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	start := time.Now()
+	err := sa.ProcessCommand(ctx, "volume.list")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("ProcessCommand error = %v, want context.Canceled", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("canceled master wait took %v", elapsed)
 	}
 }


### PR DESCRIPTION
Fixes #280

## What changed

- open a fresh, direct gRPC connection for every IAM RPC instead of using SeaweedFS's process-global connection cache
- create and close the bucket `SeaweedAdmin` once per reconciliation pass, so its background master watcher cannot remain pinned indefinitely
- make waits for a master connection context-aware and cap them at 30 seconds
- add regression coverage for fresh IAM transports, canceled master waits, and bucket-admin cleanup

## Root cause

The IAM client was documented as short-lived but used `pb.WithGrpcClient` in non-streaming mode, which reuses a process-global channel by address. The bucket reconciler also cached a `SeaweedAdmin` and its background master connection for the lifetime of the operator. Those lifetimes outlived the master and filer pods they originally resolved during a Seaweed rollout.

## Reproduction

I could not reproduce the permanent failure on current `master` with SeaweedFS 4.33. In Kind, I created an identity, credentials, and a bucket, replaced the master and filer pods so both received new UIDs and IPs, then updated the existing resources while the operator pod remained unchanged. Current `master` recovered, although its cached `adminShell` clients logged reconnect attempts for roughly 40 seconds.

With this change deployed, the same restart completed with the operator UID and restart count unchanged; the existing identity and bucket updated immediately, and a newly created identity plus credentials reached `Ready` and produced its Secret.

## Validation

- `make test`
- `go test -race ./internal/controller/swadmin -count=1`
- `go test -race ./internal/controller -run 'TestReconcile_ClosesAdminAfterPass|TestReconcile_HappyPath_AddsFinalizerThenCreates' -count=1`
- live Kind master/filer replacement and post-restart IAM, credentials, and bucket reconciliation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved resource cleanup and connection lifecycle management; admin connections are closed promptly after use.
  * Made command execution context-aware with proper timeout and cancellation handling.
  * Switched to creating fresh client connections per operation for stronger isolation.

* **Bug Fixes**
  * Ensured admin clients are closed after reconcile and maintenance tasks to avoid leaked resources.

* **Tests**
  * Added tests verifying fresh connections per call and proper cancellation/closure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->