### PR TITLE
docs: add annotated and storage-focused configuration examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,26 @@ See the next section for example usage - **at this point you only deployed the O
 
 ### Basic SeaweedFS Deployment
 
-For detailed configuration options and examples, see the sample configurations in the `config/samples/` directory.
+For detailed configuration options and examples, see the sample configurations in the `config/samples/` directory. For a line-by-line walkthrough of a full cluster, start with `config/samples/seaweed_v1_seaweed_annotated.yaml`.
+
+#### Key fields explained
+
+A `Seaweed` cluster is built from three core components, each run as its own
+StatefulSet. Every `replicas` value becomes that many Pods:
+
+- **`master`** — coordinates the cluster and assigns volumes. Use 3 replicas for HA, 1 for dev.
+- **`volume`** — stores the file data on disk. Each replica is a Pod with its own PersistentVolumeClaim(s).
+- **`filer`** — serves the namespace and the S3/WebDAV/HTTP APIs.
+
+Fields that commonly cause confusion:
+
+- **`volume.requests.storage`** — the size of each volume-server PVC. This is *where storage comes from*: Kubernetes dynamically provisions a PersistentVolume of this size from the default StorageClass (or `volume.storageClassName` if set) and binds it to the Pod. To use specific or pre-provisioned disks, see `config/samples/seaweed_v1_seaweed_existing_storage.yaml`.
+- **`volumeServerDiskCount`** — number of data disks (PVCs) attached to *each* volume-server Pod. They are mounted at `/data0`, `/data1`, … and passed to the volume server as `-dir`. Total PVCs = `volume.replicas × volumeServerDiskCount`. Leave at 1 unless a node exposes multiple disks.
+- **`master.volumeSizeLimitMB`** — the max size of a *single logical volume file* before the master allocates a new one (1024 = 1 GiB per file). This is **not** the cluster capacity and **not** the PVC size — total capacity is driven by the volume servers' disks.
+- **`hostSuffix`** — optional. Creates a single all-in-one Ingress exposing the cluster under `filer.<hostSuffix>`, `s3.<hostSuffix>`, and `<name>-volume-<n>.<hostSuffix>` (requires an Ingress controller). Omit it for in-cluster-only access, or use the per-component `ingress:` blocks for finer control.
+- **`master.config` / `filer.config`** — raw TOML dropped verbatim into that component's config file (`master.toml` / `filer.toml`). Yes, you can paste an existing SeaweedFS filer config here — for example to point the filer's metadata store at Postgres/MySQL/Redis instead of local leveldb2.
+
+To run with a cloud bucket as remote storage (Cloud Drive) backed by a local cache, see `config/samples/seaweed_v1_seaweed_remote_storage.yaml`.
 
 ### IAM Support
 
