### PR TITLE
fix(tls): store security.toml in a Secret instead of a ConfigMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,9 +425,10 @@ identity / policy they reference exists, so apply order does not matter.
 As with `Bucket`, a cross-namespace `seaweedRef` (and the `S3Credentials`
 `secretRef`) is **denied by default** and requires a
 [`ResourceReferenceGrant`](#cross-namespace-references-resourcereferencegrant)
-in the target namespace. Clusters that set `jwt.filer_signing.key` in
-`security.toml` (which makes the filer reject unauthenticated IAM gRPC
-calls) are not yet supported.
+in the target namespace. When the filer enforces `jwt.filer_signing.key`
+(rendered into the cluster's `security.toml` whenever a filer or admin is in
+spec), the operator reads that key and signs its own IAM gRPC calls with it,
+so authenticated filers are handled automatically.
 
 See the `config/samples/seaweed_v1_s3*.yaml` files for end-to-end examples.
 

--- a/internal/controller/bucket_controller_test.go
+++ b/internal/controller/bucket_controller_test.go
@@ -273,14 +273,14 @@ func newTestBucket(name string) *seaweedv1.Bucket {
 
 // TestReconcile_PassesAdminSigningKeyToFactory pins the issue #265 fix: the
 // reconciler must read jwt.filer_signing.key from the cluster's rendered
-// security ConfigMap and hand it to the BucketAdminFactory. Without it,
+// security Secret and hand it to the BucketAdminFactory. Without it,
 // s3.bucket.access (and every filer IAM call) is sent unauthenticated and the
 // bucket stays Failed with reason AccessFailed.
 func TestReconcile_PassesAdminSigningKeyToFactory(t *testing.T) {
 	sw := newTestSeaweedWithFiler()
-	cm := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Name: SecurityConfigMapName(sw), Namespace: sw.Namespace},
-		Data:       map[string]string{"security.toml": "[jwt.filer_signing]\nkey = \"abc123==\"\n"},
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: SecurityConfigSecretName(sw), Namespace: sw.Namespace},
+		Data:       map[string][]byte{"security.toml": []byte("[jwt.filer_signing]\nkey = \"abc123==\"\n")},
 	}
 	bucket := newTestBucket("photos")
 	bucket.Finalizers = []string{BucketFinalizer}
@@ -290,7 +290,7 @@ func TestReconcile_PassesAdminSigningKeyToFactory(t *testing.T) {
 	r, _ := testReconcilerWithFactory(t, func(_, _ string, key []byte, _ grpc.DialOption, _ logr.Logger) (BucketAdmin, error) {
 		gotKey = key
 		return fa, nil
-	}, sw, cm, bucket)
+	}, sw, secret, bucket)
 
 	key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
 	reconcileUntilStable(t, r, key, 5)
@@ -301,10 +301,10 @@ func TestReconcile_PassesAdminSigningKeyToFactory(t *testing.T) {
 }
 
 // TestReconcile_NoSecurityConfigPassesEmptyKey pins the unauthenticated path:
