### PR TITLE
docs: document exposing S3 and filer over TLS via Ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,80 @@ For more examples, see the `config/samples/` directory:
 - `seaweed_v1_seaweed_existing_storage.yaml` - Specific StorageClass / pre-provisioned PVs for local block storage
 - `seaweed_v1_seaweed_remote_storage.yaml` - Local cache plus a remote cloud bucket (Cloud Drive)
 - `seaweed_v1_seaweed_with_iam_embedded.yaml` - S3 with embedded IAM
+- `seaweed_v1_seaweed_ingress_tls.yaml` - Expose the S3 API and filer over TLS via per-component Ingress
+
+### Exposing the cluster via Ingress (TLS)
+
+By default the operator only creates in-cluster `Service`s. There are two
+ways to expose components (S3 API, filer, master/admin UIs, volume servers)
+outside the cluster through an Ingress controller. Both require an Ingress
+controller (ingress-nginx, Traefik, …) and DNS pointing at it.
+
+- **`hostSuffix`** — the legacy all-in-one helper. One Ingress under
+  `filer.<hostSuffix>`, `s3.<hostSuffix>`, and `<name>-volume-<n>.<hostSuffix>`.
+  It is **HTTP-only** — it cannot terminate TLS.
+- **Per-component `ingress:` blocks** — the recommended path, and the only
+  one that supports TLS. Each component carries its own `IngressSpec`, so the
+  S3 API and the filer can sit on different hostnames with different
+  certificates.
+
+The `ingress:` block is available on `master`, `volume`, `filer`,
+`filer.s3Ingress` (the filer's embedded S3 port), `admin`, and the standalone
+`s3` and `sftp` gateways. Every block shares the same fields:
+
+| Field | Description |
+| --- | --- |
+| `enabled` | Create the Ingress for this component. |
+| `host` | Hostname the Ingress matches (required when enabled). |
+| `className` | `IngressClassName`, e.g. `nginx`. |
+| `path` | Path prefix to serve. Defaults to `/`. |
+| `annotations` | Controller-specific annotations (cert-manager issuer, nginx body size, …). |
+| `tls` | List of `{hosts, secretName}` — terminates TLS using a `kubernetes.io/tls` Secret. |
+
+To reach the S3 API over an `https://` URL, enable the S3 API and give it a
+TLS Ingress. With the **filer-embedded** S3 (`filer.s3.enabled`):
+
+```yaml
+spec:
+  filer:
+    replicas: 1
+    s3:
+      enabled: true            # S3 API on port 8333 (IAM embedded)
+    s3Ingress:
+      enabled: true
+      className: nginx
+      host: s3.seaweed.example.com
+      annotations:
+        # cert-manager issues the cert into secretName below; omit if you
+        # created the TLS Secret by hand.
+        cert-manager.io/cluster-issuer: letsencrypt-prod
+        nginx.ingress.kubernetes.io/proxy-body-size: "0"   # allow large S3 PUTs
+      tls:
+        - hosts: [s3.seaweed.example.com]
+          secretName: seaweed-s3-tls
+```
+
+If you are not using cert-manager, create the TLS Secret yourself and drop
+the issuer annotation:
+
+```bash
+kubectl create secret tls seaweed-s3-tls --cert=tls.crt --key=tls.key
+```
+
+Then point any S3 client at the TLS endpoint:
+
+```bash
+aws --endpoint-url https://s3.seaweed.example.com s3 ls
+```
+
+Prefer the **standalone S3 gateway** (scales independently of the filer) by
+putting the same `ingress:` block under the top-level `s3:` instead of
+`filer.s3Ingress` — the fields are identical. See
+`config/samples/seaweed_v1_seaweed_ingress_tls.yaml` for a complete manifest.
+
+> Note: this Ingress TLS terminates HTTPS at the Ingress controller. It is
+> separate from `spec.tls`, which provisions cert-manager-issued **mTLS**
+> between SeaweedFS components (master/volume/filer gRPC).
 
 ### Declarative Buckets
 

--- a/config/samples/seaweed_v1_seaweed_ingress_tls.yaml
+++ b/config/samples/seaweed_v1_seaweed_ingress_tls.yaml
@@ -1,0 +1,82 @@
+# SeaweedFS cluster exposed over TLS through per-component Ingress.
+#
+# This answers the common question "how do I reach the S3 API over an
+# https:// URL via Ingress?". Each component declares its own `ingress:`
+# block, so you can put the S3 API and the filer UI on separate hostnames,
+# each with its own TLS certificate. This is independent of (and preferred
+# over) the legacy all-in-one `hostSuffix`, which is HTTP-only.
+#
+# Prerequisites:
+#   1. An Ingress controller is installed (e.g. ingress-nginx, Traefik).
+#   2. DNS for the hosts below points at the Ingress controller.
+#   3. A TLS certificate exists, either:
+#      a) created by hand as a kubernetes.io/tls Secret, e.g.
+#         kubectl create secret tls seaweed-s3-tls \
+#           --cert=tls.crt --key=tls.key -n default
+#      or
+#      b) issued automatically by cert-manager — set the issuer annotation
+#         under each ingress (shown commented out below) and cert-manager
+#         will populate the secretName for you.
+#
+# Apply with:
+#   kubectl apply -f seaweed_v1_seaweed_ingress_tls.yaml
+apiVersion: seaweed.seaweedfs.com/v1
+kind: Seaweed
+metadata:
+  name: seaweed-ingress-tls
+  namespace: default
+spec:
+  image: chrislusf/seaweedfs:latest
+  volumeServerDiskCount: 1
+  master:
+    replicas: 1
+    volumeSizeLimitMB: 1024
+  volume:
+    replicas: 1
+    requests:
+      storage: 10Gi
+  filer:
+    replicas: 1
+    s3:
+      # Enable the S3 API on port 8333 (IAM is embedded on the same port).
+      enabled: true
+    config: |
+      [leveldb2]
+      enabled = true
+      dir = "/data/filerldb2"
+
+    # Expose the filer's S3 API at https://s3.seaweed.example.com.
+    s3Ingress:
+      enabled: true
+      className: nginx
+      host: s3.seaweed.example.com
+      annotations:
+        # cert-manager: uncomment to have a certificate issued automatically
+        # into the `secretName` below.
+        # cert-manager.io/cluster-issuer: letsencrypt-prod
+        #
+        # S3 clients upload large objects; raise the body size limit so the
+        # ingress controller does not reject multi-part PUTs.
+        nginx.ingress.kubernetes.io/proxy-body-size: "0"
+      tls:
+        - hosts:
+            - s3.seaweed.example.com
+          secretName: seaweed-s3-tls
+
+    # Optionally expose the filer HTTP UI / REST API on its own hostname.
+    ingress:
+      enabled: true
+      className: nginx
+      host: filer.seaweed.example.com
+      tls:
+        - hosts:
+            - filer.seaweed.example.com
+          secretName: seaweed-filer-tls
+
+# Once applied and the certificate is ready, point an S3 client at the URL:
+#
+#   aws --endpoint-url https://s3.seaweed.example.com s3 ls
+#
+# For a standalone S3 gateway (scales independently of the filer) use the
+# top-level `s3:` block with its own `ingress:` instead of filer.s3Ingress —
+# the IngressSpec fields (host, className, annotations, tls) are identical.

--- a/internal/controller/controller_filer_ingress.go
+++ b/internal/controller/controller_filer_ingress.go
@@ -22,7 +22,8 @@ func (r *SeaweedReconciler) createAllIngress(m *seaweedv1.Seaweed) *networkingv1
 			Labels:    labels,
 		},
 		Spec: networkingv1.IngressSpec{
-			// TLS:   ingressSpec.TLS,
+			// The legacy HostSuffix Ingress is HTTP-only. For TLS, use the
+			// per-component ingress blocks (e.g. filer.s3Ingress.tls).
 			Rules: []networkingv1.IngressRule{
 				{
 					Host: "filer." + *m.Spec.HostSuffix,


### PR DESCRIPTION
## Summary

Addresses #17 ("ingress support TLS").

The per-component `ingress:` blocks already support TLS pass-through in code (`IngressSpec.TLS` → `networking.k8s.io/v1` `IngressTLS`, reconciled in `controller_component_ingress.go` and covered by `test/e2e/ingress_test.go`). What was missing — and what the issue's commenter actually asked for — was **documentation**: how to reach the S3 API over an `https://` URL via Ingress.

This PR is docs + a sample, with one tiny code-comment cleanup. No CRD/type changes.

## Changes

- **README**: new "Exposing the cluster via Ingress (TLS)" section that
  - contrasts the legacy HTTP-only `hostSuffix` with the per-component `ingress:` blocks (the only TLS-capable path),
  - documents every `IngressSpec` field (`enabled`, `host`, `className`, `path`, `annotations`, `tls`),
  - shows an S3-over-TLS example via `filer.s3Ingress` with both cert-manager and manual-Secret flows, plus the `aws --endpoint-url https://...` smoke test,
  - notes the standalone `s3:` gateway alternative, and clarifies that Ingress TLS (HTTPS termination) is distinct from `spec.tls` (component mTLS).
- **Sample**: `config/samples/seaweed_v1_seaweed_ingress_tls.yaml` — a runnable manifest exposing the S3 API and filer over TLS via per-component Ingress; listed in the README samples index.
- **Cleanup**: the legacy `hostSuffix` Ingress builder had a commented-out `// TLS: ingressSpec.TLS,` referencing a non-existent variable. Replaced with a note that the legacy path is HTTP-only and points users to the per-component blocks for TLS.

## Testing

- `go build ./internal/...` passes (only a comment changed).
- Sample YAML validated; field names match the `Seaweed` CRD schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration guide with TLS Ingress setup instructions, clarifying that per-component Ingress blocks enable HTTPS termination independently from component-to-component encryption.

* **New Features**
  * Added sample configuration demonstrating how to expose the filer's embedded S3 API and REST API over HTTPS with TLS via Ingress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->