@@ -230,8 +249,11 @@ spec:
 ```
 
 For more examples, see the `config/samples/` directory:
-- `seaweed_v1_seaweed_with_iam_embedded.yaml` - S3 with embedded IAM
 - `seaweed_v1_seaweed.yaml` - Basic deployment
+- `seaweed_v1_seaweed_annotated.yaml` - Basic deployment with every field explained
+- `seaweed_v1_seaweed_existing_storage.yaml` - Specific StorageClass / pre-provisioned PVs for local block storage
+- `seaweed_v1_seaweed_remote_storage.yaml` - Local cache plus a remote cloud bucket (Cloud Drive)
+- `seaweed_v1_seaweed_with_iam_embedded.yaml` - S3 with embedded IAM
 
 ### Declarative Buckets
 

--- a/config/samples/seaweed_v1_seaweed_annotated.yaml
+++ b/config/samples/seaweed_v1_seaweed_annotated.yaml
@@ -1,0 +1,85 @@
+# Fully annotated SeaweedFS cluster.
+#
+# This is the same shape as seaweed_v1_seaweed.yaml, but every field is
+# explained so you can see what the operator actually creates and where the
+# storage comes from. Apply it with:
+#
+#   kubectl apply -f seaweed_v1_seaweed_annotated.yaml
+#
+# A SeaweedFS cluster has three core components. The operator runs each as its
+# own workload, and every `replicas` below turns into that many Pods:
+#
+#   master  -> StatefulSet. Coordinates the cluster and assigns volumes.
+#   volume  -> StatefulSet. Stores the actual file data on disk (PVCs).
+#   filer   -> StatefulSet. Serves the POSIX-like namespace + S3/WebDAV/HTTP.
+#
+# StatefulSets (not Deployments) are used for these three because each Pod
+# needs a stable identity and its own persistent disk.
+apiVersion: seaweed.seaweedfs.com/v1
+kind: Seaweed
+metadata:
+  name: seaweed-annotated
+  namespace: default
+spec:
+  # Container image for every component. Pin a version in production instead
+  # of :latest, e.g. chrislusf/seaweedfs:3.80.
+  image: chrislusf/seaweedfs:latest
+
+  # Number of data disks attached to EACH volume-server Pod. The operator
+  # creates this many PVCs per Pod (mount0, mount1, ...), mounts them at
+  # /data0, /data1, ... and starts the volume server with
+  # `-dir=/data0,/data1,...`. With volumeServerDiskCount: 2 and volume.replicas: 3
+  # you get 3 Pods x 2 PVCs = 6 PersistentVolumeClaims total. Leave at 1 unless
+  # a node exposes multiple physical disks you want to use independently.
+  volumeServerDiskCount: 1
+
+  # OPTIONAL. Legacy "one Ingress for everything" helper. When set, the
+  # operator creates a single Ingress exposing the cluster under these
+  # hostnames (you must run an Ingress controller and point DNS at it):
+  #   filer.<hostSuffix>                  -> filer HTTP UI / API
+  #   s3.<hostSuffix>                     -> S3 API (when filer.s3.enabled)
+  #   <name>-volume-<n>.<hostSuffix>      -> each volume server
+  # It also sets each volume server's -publicUrl to <pod>.<hostSuffix> so
+  # clients can reach volume servers directly. Omit this field entirely if you
+  # only access the cluster from inside the cluster, or prefer the per-component
+  # `ingress:` blocks (master.ingress, filer.ingress, ...) for finer control.
+  # hostSuffix: seaweed.example.com
+
+  master:
+    # 3 master Pods => a quorum-based HA control plane. Use 1 for dev.
+    replicas: 3
+    # Max size (MiB) of a SINGLE logical volume file before the master stops
+    # writing to it and allocates a new one. This is NOT the cluster capacity
+    # or the PVC size -- it caps each .dat file so they stay manageable.
+    # 1024 = 1 GiB per volume file. Total capacity is driven by the volume
+    # servers' disks (see volume.requests.storage below).
+    volumeSizeLimitMB: 1024
+
+  volume:
+    # 2 volume-server Pods. Combined with volumeServerDiskCount: 1 above, the
+    # operator creates 2 PVCs (one per Pod) named mount0.
+    replicas: 2
+    requests:
+      # Size of EACH data PVC. This is where storage actually comes from:
+      # Kubernetes dynamically provisions a PersistentVolume of this size from
+      # the default StorageClass and binds it to the volume server's PVC. Set
+      # `storageClassName` here to choose a specific class (e.g. cloud block
+      # storage); see seaweed_v1_seaweed_existing_storage.yaml for binding to
+      # pre-provisioned PVs.
+      storage: 10Gi
+
+  filer:
+    # 2 filer Pods for HA metadata serving.
+    replicas: 2
+    s3:
+      # Expose the S3 API on port 8333 (IAM is embedded on the same port).
+      enabled: true
+    # The filer's metadata store. `config` is dropped verbatim into the
+    # filer's filer.toml -- so yes, you can paste your existing SeaweedFS filer
+    # config here. leveldb2 keeps metadata on the filer's local disk; for HA you
+    # would point this at an external store (postgres, mysql, redis, ...).
+    # NOTE: this is the component's own .toml, not an arbitrary catch-all config.
+    config: |
+      [leveldb2]
+      enabled = true
+      dir = "/data/filerldb2"

--- a/config/samples/seaweed_v1_seaweed_existing_storage.yaml
+++ b/config/samples/seaweed_v1_seaweed_existing_storage.yaml
@@ -1,0 +1,79 @@
+# Running SeaweedFS on specific or pre-provisioned storage.
+#
+# Use this when you do not want the cluster to fall back to the default
+# StorageClass -- for example to land volume data on cloud block storage, on
+# local NVMe, or on PersistentVolumes you provisioned yourself.
+#
+# Three storage knobs are shown:
+#   1. volume.storageClassName  -> dynamic provisioning from a named class
+#   2. volume.storageSelector   -> bind to pre-provisioned PVs by label (static)
+#   3. filer.persistence        -> a dedicated disk for filer metadata
+#
+# Reminder on layout: the volume StatefulSet creates volumeServerDiskCount PVCs
+# per Pod, named mount0, mount1, ... So with replicas: 3 and
+# volumeServerDiskCount: 2 there are 6 PVCs, e.g.
+# mount0-<cluster>-volume-0, mount1-<cluster>-volume-0, mount0-<cluster>-volume-1, ...
+apiVersion: seaweed.seaweedfs.com/v1
+kind: Seaweed
+metadata:
+  name: seaweed-existing-storage
+  namespace: default
+spec:
+  image: chrislusf/seaweedfs:latest
+
+  # Two data disks per volume server. Useful when each node exposes more than
+  # one block device you want SeaweedFS to use directly (mounted /data0, /data1).
+  volumeServerDiskCount: 2
+
+  master:
+    replicas: 3
+    volumeSizeLimitMB: 1024
+
+  volume:
+    replicas: 3
+    requests:
+      # Requested size of each PVC. With a cloud block-storage class this is the
+      # size of the provisioned disk (e.g. EBS/PD volume).
+      storage: 100Gi
+
+    # OPTION 1 -- dynamic provisioning from a specific StorageClass.
+    # The class must exist in the cluster. Common choices: a CSI block-storage
+    # class from your cloud provider, or "local-path" / a local-volume class for
+    # node-local NVMe. Remove this to use the cluster default class.
+    storageClassName: fast-block
+
+    # OPTION 2 -- bind PVCs to PersistentVolumes you pre-provisioned (static
+    # provisioning). The operator copies this selector onto every volume PVC, so
+    # PVCs only bind to PVs carrying matching labels. Label your PVs to match,
+    # e.g.  kubectl label pv my-pv seaweedfs-disk=volume
+    # When using purely static PVs, set storageClassName to "" so Kubernetes does
+    # not try to dynamically provision instead.
+    storageSelector:
+      matchLabels:
+        seaweedfs-disk: volume
+
+  filer:
+    # Single filer so the metadata PVC (ReadWriteOnce) has exactly one writer.
+    replicas: 1
+    s3:
+      enabled: true
+
+    # Give the filer its own persistent disk for metadata. Without this the
+    # filer's leveldb2 store lives on the Pod's ephemeral filesystem and is lost
+    # on reschedule.
+    persistence:
+      enabled: true
+      storageClassName: fast-block
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 20Gi
+      # To reuse a PVC you already created instead of provisioning a new one,
+      # drop the fields above and set:
+      # existingClaim: my-filer-metadata-pvc
+
+    config: |
+      [leveldb2]
+      enabled = true
+      dir = "/data/filerldb2"

--- a/config/samples/seaweed_v1_seaweed_remote_storage.yaml
+++ b/config/samples/seaweed_v1_seaweed_remote_storage.yaml
@@ -1,0 +1,81 @@
+# Local volumes as cache + a cloud bucket as remote storage (Cloud Drive).
+#
+# This is the "local block storage/cache, plus remote cloud storage" pattern:
+# SeaweedFS keeps a fast local copy on its volume-server PVCs while
+# transparently backing a directory with a remote object store (S3, GCS,
+# Azure, ...). Reads are cached locally; writes are asynchronously pushed to
+# the remote by a `weed filer.remote.sync` process, which we run as a filer
+# sidecar so the operator manages its lifecycle.
+#
+# IMPORTANT: the remote storage binding itself is a runtime operation, not a
+# CRD field. After this cluster is Running you configure the remote once via
+# `weed shell` (the sidecar just keeps it in sync). See the steps at the
+# bottom of this file.
+apiVersion: seaweed.seaweedfs.com/v1
+kind: Seaweed
+metadata:
+  name: seaweed-remote-storage
+  namespace: default
+spec:
+  image: chrislusf/seaweedfs:latest
+  volumeServerDiskCount: 1
+
+  master:
+    replicas: 1
+    volumeSizeLimitMB: 1024
+
+  volume:
+    # Local volume servers act as the hot tier / read cache for remote data.
+    replicas: 2
+    requests:
+      storage: 50Gi
+
+  filer:
+    replicas: 1
+    s3:
+      enabled: true
+    config: |
+      [leveldb2]
+      enabled = true
+      dir = "/data/filerldb2"
+
+    # Sidecar: a long-running `weed filer.remote.sync` that pushes local writes
+    # under the mounted directory back to the remote bucket and keeps metadata
+    # in sync. It shares the Pod's network with the filer container, so it dials
+    # the filer on localhost:8888. It reads the remote credentials from the
+    # filer (stored by `remote.configure` below), so no extra Secret is needed
+    # here. Until the remote directory is mounted it will retry -- that is
+    # expected before you run the steps below.
+    sidecars:
+      - name: remote-sync
+        image: chrislusf/seaweedfs:latest
+        command: ["weed"]
+        args:
+          - "filer.remote.sync"
+          - "-filer=localhost:8888"
+          - "-dir=/buckets/cloud"
+#
+# ---------------------------------------------------------------------------
+# One-time setup after the cluster is Running
+# ---------------------------------------------------------------------------
+# 1. Open a weed shell against the master (exec into a master Pod; master is a
+#    StatefulSet, so the first Pod is <name>-master-0):
+#
+#      kubectl exec -it seaweed-remote-storage-master-0 -- weed shell
+#
+# 2. Register the remote store. Replace the keys/region/endpoint for your
+#    provider. The name (s3_1) is an arbitrary handle reused in step 3:
+#
+#      remote.configure -name=s3_1 -type=s3 \
+#        -s3.access_key=AKIA... -s3.secret_key=... -s3.region=us-east-1
+#
+#    For non-AWS S3 (MinIO, Backblaze, R2, ...) also pass -s3.endpoint=...
+#
+# 3. Mount a remote bucket onto a filer directory. The directory here matches
+#    the sidecar's -dir flag above:
+#
+#      remote.mount -dir=/buckets/cloud -remote=s3_1/my-cloud-bucket -nonempty
+#
+# From now on, files written under /buckets/cloud (including via the S3 API)
+# are cached locally and asynchronously uploaded to my-cloud-bucket by the
+# sidecar. See https://github.com/seaweedfs/seaweedfs/wiki/Cloud-Drive-Architecture


### PR DESCRIPTION
## Summary

Closes #77.

The issue asks for more configuration examples *with explanations* — the existing `config/samples/seaweed_v1_seaweed.yaml` is sparse and leaves several common questions unanswered (what `hostSuffix` does, whether `replicas` spins up Pods, how `volumeServerDiskCount` / `volumeSizeLimitMB` / `storage` relate and where the storage comes from, whether you can paste a SeaweedFS config in, and how to combine local block storage with remote/cloud storage).

This PR adds three annotated samples and a README field glossary that answer those directly.

## New samples (`config/samples/`)

- **`seaweed_v1_seaweed_annotated.yaml`** — the same shape as the basic sample, but every field is explained: which components become StatefulSets/Pods, what `hostSuffix` exposes, that `volumeServerDiskCount` controls PVCs-per-volume-Pod (`/data0`, `/data1`, …), that `volumeSizeLimitMB` caps each logical volume file (not capacity/PVC size), that `volume.requests.storage` is where storage comes from (dynamic provisioning from the StorageClass), and that `config` is the component's raw `.toml`.
- **`seaweed_v1_seaweed_existing_storage.yaml`** — running on specific or pre-provisioned storage: `volume.storageClassName` for a named class (cloud block storage / local NVMe), `volume.storageSelector` to statically bind PVCs to labeled PVs, multiple disks per volume server, and `filer.persistence` (with an `existingClaim` note) for metadata.
- **`seaweed_v1_seaweed_remote_storage.yaml`** — the "local cache + remote cloud bucket" (Cloud Drive) pattern: local volume servers as the hot tier plus a `weed filer.remote.sync` filer sidecar, with the one-time `weed shell` `remote.configure` / `remote.mount` setup documented (since the remote binding is a runtime op, not a CRD field).

## README

Adds a **Key fields explained** glossary under *Configuration Examples* covering the commonly-confused knobs, and links the three new samples.

## Notes

- All field names verified against the generated CRD; all three manifests `yaml.safe_load` cleanly and satisfy the validating webhook (master + volume present, non-zero storage).
- `config/samples/kustomization.yaml` is intentionally left unchanged — like the other multi-purpose `seaweed_v1_seaweed_*` samples, these are reference manifests applied individually, not bundled into the default `kubectl apply -k`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Expanded configuration examples section with links to detailed walkthroughs
* Added fully annotated sample configuration with comprehensive documentation
* Introduced new configuration samples for existing storage and remote storage scenarios
* Enhanced setup and configuration guidance for SeaweedFS Kubernetes deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->