-// a cluster with no rendered security ConfigMap hands the factory an empty key
+// a cluster with no rendered security Secret hands the factory an empty key
 // so the filer IAM calls stay unauthenticated, matching its no-key branch.
 func TestReconcile_NoSecurityConfigPassesEmptyKey(t *testing.T) {
-	sw := newTestSeaweedWithFiler() // filer present, but no security ConfigMap seeded
+	sw := newTestSeaweedWithFiler() // filer present, but no security Secret seeded
 	bucket := newTestBucket("photos")
 	bucket.Finalizers = []string{BucketFinalizer}
 
@@ -319,7 +319,7 @@ func TestReconcile_NoSecurityConfigPassesEmptyKey(t *testing.T) {
 	reconcileUntilStable(t, r, key, 5)
 
 	if len(gotKey) != 0 {
-		t.Fatalf("expected empty key when no security ConfigMap, got %q", string(gotKey))
+		t.Fatalf("expected empty key when no security Secret, got %q", string(gotKey))
 	}
 }
 

--- a/internal/controller/controller_tls.go
+++ b/internal/controller/controller_tls.go
@@ -23,6 +23,10 @@ limitations under the License.
 // in the Helm chart down to one server cert (+ CA chain when using the
 // default self-signed issuer).
 //
+// security.toml itself is provisioned as a Secret rather than a ConfigMap:
+// it carries the jwt.filer_signing HMAC keys, which are credentials (anyone
+// holding them can mint valid JWTs), so they must not sit in a ConfigMap.
+//
 // We talk to cert-manager via unstructured.Unstructured instead of taking
 // a hard import dependency on the cert-manager Go module. Pulling in
 // cert-manager transitively pulls the AWS SDK, gateway-api, and dozens of
@@ -36,7 +40,7 @@ limitations under the License.
 //	Certificate <name>-ca            → Secret <name>-ca
 //	Issuer <name>-ca-issuer          (CA from <name>-ca)
 //	Certificate <name>-server        → Secret <name>-server-tls
-//	ConfigMap <name>-security-config (security.toml)
+//	Secret <name>-security-config    (security.toml)
 //
 // When TLSSpec.IssuerRef is set the operator skips the self-signed +
 // CA pair and issues <name>-server directly from the user's issuer.
@@ -71,7 +75,7 @@ const (
 	// cert/key values.
 	tlsMountPath = "/etc/sw-tls"
 
-	// securityConfigMountPath holds the security.toml ConfigMap. Separate
+	// securityConfigMountPath holds the security.toml Secret. Separate
 	// from the per-component filer.toml/master.toml path so TLS can be
 	// enabled independently of user-supplied component configs.
 	securityConfigMountPath = "/etc/sw-security"
@@ -79,12 +83,12 @@ const (
 	tlsVolumeName      = "sw-tls"
 	securityVolumeName = "sw-security"
 
-	tlsSecretSuffix         = "-server-tls"
-	caSecretSuffix          = "-ca"
-	selfSignedIssuerSuffix  = "-selfsigned"
-	caIssuerSuffix          = "-ca-issuer"
-	securityConfigMapSuffix = "-security-config"
-	serverCertSuffix        = "-server"
+	tlsSecretSuffix        = "-server-tls"
+	caSecretSuffix         = "-ca"
+	selfSignedIssuerSuffix = "-selfsigned"
+	caIssuerSuffix         = "-ca-issuer"
+	securitySecretSuffix   = "-security-config"
+	serverCertSuffix       = "-server"
 
 	certManagerGroup   = "cert-manager.io"
 	certManagerVersion = "v1"
@@ -106,9 +110,9 @@ func TLSServerSecretName(m *seaweedv1.Seaweed) string {
 	return m.Name + tlsSecretSuffix
 }
 
-// SecurityConfigMapName is the ConfigMap holding security.toml.
-func SecurityConfigMapName(m *seaweedv1.Seaweed) string {
-	return m.Name + securityConfigMapSuffix
+// SecurityConfigSecretName is the Secret holding security.toml.
+func SecurityConfigSecretName(m *seaweedv1.Seaweed) string {
+	return m.Name + securitySecretSuffix
 }
 
 // ensureTLS is called from the top-level Reconcile before any component is
@@ -142,7 +146,7 @@ func (r *SeaweedReconciler) ensureTLS(ctx context.Context, m *seaweedv1.Seaweed)
 	return ReconcileResult(nil)
 }
 
-// ensureSecurityConfig provisions the security.toml ConfigMap whenever the
+// ensureSecurityConfig provisions the security.toml Secret whenever the
 // filer or admin server is in spec, regardless of TLS state. The filer needs
 // jwt.filer_signing.key to register the IAM gRPC service the Admin UI Users
 // tab calls; the admin needs the same key to sign Bearer tokens. Bundling
@@ -152,10 +156,10 @@ func (r *SeaweedReconciler) ensureSecurityConfig(ctx context.Context, m *seaweed
 	if !securityConfigNeeded(m) {
 		return ReconcileResult(nil)
 	}
-	return r.ensureSecurityConfigMap(ctx, m)
+	return r.ensureSecuritySecret(ctx, m)
 }
 
-// securityConfigNeeded reports whether the security.toml ConfigMap should
+// securityConfigNeeded reports whether the security.toml Secret should
 // exist for this CR. True when filer or admin is in spec, or whenever TLS
 // is enabled (the [grpc.*] sections live in the same file).
 func securityConfigNeeded(m *seaweedv1.Seaweed) bool {
@@ -283,22 +287,18 @@ func (r *SeaweedReconciler) ensureServerCertificate(ctx context.Context, m *seaw
 	return ReconcileResult(r.applyUnstructured(ctx, m, u))
 }
 
-// ensureSecurityConfigMap writes the security.toml that every component
-// reads via -config_dir. All [grpc.<component>] stanzas point at the single
-// shared cert/key pair.
+// ensureSecuritySecret writes the security.toml that every component reads
+// via -config_dir. All [grpc.<component>] stanzas point at the single shared
+// cert/key pair. It is a Secret rather than a ConfigMap because the
+// jwt.filer_signing keys it carries are HMAC credentials.
 //
-// JWT keys are generated once and preserved across reconciliations by
-// reading the existing ConfigMap before rewriting it. This avoids silently
-// rotating JWT signing keys on every reconcile.
-func (r *SeaweedReconciler) ensureSecurityConfigMap(ctx context.Context, m *seaweedv1.Seaweed) (bool, ctrl.Result, error) {
-	name := SecurityConfigMapName(m)
-	existing := &corev1.ConfigMap{}
-	err := r.Get(ctx, client.ObjectKey{Name: name, Namespace: m.Namespace}, existing)
-	var jwtFilerWrite, jwtFilerRead string
-	if err == nil && existing.Data != nil {
-		jwtFilerWrite = extractTOMLKey(existing.Data["security.toml"], "jwt.filer_signing", "key")
-		jwtFilerRead = extractTOMLKey(existing.Data["security.toml"], "jwt.filer_signing.read", "key")
-	} else if err != nil && !apierrors.IsNotFound(err) {
+// JWT keys are generated once and preserved across reconciliations by reading
+// the existing material before rewriting it. This avoids silently rotating
+// JWT signing keys on every reconcile, which would invalidate live tokens.
+func (r *SeaweedReconciler) ensureSecuritySecret(ctx context.Context, m *seaweedv1.Seaweed) (bool, ctrl.Result, error) {
+	name := SecurityConfigSecretName(m)
+	jwtFilerWrite, jwtFilerRead, err := r.existingJWTSigningKeys(ctx, m, name)
+	if err != nil {
 		return ReconcileResult(err)
 	}
 	if jwtFilerWrite == "" {
@@ -308,21 +308,74 @@ func (r *SeaweedReconciler) ensureSecurityConfigMap(ctx context.Context, m *seaw
 		jwtFilerRead = randKey()
 	}
 
-	cm := &corev1.ConfigMap{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: m.Namespace,
 			Labels:    labelsForCR(m),
 		},
-		Data: map[string]string{
-			"security.toml": renderSecurityTOML(jwtFilerWrite, jwtFilerRead, tlsEffective(m)),
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"security.toml": []byte(renderSecurityTOML(jwtFilerWrite, jwtFilerRead, tlsEffective(m))),
 		},
 	}
-	if err := controllerutil.SetControllerReference(m, cm, r.Scheme); err != nil {
+	if err := controllerutil.SetControllerReference(m, secret, r.Scheme); err != nil {
 		return ReconcileResult(err)
 	}
-	_, err = r.CreateOrUpdateConfigMap(cm)
-	return ReconcileResult(err)
+	if _, err := r.CreateOrUpdateSecret(secret); err != nil {
+		return ReconcileResult(err)
+	}
+	// Remove the legacy ConfigMap left behind by operator versions that stored
+	// security.toml (and thus the JWT signing keys) in a ConfigMap.
+	if err := r.deleteLegacySecurityConfigMap(ctx, name, m.Namespace); err != nil {
+		return ReconcileResult(err)
+	}
+	return ReconcileResult(nil)
+}
+
+// existingJWTSigningKeys returns the JWT signing keys already provisioned for
+// m, so a reconcile preserves them instead of rotating. It prefers the
+// security Secret and falls back to the legacy ConfigMap (operator versions
+// before security.toml moved to a Secret), keeping keys stable across the
+// upgrade. Empty strings mean none exist yet — the caller generates fresh ones.
+func (r *SeaweedReconciler) existingJWTSigningKeys(ctx context.Context, m *seaweedv1.Seaweed, name string) (write, read string, err error) {
+	key := client.ObjectKey{Name: name, Namespace: m.Namespace}
+
+	secret := &corev1.Secret{}
+	err = r.Get(ctx, key, secret)
+	if err == nil {
+		toml := string(secret.Data["security.toml"])
+		return extractTOMLKey(toml, "jwt.filer_signing", "key"),
+			extractTOMLKey(toml, "jwt.filer_signing.read", "key"), nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return "", "", err
+	}
+
+	cm := &corev1.ConfigMap{}
+	err = r.Get(ctx, key, cm)
+	if err == nil {
+		toml := cm.Data["security.toml"]
+		return extractTOMLKey(toml, "jwt.filer_signing", "key"),
+			extractTOMLKey(toml, "jwt.filer_signing.read", "key"), nil
+	}
+	if apierrors.IsNotFound(err) {
+		return "", "", nil
+	}
+	return "", "", err
+}
+
+// deleteLegacySecurityConfigMap removes the pre-Secret security.toml ConfigMap
+// if it is still around. A missing ConfigMap (the steady state on fresh
+// installs) is not an error.
+func (r *SeaweedReconciler) deleteLegacySecurityConfigMap(ctx context.Context, name, namespace string) error {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+	}
+	if err := r.Delete(ctx, cm); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	return nil
 }
 
 // renderSecurityTOML emits the [jwt.filer_signing*] sections always (filer

--- a/internal/controller/controller_tls.go
+++ b/internal/controller/controller_tls.go
@@ -297,7 +297,7 @@ func (r *SeaweedReconciler) ensureServerCertificate(ctx context.Context, m *seaw
 // JWT signing keys on every reconcile, which would invalidate live tokens.
 func (r *SeaweedReconciler) ensureSecuritySecret(ctx context.Context, m *seaweedv1.Seaweed) (bool, ctrl.Result, error) {
 	name := SecurityConfigSecretName(m)
-	jwtFilerWrite, jwtFilerRead, err := r.existingJWTSigningKeys(ctx, m, name)
+	jwtFilerWrite, jwtFilerRead, fromLegacyConfigMap, err := r.existingJWTSigningKeys(ctx, m, name)
 	if err != nil {
 		return ReconcileResult(err)
 	}
@@ -325,10 +325,13 @@ func (r *SeaweedReconciler) ensureSecuritySecret(ctx context.Context, m *seaweed
 	if _, err := r.CreateOrUpdateSecret(secret); err != nil {
 		return ReconcileResult(err)
 	}
-	// Remove the legacy ConfigMap left behind by operator versions that stored
-	// security.toml (and thus the JWT signing keys) in a ConfigMap.
-	if err := r.deleteLegacySecurityConfigMap(ctx, name, m.Namespace); err != nil {
-		return ReconcileResult(err)
+	// Remove the legacy ConfigMap only when this reconcile actually read the
+	// keys out of it — i.e. the one migrating reconcile. Skipping it otherwise
+	// avoids a wasted Delete round-trip on every steady-state reconcile.
+	if fromLegacyConfigMap {
+		if err := r.deleteLegacySecurityConfigMap(ctx, name, m.Namespace); err != nil {
+			return ReconcileResult(err)
+		}
 	}
 	return ReconcileResult(nil)
 }
@@ -337,8 +340,10 @@ func (r *SeaweedReconciler) ensureSecuritySecret(ctx context.Context, m *seaweed
 // m, so a reconcile preserves them instead of rotating. It prefers the
 // security Secret and falls back to the legacy ConfigMap (operator versions
 // before security.toml moved to a Secret), keeping keys stable across the
-// upgrade. Empty strings mean none exist yet — the caller generates fresh ones.
-func (r *SeaweedReconciler) existingJWTSigningKeys(ctx context.Context, m *seaweedv1.Seaweed, name string) (write, read string, err error) {
+// upgrade. fromLegacyConfigMap is true only when the keys came from that
+// ConfigMap, signalling the caller to clean it up. Empty strings mean none
+// exist yet — the caller generates fresh ones.
+func (r *SeaweedReconciler) existingJWTSigningKeys(ctx context.Context, m *seaweedv1.Seaweed, name string) (write, read string, fromLegacyConfigMap bool, err error) {
 	key := client.ObjectKey{Name: name, Namespace: m.Namespace}
 
 	secret := &corev1.Secret{}
@@ -346,10 +351,10 @@ func (r *SeaweedReconciler) existingJWTSigningKeys(ctx context.Context, m *seawe
 	if err == nil {
 		toml := string(secret.Data["security.toml"])
 		return extractTOMLKey(toml, "jwt.filer_signing", "key"),
-			extractTOMLKey(toml, "jwt.filer_signing.read", "key"), nil
+			extractTOMLKey(toml, "jwt.filer_signing.read", "key"), false, nil
 	}
 	if !apierrors.IsNotFound(err) {
-		return "", "", err
+		return "", "", false, err
 	}
 
 	cm := &corev1.ConfigMap{}
@@ -357,12 +362,12 @@ func (r *SeaweedReconciler) existingJWTSigningKeys(ctx context.Context, m *seawe
 	if err == nil {
 		toml := cm.Data["security.toml"]
 		return extractTOMLKey(toml, "jwt.filer_signing", "key"),
-			extractTOMLKey(toml, "jwt.filer_signing.read", "key"), nil
+			extractTOMLKey(toml, "jwt.filer_signing.read", "key"), true, nil
 	}
 	if apierrors.IsNotFound(err) {
-		return "", "", nil
+		return "", "", false, nil
 	}
-	return "", "", err
+	return "", "", false, err
 }
 
 // deleteLegacySecurityConfigMap removes the pre-Secret security.toml ConfigMap

--- a/internal/controller/controller_tls_test.go
+++ b/internal/controller/controller_tls_test.go
@@ -1,10 +1,17 @@
 package controller
 
 import (
+	"context"
 	"strings"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
 )
@@ -96,4 +103,101 @@ func TestRenderSecurityTOML(t *testing.T) {
 			}
 		}
 	})
+}
+
+func securityTestReconciler(t *testing.T, objs ...client.Object) *SeaweedReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("clientgoscheme: %v", err)
+	}
+	if err := seaweedv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("seaweedv1: %v", err)
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	return &SeaweedReconciler{Client: cli, Scheme: scheme}
+}
+
+func newSecurityTestSeaweed() *seaweedv1.Seaweed {
+	return &seaweedv1.Seaweed{
+		ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
+		Spec:       seaweedv1.SeaweedSpec{Filer: &seaweedv1.FilerSpec{Replicas: 1}},
+	}
+}
+
+// ensureSecuritySecret must store security.toml in a Secret — JWT signing keys
+// are HMAC credentials and must not land in a ConfigMap.
+func TestEnsureSecuritySecret_CreatesSecret(t *testing.T) {
+	m := newSecurityTestSeaweed()
+	r := securityTestReconciler(t, m)
+
+	if _, _, err := r.ensureSecuritySecret(context.Background(), m); err != nil {
+		t.Fatalf("ensureSecuritySecret: %v", err)
+	}
+
+	secret := &corev1.Secret{}
+	if err := r.Get(context.Background(), client.ObjectKey{Name: SecurityConfigSecretName(m), Namespace: m.Namespace}, secret); err != nil {
+		t.Fatalf("expected security Secret to exist: %v", err)
+	}
+	if !strings.Contains(string(secret.Data["security.toml"]), "[jwt.filer_signing]") {
+		t.Errorf("expected jwt.filer_signing section in Secret, got %q", secret.Data["security.toml"])
+	}
+}
+
+// A second reconcile must reuse the keys already in the Secret rather than
+// rotating them, which would invalidate live JWTs.
+func TestEnsureSecuritySecret_PreservesKeysAcrossReconcile(t *testing.T) {
+	m := newSecurityTestSeaweed()
+	r := securityTestReconciler(t, m)
+
+	if _, _, err := r.ensureSecuritySecret(context.Background(), m); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+	first := &corev1.Secret{}
+	if err := r.Get(context.Background(), client.ObjectKey{Name: SecurityConfigSecretName(m), Namespace: m.Namespace}, first); err != nil {
+		t.Fatalf("get after first reconcile: %v", err)
+	}
+
+	if _, _, err := r.ensureSecuritySecret(context.Background(), m); err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+	second := &corev1.Secret{}
+	if err := r.Get(context.Background(), client.ObjectKey{Name: SecurityConfigSecretName(m), Namespace: m.Namespace}, second); err != nil {
+		t.Fatalf("get after second reconcile: %v", err)
+	}
+
+	if string(first.Data["security.toml"]) != string(second.Data["security.toml"]) {
+		t.Errorf("security.toml changed across reconciles:\nfirst:  %q\nsecond: %q", first.Data["security.toml"], second.Data["security.toml"])
+	}
+}
+
+// Upgrading from an operator version that stored security.toml in a ConfigMap
+// must migrate the keys into the Secret and delete the legacy ConfigMap.
+func TestEnsureSecuritySecret_MigratesLegacyConfigMap(t *testing.T) {
+	m := newSecurityTestSeaweed()
+	legacyTOML := "[jwt.filer_signing]\nkey = \"legacy-write\"\n\n[jwt.filer_signing.read]\nkey = \"legacy-read\"\n"
+	legacy := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: SecurityConfigSecretName(m), Namespace: m.Namespace},
+		Data:       map[string]string{"security.toml": legacyTOML},
+	}
+	r := securityTestReconciler(t, m, legacy)
+
+	if _, _, err := r.ensureSecuritySecret(context.Background(), m); err != nil {
+		t.Fatalf("ensureSecuritySecret: %v", err)
+	}
+
+	secret := &corev1.Secret{}
+	if err := r.Get(context.Background(), client.ObjectKey{Name: SecurityConfigSecretName(m), Namespace: m.Namespace}, secret); err != nil {
+		t.Fatalf("expected migrated Secret: %v", err)
+	}
+	got := string(secret.Data["security.toml"])
+	if !strings.Contains(got, `key = "legacy-write"`) || !strings.Contains(got, `key = "legacy-read"`) {
+		t.Errorf("expected legacy JWT keys preserved, got %q", got)
+	}
+
+	cm := &corev1.ConfigMap{}
+	err := r.Get(context.Background(), client.ObjectKey{Name: SecurityConfigSecretName(m), Namespace: m.Namespace}, cm)
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("expected legacy ConfigMap deleted, got err=%v", err)
+	}
 }

--- a/internal/controller/controller_tls_test.go
+++ b/internal/controller/controller_tls_test.go
@@ -201,3 +201,29 @@ func TestEnsureSecuritySecret_MigratesLegacyConfigMap(t *testing.T) {
 		t.Errorf("expected legacy ConfigMap deleted, got err=%v", err)
 	}
 }
+
+// Once the Secret holds the keys, a reconcile reads from it and must not issue
+// a Delete for the legacy ConfigMap — the migration is a one-time event, not a
+// per-reconcile cleanup.
+func TestEnsureSecuritySecret_SkipsLegacyDeleteWhenSecretPresent(t *testing.T) {
+	m := newSecurityTestSeaweed()
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: SecurityConfigSecretName(m), Namespace: m.Namespace},
+		Type:       corev1.SecretTypeOpaque,
+		Data:       map[string][]byte{"security.toml": []byte("[jwt.filer_signing]\nkey = \"existing\"\n")},
+	}
+	stray := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: SecurityConfigSecretName(m), Namespace: m.Namespace},
+		Data:       map[string]string{"security.toml": "stray"},
+	}
+	r := securityTestReconciler(t, m, secret, stray)
+
+	if _, _, err := r.ensureSecuritySecret(context.Background(), m); err != nil {
+		t.Fatalf("ensureSecuritySecret: %v", err)
+	}
+
+	cm := &corev1.ConfigMap{}
+	if err := r.Get(context.Background(), client.ObjectKey{Name: SecurityConfigSecretName(m), Namespace: m.Namespace}, cm); err != nil {
+		t.Errorf("legacy ConfigMap should be left untouched when the Secret already holds keys, got err=%v", err)
+	}
+}

