### PR TITLE
fix(iam): periodically resync IAM resources to self-heal lost filer state

### DIFF
--- a/internal/controller/iam_controller_common.go
+++ b/internal/controller/iam_controller_common.go
@@ -48,16 +48,10 @@ const (
 	s3OIDCProviderFinalizer  = "seaweed.seaweedfs.com/s3oidcprovider-protection"
 )
 
-// iamResyncInterval is how often a successfully reconciled IAM resource pulls
-// itself back through Reconcile even when its spec has not changed. The state
-// these controllers provision — users, access keys, policies, bindings, OIDC
-// providers — lives in the filer; if the filer's store is ephemeral, a filer
-// restart wipes it while the CR keeps reporting Ready. Without a periodic
-// resync nothing would re-trigger reconciliation, so the IAM state would stay
-// gone until the spec changed or the operator restarted. Re-running on this
-// cadence re-provisions whatever is missing, since every IAM reconcile is
-// idempotent (it checks existence and only creates what is absent). It mirrors
-// the safety-net requeue the Seaweed reconciler already performs.
+// iamResyncInterval re-runs a Ready IAM resource periodically so state lost when
+// the filer's ephemeral store restarts is re-provisioned without a spec change.
+// Each IAM reconcile is idempotent; this mirrors the Seaweed reconciler's
+// safety-net requeue.
 const iamResyncInterval = 5 * time.Minute
 
 // iamAdminProvider supplies (and caches) IAMAdmin instances per target filer.

--- a/internal/controller/iam_controller_common.go
+++ b/internal/controller/iam_controller_common.go
@@ -23,6 +23,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/go-logr/logr"
 	"google.golang.org/grpc"
@@ -46,6 +47,18 @@ const (
 	s3PolicyBindingFinalizer = "seaweed.seaweedfs.com/s3policybinding-protection"
 	s3OIDCProviderFinalizer  = "seaweed.seaweedfs.com/s3oidcprovider-protection"
 )
+
+// iamResyncInterval is how often a successfully reconciled IAM resource pulls
+// itself back through Reconcile even when its spec has not changed. The state
+// these controllers provision — users, access keys, policies, bindings, OIDC
+// providers — lives in the filer; if the filer's store is ephemeral, a filer
+// restart wipes it while the CR keeps reporting Ready. Without a periodic
+// resync nothing would re-trigger reconciliation, so the IAM state would stay
+// gone until the spec changed or the operator restarted. Re-running on this
+// cadence re-provisions whatever is missing, since every IAM reconcile is
+// idempotent (it checks existence and only creates what is absent). It mirrors
+// the safety-net requeue the Seaweed reconciler already performs.
+const iamResyncInterval = 5 * time.Minute
 
 // iamAdminProvider supplies (and caches) IAMAdmin instances per target filer.
 // Embedded in each IAM reconciler so they share the construction and caching

--- a/internal/controller/iam_controller_test.go
+++ b/internal/controller/iam_controller_test.go
@@ -112,9 +112,11 @@ func iamSeaweedRef() seaweedv1.SeaweedReference {
 	return seaweedv1.SeaweedReference{Name: "prod", Namespace: "seaweedfs"}
 }
 
