### PR TITLE
Fix webhook deploy so enabling webhooks actually serves them (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ NOTE: Due to an issue with the way the `seaweedfs-operator-webhook-server-cert` 
 
 This operator uses `kustomize` for deployment. Please [install kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/) if you do not have it.
 
-By default, the defaulting and validation webhooks are disabled. We strongly recommend to enable the webhooks.
+By default, the defaulting and validation webhooks are disabled, so `make deploy` works on any cluster without `cert-manager`. We strongly recommend enabling the webhooks for production use.
 
 First clone the repository:
 
@@ -125,8 +125,8 @@ First clone the repository:
 git clone https://github.com/seaweedfs/seaweedfs-operator --depth=1
 ```
 
-To deploy the operator with webhooks enabled, make sure you have installed the `cert-manager`(Installation docs: <https://cert-manager.io/docs/installation/>) in your cluster, then follow the instructions in the `config/default/kustomization.yaml` file to uncomment the components you need.
-Lastly, change the value of `ENABLE_WEBHOOKS` to `"true"` in `config/manager/manager.yaml`
+To deploy the operator with webhooks enabled, make sure you have installed the `cert-manager`(Installation docs: <https://cert-manager.io/docs/installation/>) in your cluster, then follow the instructions in the `config/default/kustomization.yaml` file to uncomment all the `[WEBHOOK]` and `[CERTMANAGER]` sections (including the one in `config/crd/kustomization.yaml`).
+Uncommenting those sections also flips `ENABLE_WEBHOOKS` to `"true"` for you via `config/default/manager_webhook_patch.yaml`, so no separate edit of `config/manager/manager.yaml` is needed.
 
 Manager image must be locally built and published into a registry accessible from your k8s cluster:
 

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -8,6 +8,11 @@ spec:
     spec:
       containers:
       - name: manager
+        # Applied only when webhooks are enabled, so turn the webhook server on
+        # here; otherwise the webhook configs are registered but never served.
+        env:
+        - name: ENABLE_WEBHOOKS
+          value: "true"
         ports:
         - containerPort: 9443
           name: webhook-server


### PR DESCRIPTION
## Problem

Closes #29.

`make deploy` had two failure modes around webhooks. The default path (webhooks disabled, `ENABLE_WEBHOOKS=false`) already works without `cert-manager`. The remaining gap is the **webhook-enabled** path:

When you follow the README and enable webhooks by uncommenting the `[WEBHOOK]`/`[CERTMANAGER]` sections in `config/default/kustomization.yaml` and `config/crd/kustomization.yaml`, the rendered Deployment **still carries `ENABLE_WEBHOOKS=false`** (it is hardcoded in `config/manager/manager.yaml`, which both paths share).

The result:

- The `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration` get registered with the API server.
- But the manager never registers the webhook handlers (because `ENABLE_WEBHOOKS=false`).
- So every `Seaweed` create/update is rejected by an unreachable admission webhook.

The README papered over this with a separate, easy-to-miss "also change `ENABLE_WEBHOOKS` to `true` in `config/manager/manager.yaml`" step.

## Fix

`config/default/manager_webhook_patch.yaml` is applied **only** on the webhook-enabled path, so it is the right place to flip the switch. The patch now also sets `ENABLE_WEBHOOKS=true` (a strategic-merge override of the base env, merged by name).

This makes the webhook flow self-contained — uncommenting the kustomize sections is enough — while the default flow keeps webhooks off and deploys without `cert-manager`.

## Verification

Rendered both paths with the pinned `kustomize` (v5.3.0):

- `kustomize build config/default` → `ENABLE_WEBHOOKS=false`, no cert/webhook resources pulled in.
- webhook-enabled render (sections uncommented) → `ENABLE_WEBHOOKS=true`, cert mounted, port 9443 open, webhook configs present.

## Changes

- `config/default/manager_webhook_patch.yaml`: set `ENABLE_WEBHOOKS=true` (only affects the webhook-enabled path).
- `README.md`: drop the now-unnecessary manual `manager.yaml` edit; note the default `make deploy` works without `cert-manager`.