--- a/internal/controller/controller_util.go
+++ b/internal/controller/controller_util.go
@@ -239,6 +239,28 @@ func (r *SeaweedReconciler) CreateOrUpdateConfigMap(configMap *corev1.ConfigMap)
 	return result.(*corev1.ConfigMap), nil
 }
 
+func (r *SeaweedReconciler) CreateOrUpdateSecret(secret *corev1.Secret) (*corev1.Secret, error) {
+	result, err := r.CreateOrUpdate(secret, func(existing, desired runtime.Object) error {
+		existingSecret := existing.(*corev1.Secret)
+		desiredSecret := desired.(*corev1.Secret)
+
+		if existingSecret.Annotations == nil {
+			existingSecret.Annotations = map[string]string{}
+		}
+		for k, v := range desiredSecret.Annotations {
+			existingSecret.Annotations[k] = v
+		}
+		existingSecret.Labels = desiredSecret.Labels
+		// Type is immutable, so it is left untouched on the existing object.
+		existingSecret.Data = desiredSecret.Data
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*corev1.Secret), nil
+}
+
 // CreateOrUpdateServiceMonitor upserts a ServiceMonitor, but treats a missing
 // monitoring.coreos.com CRD as a soft no-op. This lets the operator run
 // cleanly in clusters that do not have the Prometheus Operator installed

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -311,13 +311,13 @@ func tlsEffective(m *seaweedv1.Seaweed) bool {
 }
 
 // tlsVolumesAndMounts returns the set of pod volumes and container mounts
-// that wire the shared TLS Secret and security.toml ConfigMap into a
-// component pod. Returns empty slices when neither TLS nor the security
-// ConfigMap is needed — callers can safely append unconditionally. Every
-// component that speaks gRPC should use this helper so the paths stay in
-// sync with renderSecurityTOML.
+// that wire the shared TLS Secret and security.toml Secret into a component
+// pod. Returns empty slices when neither TLS nor the security config is
+// needed — callers can safely append unconditionally. Every component that
+// speaks gRPC should use this helper so the paths stay in sync with
+// renderSecurityTOML.
 //
-// The security ConfigMap mount is included independently of the TLS Secret
+// The security Secret mount is included independently of the TLS Secret
 // mount, so filer + admin pods can pick up jwt.filer_signing.key (needed for
 // the IAM gRPC service the Admin UI Users tab calls) without requiring
 // cert-manager.
@@ -328,10 +328,8 @@ func tlsVolumesAndMounts(m *seaweedv1.Seaweed) ([]corev1.Volume, []corev1.Volume
 		volumes = append(volumes, corev1.Volume{
 			Name: securityVolumeName,
 			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: SecurityConfigMapName(m),
-					},
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: SecurityConfigSecretName(m),
 				},
 			},
 		})