-// reconcileStable hammers Reconcile until the result is neither Requeue nor a
-// timed requeue, mirroring reconcileUntilStable for the generic Reconciler
-// interface.
+// reconcileStable hammers Reconcile until it reaches steady state, mirroring
+// reconcileUntilStable for the generic Reconciler interface. Steady state is no
+// requeue at all, or only the periodic safety-net resync a successful IAM
+// reconcile requests; a transient backoff (waiting on a dependency) keeps the
+// loop going.
 func reconcileStable(t *testing.T, r reconcile.Reconciler, key types.NamespacedName, maxSteps int) {
 	t.Helper()
 	for i := 0; i < maxSteps; i++ {
@@ -122,7 +124,7 @@ func reconcileStable(t *testing.T, r reconcile.Reconciler, key types.NamespacedN
 		if err != nil {
 			t.Fatalf("reconcile step %d: %v", i, err)
 		}
-		if !res.Requeue && res.RequeueAfter == 0 {
+		if !res.Requeue && (res.RequeueAfter == 0 || res.RequeueAfter == iamResyncInterval) {
 			return
 		}
 	}

--- a/internal/controller/iam_controller_test.go
+++ b/internal/controller/iam_controller_test.go
@@ -112,11 +112,9 @@ func iamSeaweedRef() seaweedv1.SeaweedReference {
 	return seaweedv1.SeaweedReference{Name: "prod", Namespace: "seaweedfs"}
 }
 
-// reconcileStable hammers Reconcile until it reaches steady state, mirroring
-// reconcileUntilStable for the generic Reconciler interface. Steady state is no
-// requeue at all, or only the periodic safety-net resync a successful IAM
-// reconcile requests; a transient backoff (waiting on a dependency) keeps the
-// loop going.
+// reconcileStable hammers Reconcile until it reaches steady state: no requeue,
+// or only the periodic resync a successful IAM reconcile requests. A transient
+// backoff (waiting on a dependency) keeps the loop going.
 func reconcileStable(t *testing.T, r reconcile.Reconciler, key types.NamespacedName, maxSteps int) {
 	t.Helper()
 	for i := 0; i < maxSteps; i++ {

--- a/internal/controller/iam_resync_test.go
+++ b/internal/controller/iam_resync_test.go
@@ -30,19 +30,18 @@ import (
 )
 
 // simulateFilerRestart drops all IAM state the fake holds, mimicking a filer
-// whose ephemeral store is wiped when its pod restarts. The Kubernetes CRs are
-// untouched and keep reporting Ready, reproducing the lost-state scenario.
+// whose ephemeral store is wiped on pod restart while the CRs stay Ready.
 func (f *fakeIAMAdmin) simulateFilerRestart() {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.users = map[string]*swadmin.IAMUser{}
 	f.policies = map[string]string{}
 	f.providers = map[string]string{}
+	f.secretKeys = map[string]string{}
 }
 
-// TestS3Identity_ResyncReprovisionsUserAfterFilerRestart verifies the success
-// path schedules a periodic resync and that re-running it re-creates a user the
-// filer lost, without any spec change.
+// Success schedules a periodic resync, and re-running it re-creates a user the
+// filer lost — no spec change.
 func TestS3Identity_ResyncReprovisionsUserAfterFilerRestart(t *testing.T) {
 	scheme := iamTestScheme(t)
 	id := &seaweedv1.S3Identity{
@@ -77,9 +76,7 @@ func TestS3Identity_ResyncReprovisionsUserAfterFilerRestart(t *testing.T) {
 	}
 }
 
-// TestS3Credentials_ResyncReregistersKeyAfterFilerRestart verifies a lost
-// access key is re-registered on the identity from the key still held in the
-// Secret, on a plain resync pass.
+// A resync re-registers a lost access key from the key still held in the Secret.
 func TestS3Credentials_ResyncReregistersKeyAfterFilerRestart(t *testing.T) {
 	scheme := iamTestScheme(t)
 	cred := &seaweedv1.S3Credentials{
@@ -129,8 +126,7 @@ func TestS3Credentials_ResyncReregistersKeyAfterFilerRestart(t *testing.T) {
 	}
 }
 
-// TestS3Policy_ResyncReappliesPolicyAfterFilerRestart verifies a lost policy
-// document is re-applied on a plain resync pass.
+// A resync re-applies a lost policy document.
 func TestS3Policy_ResyncReappliesPolicyAfterFilerRestart(t *testing.T) {
 	scheme := iamTestScheme(t)
 	pol := &seaweedv1.S3Policy{

--- a/internal/controller/iam_resync_test.go
+++ b/internal/controller/iam_resync_test.go
@@ -1,0 +1,167 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+	"github.com/seaweedfs/seaweedfs-operator/internal/controller/swadmin"
+)
+
+// simulateFilerRestart drops all IAM state the fake holds, mimicking a filer
+// whose ephemeral store is wiped when its pod restarts. The Kubernetes CRs are
+// untouched and keep reporting Ready, reproducing the lost-state scenario.
+func (f *fakeIAMAdmin) simulateFilerRestart() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.users = map[string]*swadmin.IAMUser{}
+	f.policies = map[string]string{}
+	f.providers = map[string]string{}
+}
+
+// TestS3Identity_ResyncReprovisionsUserAfterFilerRestart verifies the success
+// path schedules a periodic resync and that re-running it re-creates a user the
+// filer lost, without any spec change.
+func TestS3Identity_ResyncReprovisionsUserAfterFilerRestart(t *testing.T) {
+	scheme := iamTestScheme(t)
+	id := &seaweedv1.S3Identity{
+		ObjectMeta: metav1.ObjectMeta{Name: "alice", Namespace: "media"},
+		Spec:       seaweedv1.S3IdentitySpec{SeaweedRef: iamSeaweedRef()},
+	}
+	cli := iamTestClient(t, scheme, newTestSeaweed(), id)
+	fa := newFakeIAMAdmin()
+	r := &S3IdentityReconciler{Client: cli, Log: logf.FromContext(context.Background()), Scheme: scheme}
+	r.AdminFactory = fakeIAMFactory(fa)
+
+	key := types.NamespacedName{Namespace: "media", Name: "alice"}
+	reconcileOnce(t, r, key) // adds finalizer
+	res := reconcileOnce(t, r, key)
+	if res.RequeueAfter != iamResyncInterval {
+		t.Fatalf("success path RequeueAfter = %v, want periodic resync %v", res.RequeueAfter, iamResyncInterval)
+	}
+	if _, err := fa.GetUser(context.Background(), "alice"); err != nil {
+		t.Fatalf("expected user alice created, got %v", err)
+	}
+
+	// Filer loses its IAM state; the CR still says Ready.
+	fa.simulateFilerRestart()
+	if _, err := fa.GetUser(context.Background(), "alice"); err == nil {
+		t.Fatal("precondition: user should be gone after simulated restart")
+	}
+
+	// The next resync pass must re-create the user.
+	reconcileStable(t, r, key, 5)
+	if _, err := fa.GetUser(context.Background(), "alice"); err != nil {
+		t.Fatalf("resync did not re-provision user alice: %v", err)
+	}
+}
+
+// TestS3Credentials_ResyncReregistersKeyAfterFilerRestart verifies a lost
+// access key is re-registered on the identity from the key still held in the
+// Secret, on a plain resync pass.
+func TestS3Credentials_ResyncReregistersKeyAfterFilerRestart(t *testing.T) {
+	scheme := iamTestScheme(t)
+	cred := &seaweedv1.S3Credentials{
+		ObjectMeta: metav1.ObjectMeta{Name: "alice-creds", Namespace: "media"},
+		Spec: seaweedv1.S3CredentialsSpec{
+			SeaweedRef:  iamSeaweedRef(),
+			IdentityRef: seaweedv1.S3IdentityRef{Name: "alice"},
+			SecretRef:   seaweedv1.S3SecretRef{Name: "alice-secret"},
+		},
+	}
+	cli := iamTestClient(t, scheme, newTestSeaweed(), cred)
+	fa := newFakeIAMAdmin()
+	fa.seedUser("alice")
+	r := &S3CredentialsReconciler{Client: cli, Log: logf.FromContext(context.Background()), Scheme: scheme}
+	r.AdminFactory = fakeIAMFactory(fa)
+
+	key := types.NamespacedName{Namespace: "media", Name: "alice-creds"}
+	reconcileStable(t, r, key, 5)
+	keys := fa.userKeys("alice")
+	if len(keys) != 1 {
+		t.Fatalf("expected 1 access key on alice, got %v", keys)
+	}
+	provisioned := keys[0]
+
+	// Filer restart wipes the user and its keys; the identity controller would
+	// re-create the user, so seed it back to isolate the credentials self-heal.
+	fa.simulateFilerRestart()
+	fa.seedUser("alice")
+	if k := fa.userKeys("alice"); len(k) != 0 {
+		t.Fatalf("precondition: keys should be gone after restart, got %v", k)
+	}
+
+	// Resync must re-register the same key the Secret still holds.
+	reconcileStable(t, r, key, 5)
+	keys = fa.userKeys("alice")
+	if len(keys) != 1 || keys[0] != provisioned {
+		t.Fatalf("resync did not re-register key %q, got %v", provisioned, keys)
+	}
+
+	// The Secret must be unchanged — no spurious rotation.
+	var secret corev1.Secret
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "media", Name: "alice-secret"}, &secret); err != nil {
+		t.Fatalf("get secret: %v", err)
+	}
+	if string(secret.Data[defaultAccessKeyField]) != provisioned {
+		t.Errorf("secret accessKey changed to %q, want stable %q", secret.Data[defaultAccessKeyField], provisioned)
+	}
+}
+
+// TestS3Policy_ResyncReappliesPolicyAfterFilerRestart verifies a lost policy
+// document is re-applied on a plain resync pass.
+func TestS3Policy_ResyncReappliesPolicyAfterFilerRestart(t *testing.T) {
+	scheme := iamTestScheme(t)
+	pol := &seaweedv1.S3Policy{
+		ObjectMeta: metav1.ObjectMeta{Name: "rw", Namespace: "media"},
+		Spec: seaweedv1.S3PolicySpec{
+			SeaweedRef: iamSeaweedRef(),
+			Statements: []seaweedv1.S3PolicyStatement{{
+				Effect:    seaweedv1.S3PolicyEffectAllow,
+				Actions:   []string{"s3:GetObject"},
+				Resources: []string{"my-bucket/*"},
+			}},
+		},
+	}
+	cli := iamTestClient(t, scheme, newTestSeaweed(), pol)
+	fa := newFakeIAMAdmin()
+	r := &S3PolicyReconciler{Client: cli, Log: logf.FromContext(context.Background()), Scheme: scheme}
+	r.AdminFactory = fakeIAMFactory(fa)
+
+	key := types.NamespacedName{Namespace: "media", Name: "rw"}
+	reconcileStable(t, r, key, 5)
+	if _, err := fa.GetPolicy(context.Background(), "rw"); err != nil {
+		t.Fatalf("expected policy rw, got %v", err)
+	}
+
+	fa.simulateFilerRestart()
+	if _, err := fa.GetPolicy(context.Background(), "rw"); err == nil {
+		t.Fatal("precondition: policy should be gone after simulated restart")
+	}
+
+	reconcileStable(t, r, key, 5)
+	if _, err := fa.GetPolicy(context.Background(), "rw"); err != nil {
+		t.Fatalf("resync did not re-apply policy rw: %v", err)
+	}
+}

--- a/internal/controller/s3credentials_controller.go
+++ b/internal/controller/s3credentials_controller.go
@@ -230,7 +230,9 @@ func (r *S3CredentialsReconciler) reconcileKey(ctx context.Context, cred *seawee
 	if err := r.Status().Update(ctx, cred); err != nil {
 		return ctrl.Result{}, err
 	}
-	return ctrl.Result{}, nil
+	// Resync periodically so a filer that lost its ephemeral IAM state gets the
+	// access key re-registered on the identity without waiting for a spec change.
+	return ctrl.Result{RequeueAfter: iamResyncInterval}, nil
 }
 
 // writeSecret creates or updates the Secret holding the key pair. A Secret the

--- a/internal/controller/s3credentials_controller.go
+++ b/internal/controller/s3credentials_controller.go
@@ -230,8 +230,6 @@ func (r *S3CredentialsReconciler) reconcileKey(ctx context.Context, cred *seawee
 	if err := r.Status().Update(ctx, cred); err != nil {
 		return ctrl.Result{}, err
 	}
-	// Resync periodically so a filer that lost its ephemeral IAM state gets the
-	// access key re-registered on the identity without waiting for a spec change.
 	return ctrl.Result{RequeueAfter: iamResyncInterval}, nil
 }
 

--- a/internal/controller/s3identity_controller.go
+++ b/internal/controller/s3identity_controller.go
@@ -153,8 +153,6 @@ func (r *S3IdentityReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	if err := r.Status().Update(ctx, &identity); err != nil {
 		return ctrl.Result{}, err
 	}
-	// Resync periodically so a filer that lost its ephemeral IAM state gets the
-	// user re-provisioned without waiting for a spec change.
 	return ctrl.Result{RequeueAfter: iamResyncInterval}, nil
 }
 

--- a/internal/controller/s3identity_controller.go
+++ b/internal/controller/s3identity_controller.go
@@ -153,7 +153,9 @@ func (r *S3IdentityReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	if err := r.Status().Update(ctx, &identity); err != nil {
 		return ctrl.Result{}, err
 	}
-	return ctrl.Result{}, nil
+	// Resync periodically so a filer that lost its ephemeral IAM state gets the
+	// user re-provisioned without waiting for a spec change.
+	return ctrl.Result{RequeueAfter: iamResyncInterval}, nil
 }
 
 func (r *S3IdentityReconciler) handleDeletion(ctx context.Context, identity *seaweedv1.S3Identity, name string, admin IAMAdmin) (ctrl.Result, error) {

--- a/internal/controller/s3oidcprovider_controller.go
+++ b/internal/controller/s3oidcprovider_controller.go
@@ -123,7 +123,9 @@ func (r *S3OIDCProviderReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if err := r.Status().Update(ctx, &provider); err != nil {
 		return ctrl.Result{}, err
 	}
-	return ctrl.Result{}, nil
+	// Resync periodically so a filer that lost its ephemeral IAM state gets the
+	// OIDC provider re-registered without waiting for a spec change.
+	return ctrl.Result{RequeueAfter: iamResyncInterval}, nil
 }
 
 func (r *S3OIDCProviderReconciler) handleDeletion(ctx context.Context, provider *seaweedv1.S3OIDCProvider, issuer string, admin IAMAdmin) (ctrl.Result, error) {

--- a/internal/controller/s3oidcprovider_controller.go
+++ b/internal/controller/s3oidcprovider_controller.go
@@ -123,8 +123,6 @@ func (r *S3OIDCProviderReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if err := r.Status().Update(ctx, &provider); err != nil {
 		return ctrl.Result{}, err
 	}
-	// Resync periodically so a filer that lost its ephemeral IAM state gets the
-	// OIDC provider re-registered without waiting for a spec change.
 	return ctrl.Result{RequeueAfter: iamResyncInterval}, nil
 }
 

--- a/internal/controller/s3policy_controller.go
+++ b/internal/controller/s3policy_controller.go
@@ -135,7 +135,9 @@ func (r *S3PolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if err := r.Status().Update(ctx, &policy); err != nil {
 		return ctrl.Result{}, err
 	}
-	return ctrl.Result{}, nil
+	// Resync periodically so a filer that lost its ephemeral IAM state gets the
+	// policy re-applied without waiting for a spec change.
+	return ctrl.Result{RequeueAfter: iamResyncInterval}, nil
 }
 
 func (r *S3PolicyReconciler) handleDeletion(ctx context.Context, policy *seaweedv1.S3Policy, name string, admin IAMAdmin) (ctrl.Result, error) {

--- a/internal/controller/s3policy_controller.go
+++ b/internal/controller/s3policy_controller.go
@@ -135,8 +135,6 @@ func (r *S3PolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if err := r.Status().Update(ctx, &policy); err != nil {
 		return ctrl.Result{}, err
 	}
-	// Resync periodically so a filer that lost its ephemeral IAM state gets the
-	// policy re-applied without waiting for a spec change.
 	return ctrl.Result{RequeueAfter: iamResyncInterval}, nil
 }
 

--- a/internal/controller/s3policybinding_controller.go
+++ b/internal/controller/s3policybinding_controller.go
@@ -177,8 +177,6 @@ func (r *S3PolicyBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	if err := r.Status().Update(ctx, &binding); err != nil {
 		return ctrl.Result{}, err
 	}
-	// Resync periodically so a filer that lost its ephemeral IAM state gets the
-	// policy re-attached to its subjects without waiting for a spec change.
 	return ctrl.Result{RequeueAfter: iamResyncInterval}, nil
 }
 

--- a/internal/controller/s3policybinding_controller.go
+++ b/internal/controller/s3policybinding_controller.go
@@ -177,7 +177,9 @@ func (r *S3PolicyBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	if err := r.Status().Update(ctx, &binding); err != nil {
 		return ctrl.Result{}, err
 	}
-	return ctrl.Result{}, nil
+	// Resync periodically so a filer that lost its ephemeral IAM state gets the
+	// policy re-attached to its subjects without waiting for a spec change.
+	return ctrl.Result{RequeueAfter: iamResyncInterval}, nil
 }
 
 func (r *S3PolicyBindingReconciler) handleDeletion(ctx context.Context, binding *seaweedv1.S3PolicyBinding, policyName string, admin IAMAdmin) (ctrl.Result, error) {


### PR DESCRIPTION
## Summary

Follow-up to #280 (see [this comment](https://github.com/seaweedfs/seaweedfs-operator/issues/280#issuecomment-4706180562)). PR #281 fixed the stale gRPC connection, but a second problem remained: after a **filer restart** wipes the filer's ephemeral IAM store, the `S3Identity` and `S3Credentials` controllers never re-provision — the CRs keep reporting `Ready` while `aws iam list-users` / `list-access-keys` come back empty and the S3 gateway rejects the key with `InvalidAccessKeyId`.

## Root cause

The IAM reconcilers (`S3Identity`, `S3Credentials`, `S3Policy`, `S3PolicyBinding`, `S3OIDCProvider`) already reconcile **idempotently and unconditionally** — there is no generation short-circuit; each one checks existence and creates only what is absent. The missing piece is a **trigger**: on the success (`Ready`) path they return `ctrl.Result{}` with no requeue, so after the initial reconcile nothing re-runs them until the spec changes or the operator restarts. When the filer loses its state, that re-run never comes.

(The other three IAM kinds share the identical success-path pattern, so they had the same latent bug even though only Identity/Credentials were observed failing — `S3Policy` happened to get re-triggered by chance.)

## Fix

Add a periodic safety-net requeue on the success path of all five IAM reconcilers — `RequeueAfter: iamResyncInterval` (5m). This mirrors the cadence the `Seaweed` reconciler already uses to "pull itself back periodically rather than relying solely on watches". Because every IAM reconcile is idempotent, the next resync pass re-creates a missing user / re-registers a lost access key (from the key still held in the Secret, so no rotation) / re-applies a missing policy, etc. — bounding recovery to one interval with no spec change required.

`Bucket` is intentionally left unchanged: its usage-refresh loop patches `status`, which re-enqueues the bucket and re-creates it on the filer, so it already self-heals (matching the reporter's observation that buckets recovered).

## Reproduce

Added `iam_resync_test.go`, which simulates a filer restart by dropping the fake admin's state while leaving the CRs `Ready`:
- before the fix, the success path returns `RequeueAfter == 0` (no self-heal trigger) — reproduced and confirmed failing;
- after the fix, a resync pass re-provisions the user / access key / policy.

## Testing

- `go test ./internal/... ./api/...` — pass
- `go vet ./...`, `go build ./...`, `gofmt` — clean
- (e2e suite needs a live cluster; not run here)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added periodic resynchronization of IAM resources at 5-minute intervals to automatically restore IAM state after ephemeral data loss, covering identities, credentials, policies, policy bindings, and OIDC providers.

* **Bug Fixes**
  * Updated reconciliation behavior and steady-state determination to treat timed resync requeues as normal convergence.

* **Tests**
  * Added/extended tests validating resync after a simulated restart, including reprovisioning users, re-registering credentials without key rotation, and reapplying policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->