### PR TITLE
feat: evacuate volume servers before scale-down

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ A `Seaweed` cluster is built from three core components, each run as its own
 StatefulSet. Every `replicas` value becomes that many Pods:
 
 - **`master`** — coordinates the cluster and assigns volumes. Use 3 replicas for HA, 1 for dev.
-- **`volume`** — stores the file data on disk. Each replica is a Pod with its own PersistentVolumeClaim(s).
+- **`volume`** — stores the file data on disk. Each replica is a Pod with its own PersistentVolumeClaim(s). Lowering `volume.replicas` triggers a graceful scale-down: before removing a volume-server Pod the operator evacuates its data to the remaining servers (highest ordinal first, one at a time) and only deletes the Pod once the master confirms the server holds no volumes. A server whose data cannot be moved safely (e.g. no replication-compliant destination) blocks the scale-down rather than risking data loss.
 - **`filer`** — serves the namespace and the S3/WebDAV/HTTP APIs.
 
 Fields that commonly cause confusion:

--- a/go.mod
+++ b/go.mod
@@ -162,7 +162,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.35.2 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
-	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
+	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/yaml v1.6.0
 )

--- a/internal/controller/controller_volume.go
+++ b/internal/controller/controller_volume.go
@@ -55,7 +55,17 @@ func (r *SeaweedReconciler) ensureVolumeServerStatefulSet(ctx context.Context, s
 	if err := controllerutil.SetControllerReference(seaweedCR, volumeServerStatefulSet, r.Scheme); err != nil {
 		return ReconcileResult(err)
 	}
-	_, err := r.CreateOrUpdate(volumeServerStatefulSet, func(existing, desired runtime.Object) error {
+
+	// Gate scale-down on evacuation: cap the replica count so a volume server
+	// pod is removed only after its data has drained to the other servers.
+	allowed, err := r.allowedVolumeServerReplicas(ctx, seaweedCR, volumeServerStatefulSet.Name, seaweedCR.Spec.Volume.Replicas,
+		func(ord int32) string { return volumeServerNodeAddress(seaweedCR, ord) })
+	if err != nil {
+		return ReconcileResult(err)
+	}
+	volumeServerStatefulSet.Spec.Replicas = &allowed
+
+	_, err = r.CreateOrUpdate(volumeServerStatefulSet, func(existing, desired runtime.Object) error {
 		existingStatefulSet := existing.(*appsv1.StatefulSet)
 		desiredStatefulSet := desired.(*appsv1.StatefulSet)
 
@@ -181,7 +191,16 @@ func (r *SeaweedReconciler) ensureVolumeServerTopologyStatefulSet(ctx context.Co
 	if err := controllerutil.SetControllerReference(seaweedCR, volumeServerStatefulSet, r.Scheme); err != nil {
 		return ReconcileResult(err)
 	}
-	_, err := r.CreateOrUpdate(volumeServerStatefulSet, func(existing, desired runtime.Object) error {
+
+	// Gate scale-down on evacuation, as for the flat volume StatefulSet.
+	allowed, err := r.allowedVolumeServerReplicas(ctx, seaweedCR, volumeServerStatefulSet.Name, topologySpec.Replicas,
+		func(ord int32) string { return volumeServerTopologyNodeAddress(seaweedCR, topologyName, ord) })
+	if err != nil {
+		return ReconcileResult(err)
+	}
+	volumeServerStatefulSet.Spec.Replicas = &allowed
+
+	_, err = r.CreateOrUpdate(volumeServerStatefulSet, func(existing, desired runtime.Object) error {
 		existingStatefulSet := existing.(*appsv1.StatefulSet)
 		desiredStatefulSet := desired.(*appsv1.StatefulSet)
 

--- a/internal/controller/seaweed_controller.go
+++ b/internal/controller/seaweed_controller.go
@@ -90,6 +90,13 @@ type SeaweedReconciler struct {
 	Log      logr.Logger
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
+
+	// VolumeAdminFactory builds the master-side admin used to evacuate volume
+	// servers before a scale-down removes them. Defaulted in SetupWithManager;
+	// tests inject a fake.
+	VolumeAdminFactory VolumeAdminFactory
+	// evac tracks in-flight background volume server evacuations.
+	evac *evacuationTracker
 }
 
 // +kubebuilder:rbac:groups=seaweed.seaweedfs.com,resources=seaweeds,verbs=get;list;watch;create;update;patch;delete
@@ -223,6 +230,12 @@ func (r *SeaweedReconciler) findSeaweedCustomResourceInstance(ctx context.Contex
 }
 
 func (r *SeaweedReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if r.VolumeAdminFactory == nil {
+		r.VolumeAdminFactory = NewSwadminVolumeAdmin
+	}
+	if r.evac == nil {
+		r.evac = newEvacuationTracker()
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&seaweedv1.Seaweed{}).
 		Complete(r)

--- a/internal/controller/swadmin/seaweed_admin.go
+++ b/internal/controller/swadmin/seaweed_admin.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/seaweedfs/seaweedfs/weed/pb"
+	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
 	"github.com/seaweedfs/seaweedfs/weed/shell"
 	"github.com/seaweedfs/seaweedfs/weed/util/fla9"
 )
@@ -116,4 +117,56 @@ func (sa *SeaweedAdmin) ProcessCommand(ctx context.Context, cmd string) error {
 
 	return fmt.Errorf("unknown command: %v", cmd)
 
+}
+
+// VolumeServerVolumeCounts asks the master for the cluster topology and returns
+// the number of volumes (normal volumes plus EC shards) each volume server
+// currently hosts, keyed by the server's node id (its <host>:<port>, the same
+// identifier `volumeServer.evacuate -node` expects). A server present in the
+// topology with no data maps to 0; a server absent from the topology (not
+// registered with the master) is simply missing from the map. The caller uses
+// this to decide when an evacuated volume server is safe to remove.
+func (sa *SeaweedAdmin) VolumeServerVolumeCounts(ctx context.Context) (map[string]int, error) {
+	// WithClient resolves the master via a blocking GetMaster(Background()); cap
+	// the wait here the same way ProcessCommand does so a cluster the operator
+	// cannot reach surfaces a timeout instead of hanging the caller forever.
+	waitCtx, cancel := context.WithTimeout(ctx, masterConnectionTimeout)
+	defer cancel()
+	if sa.commandEnv.MasterClient.GetMaster(waitCtx) == "" {
+		return nil, fmt.Errorf("wait for master connection: %w", waitCtx.Err())
+	}
+
+	var resp *master_pb.VolumeListResponse
+	err := sa.commandEnv.MasterClient.WithClient(false, func(client master_pb.SeaweedClient) error {
+		r, e := client.VolumeList(ctx, &master_pb.VolumeListRequest{})
+		if e != nil {
+			return e
+		}
+		resp = r
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return volumeServerVolumeCounts(resp.GetTopologyInfo()), nil
+}
+
+// volumeServerVolumeCounts walks a master TopologyInfo and totals the volumes
+// and EC shards hosted on each data node. Split out from the RPC call so the
+// aggregation is unit-testable without a live cluster.
+func volumeServerVolumeCounts(topo *master_pb.TopologyInfo) map[string]int {
+	counts := map[string]int{}
+	for _, dc := range topo.GetDataCenterInfos() {
+		for _, rack := range dc.GetRackInfos() {
+			for _, dn := range rack.GetDataNodeInfos() {
+				n := 0
+				for _, disk := range dn.GetDiskInfos() {
+					n += len(disk.GetVolumeInfos()) + len(disk.GetEcShardInfos())
+				}
+				counts[dn.GetId()] = n
+			}
+		}
+	}
+	return counts
 }

--- a/internal/controller/swadmin/seaweed_admin_test.go
+++ b/internal/controller/swadmin/seaweed_admin_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
 )
 
 // TestNewSeaweedAdmin_DoesNotPanic guards against regressions like
@@ -38,6 +39,52 @@ func TestNewSeaweedAdmin_FilerAddressWired(t *testing.T) {
 	})
 	if err != nil && strings.Contains(err.Error(), "received empty target") {
 		t.Fatalf("regression of issue #237: empty target leaked through despite non-empty filer arg: %v", err)
+	}
+}
+
+func TestVolumeServerVolumeCounts_Aggregation(t *testing.T) {
+	topo := &master_pb.TopologyInfo{
+		DataCenterInfos: []*master_pb.DataCenterInfo{{
+			RackInfos: []*master_pb.RackInfo{{
+				DataNodeInfos: []*master_pb.DataNodeInfo{
+					{
+						// Two disks, volumes plus an EC shard => counts sum across disks.
+						Id: "vol-0:8444",
+						DiskInfos: map[string]*master_pb.DiskInfo{
+							"hdd": {
+								VolumeInfos:  []*master_pb.VolumeInformationMessage{{Id: 1}, {Id: 2}},
+								EcShardInfos: []*master_pb.VolumeEcShardInformationMessage{{Id: 3}},
+							},
+							"ssd": {
+								VolumeInfos: []*master_pb.VolumeInformationMessage{{Id: 4}},
+							},
+						},
+					},
+					{
+						// Registered but empty => present with count 0.
+						Id:        "vol-1:8444",
+						DiskInfos: map[string]*master_pb.DiskInfo{"hdd": {}},
+					},
+				},
+			}},
+		}},
+	}
+
+	got := volumeServerVolumeCounts(topo)
+	want := map[string]int{"vol-0:8444": 4, "vol-1:8444": 0}
+	if len(got) != len(want) {
+		t.Fatalf("counts = %v, want %v", got, want)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("counts[%q] = %d, want %d", k, got[k], v)
+		}
+	}
+}
+
+func TestVolumeServerVolumeCounts_EmptyTopology(t *testing.T) {
+	if got := volumeServerVolumeCounts(nil); len(got) != 0 {
+		t.Fatalf("counts for nil topology = %v, want empty", got)
 	}
 }
 

--- a/internal/controller/volume_admin.go
+++ b/internal/controller/volume_admin.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/go-logr/logr"
 	"google.golang.org/grpc"
@@ -51,6 +52,10 @@ type VolumeAdmin interface {
 // grpcDialOption carries the transport credentials for clusters with [grpc]
 // mTLS (nil to dial without TLS). Replaceable in tests.
 type VolumeAdminFactory func(masters string, grpcDialOption grpc.DialOption, log logr.Logger) (VolumeAdmin, error)
+
+// unlockTimeout bounds the master-connection wait when releasing the shell lock
+// after an evacuation, so a defer never hangs on an unresponsive master.
+const unlockTimeout = 15 * time.Second
 
 // swadminVolumeAdmin is the default VolumeAdmin, backed by swadmin.SeaweedAdmin.
 // mu serializes command execution (which swaps the shared Output writer) and Close.
@@ -86,10 +91,14 @@ func (a *swadminVolumeAdmin) EvacuateServer(ctx context.Context, node string) er
 		return fmt.Errorf("lock masters: %w", err)
 	}
 	// Release the lock even if ctx is already done; a leaked lock would block
-	// every later admin command until the master's lease expires.
+	// every later admin command until the master's lease expires. Use a fresh,
+	// short-bounded context so an unresponsive master caps the unlock's
+	// master-connection wait instead of stalling this defer.
 	defer func() {
 		a.sa.Output = io.Discard
-		_ = a.sa.ProcessCommand(context.Background(), "unlock")
+		unlockCtx, cancel := context.WithTimeout(context.Background(), unlockTimeout)
+		defer cancel()
+		_ = a.sa.ProcessCommand(unlockCtx, "unlock")
 	}()
 
 	// No -skipNonMoveable: a volume that cannot be moved must fail the

--- a/internal/controller/volume_admin.go
+++ b/internal/controller/volume_admin.go
@@ -1,0 +1,111 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+
+	"github.com/go-logr/logr"
+	"google.golang.org/grpc"
+
+	"github.com/seaweedfs/seaweedfs-operator/internal/controller/swadmin"
+)
+
+// VolumeAdmin is the small surface the volume reconciler uses to drain a volume
+// server before a scale-down removes its pod. The default implementation drives
+// `weed shell` through swadmin.SeaweedAdmin; tests inject a fake.
+type VolumeAdmin interface {
+	// VolumeServerVolumeCounts returns, per volume-server node id
+	// (<host>:<port>), the number of volumes and EC shards the master reports
+	// it hosts. A server absent from the map is not registered with the master.
+	VolumeServerVolumeCounts(ctx context.Context) (map[string]int, error)
+	// EvacuateServer moves every volume and EC shard off node (a <host>:<port>
+	// id) onto the remaining servers, returning only once the node holds no
+	// data. It is safe to call on an already-empty node (a fast no-op) and
+	// returns an error if any volume cannot be moved (e.g. no replication-safe
+	// destination), so the caller never removes a server that still holds data.
+	EvacuateServer(ctx context.Context, node string) error
+	io.Closer
+}
+
+// VolumeAdminFactory builds a VolumeAdmin for a target cluster's masters.
+// grpcDialOption carries the transport credentials for clusters with [grpc]
+// mTLS (nil to dial without TLS). Replaceable in tests.
+type VolumeAdminFactory func(masters string, grpcDialOption grpc.DialOption, log logr.Logger) (VolumeAdmin, error)
+
+// swadminVolumeAdmin is the default VolumeAdmin, backed by swadmin.SeaweedAdmin.
+// mu serializes command execution (which swaps the shared Output writer) and Close.
+type swadminVolumeAdmin struct {
+	sa  *swadmin.SeaweedAdmin
+	log logr.Logger
+	mu  sync.Mutex
+}
+
+// NewSwadminVolumeAdmin returns a VolumeAdmin that talks to masters over the
+// embedded `weed shell`. No filer is needed: every command it issues
+// (volume.list, volumeServer.evacuate, lock/unlock) is master-only.
+func NewSwadminVolumeAdmin(masters string, grpcDialOption grpc.DialOption, log logr.Logger) (VolumeAdmin, error) {
+	sa := swadmin.NewSeaweedAdmin(masters, "", grpcDialOption, io.Discard)
+	return &swadminVolumeAdmin{sa: sa, log: log}, nil
+}
+
+func (a *swadminVolumeAdmin) VolumeServerVolumeCounts(ctx context.Context) (map[string]int, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.sa.VolumeServerVolumeCounts(ctx)
+}
+
+func (a *swadminVolumeAdmin) EvacuateServer(ctx context.Context, node string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	var buf bytes.Buffer
+	a.sa.Output = &buf
+
+	// volumeServer.evacuate -apply refuses to run unless the masters are locked.
+	if err := a.sa.ProcessCommand(ctx, "lock"); err != nil {
+		return fmt.Errorf("lock masters: %w", err)
+	}
+	// Release the lock even if ctx is already done; a leaked lock would block
+	// every later admin command until the master's lease expires.
+	defer func() {
+		a.sa.Output = io.Discard
+		_ = a.sa.ProcessCommand(context.Background(), "unlock")
+	}()
+
+	// No -skipNonMoveable: a volume that cannot be moved must fail the
+	// evacuation so the caller keeps the server (and its only copy of that
+	// data) alive rather than deleting the pod out from under it.
+	cmd := fmt.Sprintf("volumeServer.evacuate -node %s -apply", node)
+	if err := a.sa.ProcessCommand(ctx, cmd); err != nil {
+		return fmt.Errorf("evacuate %s: %w (output: %s)", node, err, strings.TrimSpace(buf.String()))
+	}
+
+	a.log.Info("volume server evacuated", "node", node)
+	return nil
+}
+
+func (a *swadminVolumeAdmin) Close() error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.sa.Close()
+}

--- a/internal/controller/volume_evacuation.go
+++ b/internal/controller/volume_evacuation.go
@@ -1,0 +1,269 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+)
+
+// evacuationRetryBackoff bounds how often a failed background evacuation is
+// retried. A stuck evacuation (e.g. a volume with no replication-safe
+// destination) errors quickly, and the reconcile loop revisits a draining
+// cluster every few seconds; without a floor that would relaunch the move on
+// every pass.
+const evacuationRetryBackoff = 30 * time.Second
+
+// evacuationTracker is the controller's in-memory registry of background volume
+// server evacuations, keyed by node id (<host>:<port>). It is purely a
+// concurrency guard and retry throttle: the authoritative "is this server
+// drained?" signal is the master's volume count, never this tracker, so losing
+// its state on an operator restart only re-triggers an evacuation that is then
+// a fast no-op against an already-empty server.
+type evacuationTracker struct {
+	mu     sync.Mutex
+	states map[string]*evacuationState
+	now    func() time.Time // overridable in tests
+}
+
+type evacuationState struct {
+	running   bool
+	lastErr   error
+	nextRetry time.Time
+}
+
+func newEvacuationTracker() *evacuationTracker {
+	return &evacuationTracker{
+		states: map[string]*evacuationState{},
+		now:    time.Now,
+	}
+}
+
+// start launches fn in the background for node unless an evacuation is already
+// running for it, or a previous attempt failed within the retry backoff window.
+// It reports whether a new goroutine was started so the caller can emit an
+// event only on a genuine (re)launch.
+func (t *evacuationTracker) start(node string, fn func() error) bool {
+	t.mu.Lock()
+	st := t.states[node]
+	if st == nil {
+		st = &evacuationState{}
+		t.states[node] = st
+	}
+	if st.running || (st.lastErr != nil && t.now().Before(st.nextRetry)) {
+		t.mu.Unlock()
+		return false
+	}
+	st.running = true
+	t.mu.Unlock()
+
+	go func() {
+		err := fn()
+		t.mu.Lock()
+		st.running = false
+		st.lastErr = err
+		if err != nil {
+			st.nextRetry = t.now().Add(evacuationRetryBackoff)
+		}
+		t.mu.Unlock()
+	}()
+	return true
+}
+
+// lastErr returns the error from node's most recent finished evacuation, or nil
+// if none has finished (or the last one succeeded).
+func (t *evacuationTracker) lastErr(node string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if st := t.states[node]; st != nil {
+		return st.lastErr
+	}
+	return nil
+}
+
+// forget drops node's state once it is no longer a scale-down target, so a
+// later scale-down of a freshly repopulated server starts from a clean slate.
+func (t *evacuationTracker) forget(node string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.states, node)
+}
+
+// evacuationDecision computes, for a volume StatefulSet whose desired replica
+// count is below its current size, the replica count it may safely run at right
+// now and the single highest still-populated doomed server that should be
+// evacuated next ("" if none needs evacuating this pass).
+//
+// StatefulSets always delete the highest-ordinal pod first, so a server is only
+// removable once it AND every higher-ordinal doomed server are drained. counts
+// maps node id -> hosted volume/EC-shard count; a node missing from counts is
+// not registered with the master and is treated as "not yet confirmed drained"
+// (hold), because the operator must not delete a pod whose data it cannot see.
+func evacuationDecision(desired, current int32, nodeFor func(int32) string, counts map[string]int) (allowed int32, evacuate string) {
+	if desired >= current {
+		return desired, ""
+	}
+	allowed = current
+	for ord := current - 1; ord >= desired; ord-- {
+		node := nodeFor(ord)
+		if n, known := counts[node]; known && n == 0 {
+			allowed = ord // drained: this server (and all above it) may go
+			continue
+		} else if known && n > 0 {
+			evacuate = node // highest server still holding data: drain it next
+		}
+		// Either still populated or not visible in the topology yet: stop here so
+		// no pod at or below this ordinal is removed until it is confirmed empty.
+		break
+	}
+	if allowed < desired {
+		allowed = desired
+	}
+	return allowed, evacuate
+}
+
+// allowedVolumeServerReplicas returns the replica count the named volume
+// StatefulSet may run at this reconcile pass. On creation, scale-up, or steady
+// state it is simply desired and no master call is made. On scale-down it caps
+// the count so a volume server pod is removed only after the master confirms it
+// holds no data; the highest still-populated server is evacuated in the
+// background first. nodeFor maps a pod ordinal to its master node id.
+func (r *SeaweedReconciler) allowedVolumeServerReplicas(ctx context.Context, m *seaweedv1.Seaweed, stsName string, desired int32, nodeFor func(int32) string) (int32, error) {
+	// Gating depends on the master admin and the evacuation tracker, both wired
+	// by SetupWithManager. When absent (e.g. a reconciler built directly in an
+	// unrelated test) fall back to the plain desired count.
+	if r.VolumeAdminFactory == nil || r.evac == nil {
+		return desired, nil
+	}
+
+	sts := &appsv1.StatefulSet{}
+	err := r.Get(ctx, types.NamespacedName{Namespace: m.Namespace, Name: stsName}, sts)
+	if apierrors.IsNotFound(err) {
+		return desired, nil // not created yet: nothing to drain
+	}
+	if err != nil {
+		return desired, err
+	}
+
+	current := ptr.Deref(sts.Spec.Replicas, 0)
+	if desired >= current {
+		return desired, nil // creation already handled above; this is scale-up/steady
+	}
+
+	counts, err := r.volumeServerVolumeCounts(ctx, m)
+	if err != nil {
+		// Without an authoritative drain signal we must not shrink: hold the
+		// StatefulSet at its current size and retry on the next pass.
+		r.Log.Error(err, "cannot read volume topology; holding volume scale-down", "statefulset", stsName)
+		return current, nil
+	}
+
+	allowed, evacuate := evacuationDecision(desired, current, nodeFor, counts)
+	if evacuate != "" {
+		r.startVolumeServerEvacuation(ctx, m, evacuate)
+	}
+	// Drop tracker state for every server that is now leaving so a future
+	// scale-down of a repopulated pod at the same ordinal starts fresh.
+	for ord := allowed; ord < current; ord++ {
+		r.evac.forget(nodeFor(ord))
+	}
+	return allowed, nil
+}
+
+// startVolumeServerEvacuation kicks off (or, after the retry backoff, retries) a
+// background evacuation of node. The heavy data move runs on its own goroutine
+// with a detached context so it survives this reconcile returning; the master
+// volume count gates the actual pod removal.
+func (r *SeaweedReconciler) startVolumeServerEvacuation(ctx context.Context, m *seaweedv1.Seaweed, node string) {
+	masters := getMasterPeersString(m)
+	dialOption, _, err := loadSeaweedGrpcDialOption(ctx, r.Client, m)
+	if err != nil {
+		r.Log.Error(err, "cannot build gRPC dial option for evacuation", "node", node)
+		return
+	}
+
+	prevErr := r.evac.lastErr(node)
+	started := r.evac.start(node, func() error {
+		admin, err := r.VolumeAdminFactory(masters, dialOption, r.Log)
+		if err != nil {
+			return err
+		}
+		defer admin.Close()
+		return admin.EvacuateServer(context.Background(), node)
+	})
+	if !started {
+		return // already running, or waiting out the retry backoff
+	}
+
+	r.Log.Info("evacuating volume server before scale-down", "node", node)
+	if prevErr != nil {
+		r.recordVolumeEvent(m, corev1.EventTypeWarning, "VolumeServerEvacuationFailed",
+			"Retrying evacuation of volume server %s after failure: %v", node, prevErr)
+	} else {
+		r.recordVolumeEvent(m, corev1.EventTypeNormal, "VolumeServerEvacuating",
+			"Evacuating volume server %s before scale-down", node)
+	}
+}
+
+// volumeServerVolumeCounts builds a short-lived admin and asks the master for
+// the per-server volume counts used to gate scale-down.
+func (r *SeaweedReconciler) volumeServerVolumeCounts(ctx context.Context, m *seaweedv1.Seaweed) (map[string]int, error) {
+	masters := getMasterPeersString(m)
+	dialOption, _, err := loadSeaweedGrpcDialOption(ctx, r.Client, m)
+	if err != nil {
+		return nil, err
+	}
+	admin, err := r.VolumeAdminFactory(masters, dialOption, r.Log)
+	if err != nil {
+		return nil, err
+	}
+	defer admin.Close()
+	return admin.VolumeServerVolumeCounts(ctx)
+}
+
+func (r *SeaweedReconciler) recordVolumeEvent(m *seaweedv1.Seaweed, eventType, reason, messageFmt string, args ...interface{}) {
+	if r.Recorder == nil {
+		return
+	}
+	r.Recorder.Eventf(m, eventType, reason, messageFmt, args...)
+}
+
+// volumeServerNodeAddress is the master node id of the flat volume StatefulSet
+// pod at the given ordinal: the pod's stable peer DNS name plus the volume HTTP
+// port, matching the `-ip`/`-port` the pod registers with (see
+// buildVolumeServerStartupScript).
+func volumeServerNodeAddress(m *seaweedv1.Seaweed, ordinal int32) string {
+	return fmt.Sprintf("%s-volume-%d.%s-volume-peer.%s:%d",
+		m.Name, ordinal, m.Name, m.Namespace, seaweedv1.VolumeHTTPPort)
+}
+
+// volumeServerTopologyNodeAddress is volumeServerNodeAddress for a topology
+// group's StatefulSet (see buildVolumeServerStartupScriptWithTopology).
+func volumeServerTopologyNodeAddress(m *seaweedv1.Seaweed, topology string, ordinal int32) string {
+	return fmt.Sprintf("%s-volume-%s-%d.%s-volume-%s-peer.%s:%d",
+		m.Name, topology, ordinal, m.Name, topology, m.Namespace, seaweedv1.VolumeHTTPPort)
+}

--- a/internal/controller/volume_evacuation.go
+++ b/internal/controller/volume_evacuation.go
@@ -38,6 +38,14 @@ import (
 // every pass.
 const evacuationRetryBackoff = 30 * time.Second
 
+// evacuationTimeout is the outer ceiling on a single background evacuation. It
+// bounds the master-connection waits the shell observes and acts as a deadline
+// for the move work should a future SeaweedFS release thread the context
+// through; today the move loop carries its own per-RPC timeouts. Because
+// evacuation is re-entrant, a drain cut off here simply resumes on the next
+// reconcile pass, so the ceiling is generous rather than tight.
+const evacuationTimeout = time.Hour
+
 // evacuationTracker is the controller's in-memory registry of background volume
 // server evacuations, keyed by node id (<host>:<port>). It is purely a
 // concurrency guard and retry throttle: the authoritative "is this server
@@ -210,10 +218,17 @@ func (r *SeaweedReconciler) startVolumeServerEvacuation(ctx context.Context, m *
 	started := r.evac.start(node, func() error {
 		admin, err := r.VolumeAdminFactory(masters, dialOption, r.Log)
 		if err != nil {
+			r.Log.Error(err, "cannot build volume admin for evacuation", "node", node)
 			return err
 		}
 		defer admin.Close()
-		return admin.EvacuateServer(context.Background(), node)
+		evacCtx, cancel := context.WithTimeout(context.Background(), evacuationTimeout)
+		defer cancel()
+		if err := admin.EvacuateServer(evacCtx, node); err != nil {
+			r.Log.Error(err, "volume server evacuation failed", "node", node)
+			return err
+		}
+		return nil
 	})
 	if !started {
 		return // already running, or waiting out the retry backoff

--- a/internal/controller/volume_evacuation_test.go
+++ b/internal/controller/volume_evacuation_test.go
@@ -1,0 +1,393 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"google.golang.org/grpc"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+)
+
+// fakeVolumeAdmin is a test double for VolumeAdmin. It is safe for concurrent
+// use because EvacuateServer runs on a background goroutine.
+type fakeVolumeAdmin struct {
+	mu sync.Mutex
+
+	counts    map[string]int
+	countsErr error
+
+	evacErr   error
+	evacuated []string
+	// evacGate, when non-nil, blocks EvacuateServer until the test closes it.
+	evacGate chan struct{}
+
+	countsCalls int
+	closeCalls  int
+}
+
+func (f *fakeVolumeAdmin) VolumeServerVolumeCounts(_ context.Context) (map[string]int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.countsCalls++
+	if f.countsErr != nil {
+		return nil, f.countsErr
+	}
+	cp := make(map[string]int, len(f.counts))
+	for k, v := range f.counts {
+		cp[k] = v
+	}
+	return cp, nil
+}
+
+func (f *fakeVolumeAdmin) EvacuateServer(_ context.Context, node string) error {
+	f.mu.Lock()
+	gate := f.evacGate
+	f.mu.Unlock()
+	if gate != nil {
+		<-gate
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.evacuated = append(f.evacuated, node)
+	return f.evacErr
+}
+
+func (f *fakeVolumeAdmin) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closeCalls++
+	return nil
+}
+
+func (f *fakeVolumeAdmin) evacuatedNodes() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.evacuated...)
+}
+
+func newEvacTestReconciler(t *testing.T, fa *fakeVolumeAdmin, objs ...client.Object) *SeaweedReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("clientgoscheme: %v", err)
+	}
+	if err := seaweedv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("seaweedv1: %v", err)
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	return &SeaweedReconciler{
+		Client: cli,
+		Log:    logf.FromContext(context.Background()),
+		Scheme: scheme,
+		VolumeAdminFactory: func(_ string, _ grpc.DialOption, _ logr.Logger) (VolumeAdmin, error) {
+			return fa, nil
+		},
+		evac: newEvacuationTracker(),
+	}
+}
+
+func evacTestSeaweed() *seaweedv1.Seaweed {
+	return &seaweedv1.Seaweed{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec: seaweedv1.SeaweedSpec{
+			Image:  "seaweedfs/seaweedfs:latest",
+			Master: &seaweedv1.MasterSpec{Replicas: 1},
+			Volume: &seaweedv1.VolumeSpec{Replicas: 2},
+		},
+	}
+}
+
+func volumeSTS(name, namespace string, replicas int32) *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To(replicas)},
+	}
+}
+
+func waitForEvacuation(t *testing.T, fa *fakeVolumeAdmin, node string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		for _, n := range fa.evacuatedNodes() {
+			if n == node {
+				return
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("evacuation of %s was not triggered; evacuated=%v", node, fa.evacuatedNodes())
+}
+
+func TestEvacuationDecision(t *testing.T) {
+	nodeFor := func(ord int32) string { return nodeName(ord) }
+	cases := []struct {
+		name         string
+		desired      int32
+		current      int32
+		counts       map[string]int
+		wantAllowed  int32
+		wantEvacuate string
+	}{
+		{
+			name:    "scale up returns desired, evacuates nothing",
+			desired: 4, current: 2, wantAllowed: 4, wantEvacuate: "",
+		},
+		{
+			name:    "steady state returns desired",
+			desired: 3, current: 3, wantAllowed: 3, wantEvacuate: "",
+		},
+		{
+			name:    "top server still populated holds and evacuates it",
+			desired: 2, current: 5,
+			counts:      map[string]int{nodeName(4): 7, nodeName(3): 7, nodeName(2): 7},
+			wantAllowed: 5, wantEvacuate: nodeName(4),
+		},
+		{
+			name:    "top server drained shrinks by one and evacuates next",
+			desired: 2, current: 5,
+			counts:      map[string]int{nodeName(4): 0, nodeName(3): 7, nodeName(2): 7},
+			wantAllowed: 4, wantEvacuate: nodeName(3),
+		},
+		{
+			name:    "several top servers drained removed together",
+			desired: 2, current: 5,
+			counts:      map[string]int{nodeName(4): 0, nodeName(3): 0, nodeName(2): 7},
+			wantAllowed: 3, wantEvacuate: nodeName(2),
+		},
+		{
+			name:    "all doomed servers drained shrinks to desired",
+			desired: 2, current: 5,
+			counts:      map[string]int{nodeName(4): 0, nodeName(3): 0, nodeName(2): 0},
+			wantAllowed: 2, wantEvacuate: "",
+		},
+		{
+			name:    "top server not in topology holds without evacuating",
+			desired: 2, current: 4,
+			counts:      map[string]int{nodeName(2): 0}, // ordinal 3 missing
+			wantAllowed: 4, wantEvacuate: "",
+		},
+		{
+			name:    "drained top then missing holds at the missing one",
+			desired: 1, current: 4,
+			counts:      map[string]int{nodeName(3): 0, nodeName(1): 0}, // ordinal 2 missing
+			wantAllowed: 3, wantEvacuate: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotAllowed, gotEvacuate := evacuationDecision(tc.desired, tc.current, nodeFor, tc.counts)
+			if gotAllowed != tc.wantAllowed {
+				t.Errorf("allowed = %d, want %d", gotAllowed, tc.wantAllowed)
+			}
+			if gotEvacuate != tc.wantEvacuate {
+				t.Errorf("evacuate = %q, want %q", gotEvacuate, tc.wantEvacuate)
+			}
+		})
+	}
+}
+
+// nodeName is a compact stand-in node id for evacuationDecision table tests.
+func nodeName(ord int32) string { return "node-" + itoa(ord) }
+
+func itoa(i int32) string {
+	if i == 0 {
+		return "0"
+	}
+	neg := i < 0
+	if neg {
+		i = -i
+	}
+	var b [12]byte
+	p := len(b)
+	for i > 0 {
+		p--
+		b[p] = byte('0' + i%10)
+		i /= 10
+	}
+	if neg {
+		p--
+		b[p] = '-'
+	}
+	return string(b[p:])
+}
+
+func TestVolumeServerNodeAddress(t *testing.T) {
+	m := evacTestSeaweed()
+	if got, want := volumeServerNodeAddress(m, 3), "test-volume-3.test-volume-peer.default:8444"; got != want {
+		t.Errorf("volumeServerNodeAddress = %q, want %q", got, want)
+	}
+	if got, want := volumeServerTopologyNodeAddress(m, "dc1", 2), "test-volume-dc1-2.test-volume-dc1-peer.default:8444"; got != want {
+		t.Errorf("volumeServerTopologyNodeAddress = %q, want %q", got, want)
+	}
+}
+
+func TestAllowedVolumeServerReplicas_NoStatefulSetReturnsDesired(t *testing.T) {
+	fa := &fakeVolumeAdmin{}
+	r := newEvacTestReconciler(t, fa, evacTestSeaweed())
+	got, err := r.allowedVolumeServerReplicas(context.Background(), evacTestSeaweed(), "test-volume", 2,
+		func(ord int32) string { return volumeServerNodeAddress(evacTestSeaweed(), ord) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 2 {
+		t.Errorf("allowed = %d, want 2", got)
+	}
+	if fa.countsCalls != 0 {
+		t.Errorf("expected no master call when StatefulSet is absent, got %d", fa.countsCalls)
+	}
+}
+
+func TestAllowedVolumeServerReplicas_ScaleUpSkipsMaster(t *testing.T) {
+	fa := &fakeVolumeAdmin{}
+	m := evacTestSeaweed()
+	r := newEvacTestReconciler(t, fa, m, volumeSTS("test-volume", "default", 2))
+	got, err := r.allowedVolumeServerReplicas(context.Background(), m, "test-volume", 5,
+		func(ord int32) string { return volumeServerNodeAddress(m, ord) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 5 {
+		t.Errorf("allowed = %d, want 5", got)
+	}
+	if fa.countsCalls != 0 {
+		t.Errorf("expected no master call on scale-up, got %d", fa.countsCalls)
+	}
+}
+
+func TestAllowedVolumeServerReplicas_HoldsAndEvacuatesPopulatedServer(t *testing.T) {
+	m := evacTestSeaweed()
+	fa := &fakeVolumeAdmin{counts: map[string]int{
+		volumeServerNodeAddress(m, 2): 9,
+	}}
+	r := newEvacTestReconciler(t, fa, m, volumeSTS("test-volume", "default", 3))
+	got, err := r.allowedVolumeServerReplicas(context.Background(), m, "test-volume", 2,
+		func(ord int32) string { return volumeServerNodeAddress(m, ord) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 3 {
+		t.Errorf("allowed = %d, want 3 (held while draining)", got)
+	}
+	waitForEvacuation(t, fa, volumeServerNodeAddress(m, 2))
+}
+
+func TestAllowedVolumeServerReplicas_ShrinksAsServersDrain(t *testing.T) {
+	m := evacTestSeaweed()
+	// Ordinal 2 already empty, ordinal 1 (still desired) is not doomed.
+	fa := &fakeVolumeAdmin{counts: map[string]int{
+		volumeServerNodeAddress(m, 2): 0,
+	}}
+	r := newEvacTestReconciler(t, fa, m, volumeSTS("test-volume", "default", 3))
+	got, err := r.allowedVolumeServerReplicas(context.Background(), m, "test-volume", 2,
+		func(ord int32) string { return volumeServerNodeAddress(m, ord) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 2 {
+		t.Errorf("allowed = %d, want 2 (drained server removed)", got)
+	}
+}
+
+func TestAllowedVolumeServerReplicas_HoldsWhenTopologyUnavailable(t *testing.T) {
+	m := evacTestSeaweed()
+	fa := &fakeVolumeAdmin{countsErr: errors.New("masters unreachable")}
+	r := newEvacTestReconciler(t, fa, m, volumeSTS("test-volume", "default", 5))
+	got, err := r.allowedVolumeServerReplicas(context.Background(), m, "test-volume", 2,
+		func(ord int32) string { return volumeServerNodeAddress(m, ord) })
+	if err != nil {
+		t.Fatalf("expected a held scale-down, not an error: %v", err)
+	}
+	if got != 5 {
+		t.Errorf("allowed = %d, want 5 (hold current when drain state is unknown)", got)
+	}
+	if len(fa.evacuatedNodes()) != 0 {
+		t.Errorf("no server should be evacuated when topology is unknown, got %v", fa.evacuatedNodes())
+	}
+}
+
+func TestEvacuationTracker_DeduplicatesAndBacksOff(t *testing.T) {
+	tr := newEvacuationTracker()
+	clock := time.Unix(0, 0)
+	tr.now = func() time.Time { return clock }
+
+	release := make(chan struct{})
+	var runs int
+	var mu sync.Mutex
+	run := func() error {
+		<-release
+		mu.Lock()
+		runs++
+		mu.Unlock()
+		return errors.New("boom")
+	}
+
+	if !tr.start("n", run) {
+		t.Fatal("first start should launch")
+	}
+	if tr.start("n", run) {
+		t.Fatal("second start should be deduplicated while running")
+	}
+	close(release) // let the first attempt finish (and fail)
+
+	// Wait for the goroutine to record the failure.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if tr.lastErr("n") != nil {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if tr.lastErr("n") == nil {
+		t.Fatal("expected recorded failure")
+	}
+
+	// Within the backoff window a retry is suppressed.
+	noop := func() error { return nil }
+	if tr.start("n", noop) {
+		t.Fatal("retry within backoff window should be suppressed")
+	}
+	// Past the backoff window it is allowed again.
+	clock = clock.Add(evacuationRetryBackoff + time.Second)
+	if !tr.start("n", noop) {
+		t.Fatal("retry after backoff window should launch")
+	}
+
+	// forget clears state so a fresh scale-down starts clean.
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && tr.lastErr("n") != nil {
+		time.Sleep(5 * time.Millisecond)
+	}
+	tr.forget("n")
+	if tr.lastErr("n") != nil {
+		t.Fatal("forget should drop tracker state")
+	}
+}

--- a/test/e2e/volume_evacuation_test.go
+++ b/test/e2e/volume_evacuation_test.go
@@ -1,0 +1,277 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-resty/resty/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+	"github.com/seaweedfs/seaweedfs-operator/test/utils"
+)
+
+// dirStatus is the subset of the master's /dir/status JSON the spec needs:
+// the per-volume-server volume counts, keyed by the server's node Url
+// (<host>:<port>) — the same identifier the operator drains by.
+type dirStatus struct {
+	Topology struct {
+		DataCenters []struct {
+			Racks []struct {
+				DataNodes []struct {
+					Url     string `json:"Url"`
+					Volumes int64  `json:"Volumes"`
+				} `json:"DataNodes"`
+			} `json:"Racks"`
+		} `json:"DataCenters"`
+	} `json:"Topology"`
+}
+
+// volumesByNode flattens a dirStatus into Url -> volume count.
+func (d dirStatus) volumesByNode() map[string]int64 {
+	out := map[string]int64{}
+	for _, dc := range d.Topology.DataCenters {
+		for _, rack := range dc.Racks {
+			for _, dn := range rack.DataNodes {
+				out[dn.Url] = dn.Volumes
+			}
+		}
+	}
+	return out
+}
+
+func (d dirStatus) totalVolumes() int64 {
+	var n int64
+	for _, v := range d.volumesByNode() {
+		n += v
+	}
+	return n
+}
+
+// This spec verifies the volume-server evacuation gate end-to-end against a real
+// cluster: when volume.replicas is lowered, the operator drains the doomed
+// volume server's data onto the remaining server BEFORE deleting its pod, so no
+// volumes are lost. It needs running, registered volume servers (the gate reads
+// the master topology), so it lives in the heavier "integration" e2e group.
+var _ = Describe("Volume server evacuation on scale-down", Ordered, Label("integration"), func() {
+	var (
+		ctx           context.Context
+		k8sClient     client.Client
+		restCfg       *rest.Config
+		testNamespace = "test-volume-evacuation"
+		seaweedName   = "test-seaweed-evac"
+		masterPod     string
+	)
+
+	volumeStsKey := types.NamespacedName{Name: seaweedName + "-volume", Namespace: testNamespace}
+	seaweedKey := types.NamespacedName{Name: seaweedName, Namespace: testNamespace}
+	// doomedNodePrefix matches the volume server at ordinal 1 — the pod a
+	// 2 -> 1 scale-down removes — by its master node Url.
+	doomedNodePrefix := fmt.Sprintf("%s-volume-1.", seaweedName)
+
+	// masterGet performs an HTTP GET against the master over a fresh
+	// port-forward. A per-call forward keeps the helper robust across the
+	// multi-minute drain poll, where a single long-lived forward can drop.
+	masterGet := func(path string) (string, error) {
+		stopCh := make(chan struct{}, 1)
+		readyCh := make(chan struct{})
+		localPort, err := utils.GetFreePort()
+		if err != nil {
+			return "", err
+		}
+		if err := utils.RunPortForward(restCfg, testNamespace, masterPod,
+			[]string{fmt.Sprintf("%d:%d", localPort, seaweedv1.MasterHTTPPort)}, stopCh, readyCh); err != nil {
+			return "", err
+		}
+		defer close(stopCh)
+		select {
+		case <-readyCh:
+		case <-time.After(15 * time.Second):
+			return "", fmt.Errorf("port-forward to %s not ready", masterPod)
+		}
+		resp, err := resty.New().SetTimeout(15 * time.Second).R().
+			Get(fmt.Sprintf("http://localhost:%d%s", localPort, path))
+		if err != nil {
+			return "", err
+		}
+		if resp.StatusCode() != http.StatusOK {
+			return "", fmt.Errorf("GET %s: status %d: %s", path, resp.StatusCode(), resp.String())
+		}
+		return resp.String(), nil
+	}
+
+	fetchTopology := func() (dirStatus, error) {
+		var ds dirStatus
+		body, err := masterGet("/dir/status")
+		if err != nil {
+			return ds, err
+		}
+		if err := json.Unmarshal([]byte(body), &ds); err != nil {
+			return ds, fmt.Errorf("parse /dir/status: %w (body: %s)", err, body)
+		}
+		return ds, nil
+	}
+
+	BeforeAll(func() {
+		ctx = context.Background()
+		k8sClient, restCfg = utils.NewE2EClient()
+		utils.EnsureNamespace(ctx, k8sClient, testNamespace)
+	})
+
+	BeforeEach(func() {
+		DeferCleanup(func() {
+			utils.CollectDiagnostics(ctx, k8sClient, restCfg, testNamespace)
+		})
+	})
+
+	AfterAll(func() {
+		seaweed := &seaweedv1.Seaweed{}
+		if err := k8sClient.Get(ctx, seaweedKey, seaweed); err == nil {
+			_ = k8sClient.Delete(ctx, seaweed)
+		}
+		utils.DeleteNamespace(ctx, k8sClient, testNamespace)
+	})
+
+	It("drains a volume server before removing it and preserves its volumes", func() {
+		concurrentStart := true
+		diskCount := int32(1)
+		// An explicit per-server max lets /vol/grow create volumes on the tiny
+		// test PVCs (with the default -max=0 the server derives its cap from
+		// free disk and a small PVC computes to ~0 writable volumes).
+		maxVolumeCounts := int32(10)
+		seaweed := &seaweedv1.Seaweed{
+			ObjectMeta: metav1.ObjectMeta{Name: seaweedName, Namespace: testNamespace},
+			Spec: seaweedv1.SeaweedSpec{
+				Image:                 "chrislusf/seaweedfs:latest",
+				VolumeServerDiskCount: &diskCount,
+				Master: &seaweedv1.MasterSpec{
+					Replicas:        1,
+					ConcurrentStart: &concurrentStart,
+				},
+				Volume: &seaweedv1.VolumeSpec{
+					Replicas: 2,
+					VolumeServerConfig: seaweedv1.VolumeServerConfig{
+						MaxVolumeCounts: &maxVolumeCounts,
+						ResourceRequirements: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("2Gi"),
+							},
+						},
+					},
+				},
+			},
+		}
+
+		By("creating a master + 2-volume-server cluster and waiting for Ready")
+		Expect(k8sClient.Create(ctx, seaweed)).To(Succeed())
+		utils.WaitForSeaweedReady(ctx, k8sClient, seaweedKey, 7*time.Minute)
+
+		By("locating the master pod for port-forwarding")
+		clientset, err := utils.GetClientset(restCfg)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(func(g Gomega) {
+			pods, err := clientset.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("app.kubernetes.io/component=master,app.kubernetes.io/instance=%s", seaweedName),
+			})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(pods.Items).NotTo(BeEmpty(), "no master pods found")
+			masterPod = pods.Items[0].Name
+		}, time.Minute, time.Second*5).Should(Succeed())
+
+		By("growing volumes so both servers host data")
+		// replication=000 keeps every volume to a single copy, so the doomed
+		// server's volumes can always move onto the one remaining server.
+		Eventually(func(g Gomega) {
+			_, err := masterGet("/vol/grow?count=10&replication=000")
+			g.Expect(err).NotTo(HaveOccurred())
+			ds, err := fetchTopology()
+			g.Expect(err).NotTo(HaveOccurred())
+			byNode := ds.volumesByNode()
+			g.Expect(byNode).To(HaveLen(2), "expected two registered volume servers")
+			var doomed int64 = -1
+			for url, n := range byNode {
+				if strings.HasPrefix(url, doomedNodePrefix) {
+					doomed = n
+				}
+			}
+			g.Expect(doomed).To(BeNumerically(">", 0), "doomed server holds no volumes to evacuate")
+		}, time.Minute*2, time.Second*5).Should(Succeed())
+
+		ds, err := fetchTopology()
+		Expect(err).NotTo(HaveOccurred())
+		totalBefore := ds.totalVolumes()
+		Expect(totalBefore).To(BeNumerically(">", 0))
+		GinkgoWriter.Printf("volumes before scale-down: %d across %v\n", totalBefore, ds.volumesByNode())
+
+		By("scaling the volume servers from 2 down to 1")
+		Eventually(func(g Gomega) {
+			fetched := &seaweedv1.Seaweed{}
+			g.Expect(k8sClient.Get(ctx, seaweedKey, fetched)).To(Succeed())
+			fetched.Spec.Volume.Replicas = 1
+			g.Expect(k8sClient.Update(ctx, fetched)).To(Succeed())
+		}, time.Minute, time.Second*5).Should(Succeed())
+
+		By("emitting a VolumeServerEvacuating event for the doomed server")
+		Eventually(func(g Gomega) {
+			events := &corev1.EventList{}
+			g.Expect(k8sClient.List(ctx, events, client.InNamespace(testNamespace))).To(Succeed())
+			found := false
+			for _, e := range events.Items {
+				if e.InvolvedObject.Name == seaweedName && e.Reason == "VolumeServerEvacuating" {
+					found = true
+				}
+			}
+			g.Expect(found).To(BeTrue(), "no VolumeServerEvacuating event was recorded")
+		}, time.Minute*3, time.Second*5).Should(Succeed())
+
+		By("removing the drained pod only after its volumes moved, losing none")
+		Eventually(func(g Gomega) {
+			sts := &appsv1.StatefulSet{}
+			g.Expect(k8sClient.Get(ctx, volumeStsKey, sts)).To(Succeed())
+			g.Expect(sts.Spec.Replicas).NotTo(BeNil())
+			g.Expect(*sts.Spec.Replicas).To(Equal(int32(1)), "volume StatefulSet did not shrink to 1")
+			g.Expect(sts.Status.Replicas).To(Equal(int32(1)), "doomed volume pod was not removed")
+
+			ds, err := fetchTopology()
+			g.Expect(err).NotTo(HaveOccurred())
+			byNode := ds.volumesByNode()
+			// The doomed server is gone from the topology...
+			for url := range byNode {
+				g.Expect(url).NotTo(HavePrefix(doomedNodePrefix), "doomed server still registered")
+			}
+			// ...and every volume it held now lives on the surviving server.
+			g.Expect(ds.totalVolumes()).To(Equal(totalBefore), "volumes were lost during scale-down")
+		}, time.Minute*6, time.Second*10).Should(Succeed())
+
+		By("returning the cluster to Ready at the new size")
+		utils.WaitForSeaweedReady(ctx, k8sClient, seaweedKey, 3*time.Minute)
+	})
+})

--- a/test/e2e/volume_evacuation_test.go
+++ b/test/e2e/volume_evacuation_test.go
@@ -165,8 +165,10 @@ var _ = Describe("Volume server evacuation on scale-down", Ordered, Label("integ
 		diskCount := int32(1)
 		// An explicit per-server max lets /vol/grow create volumes on the tiny
 		// test PVCs (with the default -max=0 the server derives its cap from
-		// free disk and a small PVC computes to ~0 writable volumes).
-		maxVolumeCounts := int32(10)
+		// free disk and a small PVC computes to ~0 writable volumes). Set well
+		// above the grow count so the surviving server has slots to spare for
+		// the evacuated volumes.
+		maxVolumeCounts := int32(20)
 		seaweed := &seaweedv1.Seaweed{
 			ObjectMeta: metav1.ObjectMeta{Name: seaweedName, Namespace: testNamespace},
 			Spec: seaweedv1.SeaweedSpec{
@@ -208,10 +210,15 @@ var _ = Describe("Volume server evacuation on scale-down", Ordered, Label("integ
 
 		By("growing volumes so both servers host data")
 		// replication=000 keeps every volume to a single copy, so the doomed
-		// server's volumes can always move onto the one remaining server.
+		// server's volumes can always move onto the one remaining server. Grow
+		// once (retrying only a transient HTTP error), then wait separately for
+		// the new volumes to register so a slow heartbeat does not re-grow.
 		Eventually(func(g Gomega) {
-			_, err := masterGet("/vol/grow?count=10&replication=000")
+			_, err := masterGet("/vol/grow?count=6&replication=000")
 			g.Expect(err).NotTo(HaveOccurred())
+		}, time.Minute, time.Second*5).Should(Succeed())
+
+		Eventually(func(g Gomega) {
 			ds, err := fetchTopology()
 			g.Expect(err).NotTo(HaveOccurred())
 			byNode := ds.volumesByNode()


### PR DESCRIPTION
Closes #20.

## Problem

Lowering `volume.replicas` (or a `volumeTopology` group's `replicas`) only changed the StatefulSet's replica count, so Kubernetes deleted the highest-ordinal volume-server pods immediately. Any data those servers held that was not already replicated elsewhere was lost. Issue #20 asks the operator to **evacuate a volume server before it is taken down**.

Its prerequisite (#23 — an embedded `weed` master client) already landed and is used by the bucket controller and `seaweed_maintenance.go`; this builds on that.

## Approach

A non-blocking, reconcile-driven gate in the volume reconcile path. It is **always on** — graceful drain is the safe default for a storage operator and there is no opt-out.

On scale-down:

1. The volume StatefulSet is **held at its current size** while draining (pods stay alive so their data can be moved).
2. The operator asks the master for each server's volume/EC-shard count (`VolumeList`), and evacuates the **highest still-populated doomed server** in the background via `volumeServer.evacuate -node <addr> -apply`.
3. A pod is removed **only once the master confirms its server holds no volumes**. Servers drain and pods are removed **one at a time, top-ordinal first**, matching StatefulSet scale-down order.

`-skipNonMoveable` is deliberately **not** passed: a volume with no replication-compliant destination fails the evacuation and **blocks** the scale-down (surfaced as a `VolumeServerEvacuationFailed` event) rather than risking data loss.

### Why it's safe under restarts/races

Drain state is read **authoritatively from the master topology** every pass, never from operator memory. The in-memory `evacuationTracker` is purely a concurrency guard + retry throttle, so losing it on an operator restart just re-runs an evacuation that is then a fast no-op against an already-empty server.

### Behavior notes

- No master calls are made on create, scale-up, or steady state — only on an actual scale-down.
- If the topology can't be read, the scale-down is **held** (never shrinks blindly) and retried.
- Both the flat `-volume` StatefulSet and per-topology `-volume-<topo>` StatefulSets are gated.
- Emits `VolumeServerEvacuating` / `VolumeServerEvacuationFailed` events on the `Seaweed` CR.
- No new CRD fields or RBAC verbs (the StatefulSet read is already permitted; topology is fetched over gRPC).

## Implementation

- `swadmin`: `VolumeServerVolumeCounts` — fetches the master topology and totals volumes + EC shards per node id.
- `volume_admin.go`: `VolumeAdmin` interface + `VolumeAdminFactory` (injectable for tests; mirrors the existing `BucketAdmin` pattern), backed by `weed shell`'s `lock` + `volumeServer.evacuate -apply` + `unlock`.
- `volume_evacuation.go`: the pure `evacuationDecision` (allowed replica count + which server to drain next), the `evacuationTracker`, the reconcile glue, and node-address helpers.
- `controller_volume.go`: caps the StatefulSet replica count via `allowedVolumeServerReplicas` in both volume ensure paths.

## Testing

- `go test ./api/... ./internal/...` passes (incl. `-race` on the new concurrency paths).
- `make vet` and `make nilaway-lint` clean.
- New tests cover the decision table (drained / populated / missing-from-topology, multi-server drain), node addressing, the no-scale-down fast path (no master call), hold-on-unavailable-topology, the evacuation trigger, and the tracker's dedup + backoff + forget.
- `test/e2e` requires a live cluster and is unaffected.