--- a/internal/controller/iam_controller_common.go
+++ b/internal/controller/iam_controller_common.go
@@ -165,23 +165,23 @@ func resolveSeaweedFiler(ctx context.Context, c client.Client, ref seaweedv1.Sea
 }
 
 // loadFilerAdminSigningKey reads jwt.filer_signing.key from the
-// seaweedfs-security-config ConfigMap the operator renders for sw. Returns
-// nil with no error when the ConfigMap does not exist or its security.toml
+// seaweedfs-security-config Secret the operator renders for sw. Returns
+// nil with no error when the Secret does not exist or its security.toml
 // has no key (the cluster will be running unauthenticated in that case).
 // A non-NotFound API error is propagated so the reconciler can requeue.
 func loadFilerAdminSigningKey(ctx context.Context, c client.Client, sw *seaweedv1.Seaweed) ([]byte, error) {
 	if !securityConfigNeeded(sw) {
 		return nil, nil
 	}
-	var cm corev1.ConfigMap
-	err := c.Get(ctx, types.NamespacedName{Namespace: sw.Namespace, Name: SecurityConfigMapName(sw)}, &cm)
+	var secret corev1.Secret
+	err := c.Get(ctx, types.NamespacedName{Namespace: sw.Namespace, Name: SecurityConfigSecretName(sw)}, &secret)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	raw := extractTOMLKey(cm.Data["security.toml"], "jwt.filer_signing", "key")
+	raw := extractTOMLKey(string(secret.Data["security.toml"]), "jwt.filer_signing", "key")
 	if raw == "" {
 		return nil, nil
 	}

--- a/internal/controller/iam_controller_common.go
+++ b/internal/controller/iam_controller_common.go
@@ -123,7 +123,7 @@ type filerTarget struct {
 
 // resolveSeaweedFiler looks up the Seaweed CR named by ref and returns its
 // filer address along with the admin signing key the operator rendered into
-// the cluster's security.toml ConfigMap (issue #257: the filer's IAM gRPC
+// the cluster's security.toml Secret (issue #257: the filer's IAM gRPC
 // service rejects unauthenticated calls when jwt.filer_signing.key is set, so
 // the operator must sign its own Bearer tokens with the same key) and the
 // gRPC transport credentials matching the cluster's mTLS state. found is
@@ -131,9 +131,9 @@ type filerTarget struct {
 // surface a transient "cluster not found" condition and requeue rather than
 // treating it as a hard error.
 //
-// adminSigningKey is nil when the security ConfigMap has not been reconciled
+// adminSigningKey is nil when the security Secret has not been reconciled
 // yet, when its data is missing/malformed, or when the cluster was not
-// provisioned by this operator (no ConfigMap to read). In those cases the IAM
+// provisioned by this operator (no Secret to read). In those cases the IAM
 // client falls back to unauthenticated calls, matching the cluster's likely
 // configuration.
 func resolveSeaweedFiler(ctx context.Context, c client.Client, ref seaweedv1.SeaweedReference, ownNamespace string) (target filerTarget, found bool, err error) {

--- a/internal/controller/iam_controller_test.go
+++ b/internal/controller/iam_controller_test.go
@@ -792,22 +792,22 @@ var (
 
 // TestResolveSeaweedFiler_LoadsAdminSigningKey pins the issue #257 fix:
 // resolveSeaweedFiler must surface jwt.filer_signing.key from the rendered
-// security ConfigMap so the IAM client can mint admin Bearer tokens. A
-// missing ConfigMap (cluster mid-reconcile, or an externally managed cluster)
+// security Secret so the IAM client can mint admin Bearer tokens. A
+// missing Secret (cluster mid-reconcile, or an externally managed cluster)
 // degrades to an empty key — matching the filer's unauthenticated branch.
 func TestResolveSeaweedFiler_LoadsAdminSigningKey(t *testing.T) {
 	scheme := iamTestScheme(t)
 	sw := newTestSeaweedWithFiler()
-	cm := &corev1.ConfigMap{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      SecurityConfigMapName(sw),
+			Name:      SecurityConfigSecretName(sw),
 			Namespace: sw.Namespace,
 		},
-		Data: map[string]string{
-			"security.toml": "[jwt.filer_signing]\nkey = \"abc123==\"\n",
+		Data: map[string][]byte{
+			"security.toml": []byte("[jwt.filer_signing]\nkey = \"abc123==\"\n"),
 		},
 	}
-	cli := iamTestClient(t, scheme, sw, cm)
+	cli := iamTestClient(t, scheme, sw, secret)
 
 	target, found, err := resolveSeaweedFiler(context.Background(), cli, iamSeaweedRef(), "media")
 	if err != nil {
@@ -824,7 +824,7 @@ func TestResolveSeaweedFiler_LoadsAdminSigningKey(t *testing.T) {
 	}
 }
 
-func TestResolveSeaweedFiler_MissingConfigMapReturnsEmptyKey(t *testing.T) {
+func TestResolveSeaweedFiler_MissingSecretReturnsEmptyKey(t *testing.T) {
 	scheme := iamTestScheme(t)
 	sw := newTestSeaweedWithFiler()
 	cli := iamTestClient(t, scheme, sw)
@@ -837,7 +837,7 @@ func TestResolveSeaweedFiler_MissingConfigMapReturnsEmptyKey(t *testing.T) {
 		t.Fatal("expected cluster to be found")
 	}
 	if len(target.adminSigningKey) != 0 {
-		t.Fatalf("expected empty key when ConfigMap missing, got %q", string(target.adminSigningKey))
+		t.Fatalf("expected empty key when Secret missing, got %q", string(target.adminSigningKey))
 	}
 }
 
@@ -992,7 +992,7 @@ func assertOIDCGone(t *testing.T, cli client.Client, key types.NamespacedName) {
 
 // newTestSeaweedWithFiler returns the standard test Seaweed CR with a Filer
 // spec so securityConfigNeeded returns true and the operator would render a
-// security.toml ConfigMap with jwt.filer_signing.key.
+// security.toml Secret with jwt.filer_signing.key.
 func newTestSeaweedWithFiler() *seaweedv1.Seaweed {
 	sw := newTestSeaweed()
 	sw.Spec.Filer = &seaweedv1.FilerSpec{Replicas: 1}

--- a/internal/controller/seaweed_controller.go
+++ b/internal/controller/seaweed_controller.go
@@ -117,7 +117,7 @@ func (r *SeaweedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	// TLS must be reconciled first: component pod specs reference the
-	// server Secret and security ConfigMap names, and skipping these when
+	// server Secret and security Secret names, and skipping these when
 	// cert-manager is absent is the difference between reconciling cleanly
 	// and crashlooping pods whose VolumeMounts can never be satisfied.
 	if done, result, err = r.ensureTLS(ctx, seaweedCR); done {

--- a/test/e2e/tls_test.go
+++ b/test/e2e/tls_test.go
@@ -9,7 +9,7 @@ You may obtain a copy of the License at
 */
 
 // TLS integration test: verifies the operator provisions the self-signed
-// issuer chain, the wildcard server Certificate, the security ConfigMap,
+// issuer chain, the wildcard server Certificate, the security Secret,
 // and wires them into every component pod so the cluster still comes up
 // cleanly. Kind test clusters provisioned by `make kind-prepare` already
 // install cert-manager, so this spec can run without additional setup.
@@ -124,7 +124,7 @@ var _ = Describe("SeaweedFS TLS via cert-manager", Ordered, Label("integration")
 			return isCertManagerReady(ctx, k8sClient, testNamespace, seaweedName+"-server", "Certificate")
 		}, 2*time.Minute, 5*time.Second).Should(BeTrue(), "server Certificate did not become Ready")
 
-		By("confirming the server Secret and security ConfigMap exist")
+		By("confirming the server Secret and security Secret exist")
 		secret := &corev1.Secret{}
 		Expect(k8sClient.Get(ctx, types.NamespacedName{
 			Name:      seaweedName + "-server-tls",
@@ -134,14 +134,15 @@ var _ = Describe("SeaweedFS TLS via cert-manager", Ordered, Label("integration")
 		Expect(secret.Data).To(HaveKey("tls.key"))
 		Expect(secret.Data).To(HaveKey("ca.crt"))
 
-		cm := &corev1.ConfigMap{}
+		securitySecret := &corev1.Secret{}
 		Expect(k8sClient.Get(ctx, types.NamespacedName{
 			Name:      seaweedName + "-security-config",
 			Namespace: testNamespace,
-		}, cm)).To(Succeed())
-		Expect(cm.Data["security.toml"]).To(ContainSubstring(`ca = "/etc/sw-tls/ca.crt"`))
-		Expect(cm.Data["security.toml"]).To(ContainSubstring(`[grpc.master]`))
-		Expect(cm.Data["security.toml"]).To(ContainSubstring(`[grpc.filer]`))
+		}, securitySecret)).To(Succeed())
+		securityTOML := string(securitySecret.Data["security.toml"])
+		Expect(securityTOML).To(ContainSubstring(`ca = "/etc/sw-tls/ca.crt"`))
+		Expect(securityTOML).To(ContainSubstring(`[grpc.master]`))
+		Expect(securityTOML).To(ContainSubstring(`[grpc.filer]`))
 
 		By("confirming pods mount the TLS Secret and security.toml")
 		pods := &corev1.PodList{}


### PR DESCRIPTION
## Summary

Closes #283.

The operator-generated `security.toml` carries the `jwt.filer_signing` HMAC keys. As confirmed upstream, these are **credentials** — anyone holding them can mint valid JWTs — so storing them in a `ConfigMap` exposes them to any principal with `configmaps` read access.

This PR moves `security.toml` from a `ConfigMap` to an Opaque `Secret`:

- `ensureSecuritySecret` provisions `<name>-security-config` as a `Secret` (JWT signing keys + the `[grpc.*]` mTLS stanzas live in the same file, so the whole file moves).
- Pods mount it via a `Secret` volume source instead of a `ConfigMap` volume source (same `/etc/sw-security` mount path and `-config_dir` flag — `weed` is unchanged).
- The IAM/bucket reconcilers read `jwt.filer_signing.key` from the Secret.

## Upgrade / migration

- On upgrade, existing JWT keys are read from the legacy `ConfigMap` and carried into the new `Secret`, so **live tokens stay valid** and keys are not silently rotated.
- The security `Secret` is created before component pods are reconciled (TLS reconcile runs first), so pods never reference a missing volume source.
- The legacy `ConfigMap` is deleted once the `Secret` exists, fully removing the credential from ConfigMap storage.

## RBAC

No change needed — the manager `ClusterRole` already grants `secrets` (`get;list;watch;create;update;patch;delete`).

## Tests

- New unit tests: Secret creation, key preservation across reconciles, and legacy-ConfigMap → Secret migration with key preservation + ConfigMap cleanup.
- Updated existing unit tests (IAM/bucket signing-key readers) and the e2e TLS test to expect a `Secret`.
- `go build ./...`, `go vet ./...`, and `go test ./internal/...` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * JWT signing keys in `security.toml` are now managed via Kubernetes Secrets (instead of ConfigMaps), improving protection of sensitive credential material.

* **Improvements**
  * `security.toml` is created and reconciled using the Secret, preserving existing signing keys across reconciles to prevent unintended rotation.
  * Legacy ConfigMap-based configuration is automatically migrated to the Secret, with cleanup handled safely.

* **Tests**
  * Updated controller and e2e TLS tests to validate the new Secret-based behavior and migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->