### PR TITLE
Fix filer CrashLoopBackOff on fresh no-TLS install (probe 401)

### DIFF
--- a/internal/controller/controller_filer_statefulset_test.go
+++ b/internal/controller/controller_filer_statefulset_test.go
@@ -1,0 +1,77 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+)
+
+// filerContainer returns the "filer" container from a StatefulSet built by the
+// reconciler, failing the test if it is missing.
+func filerContainer(t *testing.T, sts *corev1.PodSpec) *corev1.Container {
+	t.Helper()
+	for i := range sts.Containers {
+		if sts.Containers[i].Name == "filer" {
+			return &sts.Containers[i]
+		}
+	}
+	t.Fatalf("filer container not found in pod spec")
+	return nil
+}
+
+// On a fresh, no-TLS install the operator used to mount a security.toml that
+// enabled [jwt.filer_signing.read], which made the filer demand a signed JWT
+// on every GET. The readiness/liveness probe is an unauthenticated GET / on
+// the filer HTTP port, so the filer answered 401 ("wrong jwt"), the probe
+// failed, and the pod landed in CrashLoopBackOff.
+//
+// The invariant: the filer must not be probed with an unauthenticated read
+// while the security.toml mounted into the same pod requires JWT-signed reads.
+func TestFilerProbeNotRejectedByReadJWT(t *testing.T) {
+	// The minimal CR from the issue: filer present, no TLS, no admin.
+	m := &seaweedv1.Seaweed{
+		ObjectMeta: metav1.ObjectMeta{Name: "seaweedfs", Namespace: "default"},
+		Spec: seaweedv1.SeaweedSpec{
+			Image:  "chrislusf/seaweedfs:3.96",
+			Master: &seaweedv1.MasterSpec{Replicas: 1},
+			Volume: &seaweedv1.VolumeSpec{Replicas: 1},
+			Filer:  &seaweedv1.FilerSpec{Replicas: 1},
+		},
+	}
+	r := &SeaweedReconciler{}
+	sts := r.createFilerStatefulSet(m)
+
+	c := filerContainer(t, &sts.Spec.Template.Spec)
+
+	// The probe the kubelet runs against the filer: an unauthenticated GET /
+	// on the filer HTTP port. It carries no Authorization header.
+	probe := c.ReadinessProbe
+	if probe == nil || probe.HTTPGet == nil {
+		t.Fatalf("expected an HTTP readiness probe on the filer container")
+	}
+	unauthenticatedReadProbe := probe.HTTPGet.Path == "/" &&
+		probe.HTTPGet.Port.IntValue() == seaweedv1.FilerHTTPPort
+	if !unauthenticatedReadProbe {
+		t.Fatalf("expected probe GET / on port %d, got %s:%s",
+			seaweedv1.FilerHTTPPort, probe.HTTPGet.Path, probe.HTTPGet.Port.String())
+	}
+
+	// The security.toml the operator mounts into this very pod, rendered for a
+	// no-TLS cluster exactly as ensureSecuritySecret writes it.
+	if !securityConfigNeeded(m) {
+		t.Fatalf("precondition: expected security.toml to be mounted for a filer CR")
+	}
+	securityTOML := renderSecurityTOML("write-key", tlsEffective(m))
+	readJWTRequired := strings.Contains(securityTOML, "[jwt.filer_signing.read]")
+
+	// The bug was both holding at once: every probe GET answered with 401.
+	if unauthenticatedReadProbe && readJWTRequired {
+		t.Fatalf("filer is probed with an unauthenticated GET / but the mounted "+
+			"security.toml enables [jwt.filer_signing.read], so the probe gets "+
+			"401 \"wrong jwt\" and the pod CrashLoopBackOffs.\nsecurity.toml:\n%s", securityTOML)
+	}
+}

--- a/internal/controller/controller_tls.go
+++ b/internal/controller/controller_tls.go
@@ -297,15 +297,12 @@ func (r *SeaweedReconciler) ensureServerCertificate(ctx context.Context, m *seaw
 // JWT signing keys on every reconcile, which would invalidate live tokens.
 func (r *SeaweedReconciler) ensureSecuritySecret(ctx context.Context, m *seaweedv1.Seaweed) (bool, ctrl.Result, error) {
 	name := SecurityConfigSecretName(m)
-	jwtFilerWrite, jwtFilerRead, fromLegacyConfigMap, err := r.existingJWTSigningKeys(ctx, m, name)
+	jwtFilerWrite, fromLegacyConfigMap, err := r.existingJWTSigningKeys(ctx, m, name)
 	if err != nil {
 		return ReconcileResult(err)
 	}
 	if jwtFilerWrite == "" {
 		jwtFilerWrite = randKey()
-	}
-	if jwtFilerRead == "" {
-		jwtFilerRead = randKey()
 	}
 
 	secret := &corev1.Secret{
@@ -316,7 +313,7 @@ func (r *SeaweedReconciler) ensureSecuritySecret(ctx context.Context, m *seaweed
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
-			"security.toml": []byte(renderSecurityTOML(jwtFilerWrite, jwtFilerRead, tlsEffective(m))),
+			"security.toml": []byte(renderSecurityTOML(jwtFilerWrite, tlsEffective(m))),
 		},
 	}
 	if err := controllerutil.SetControllerReference(m, secret, r.Scheme); err != nil {
@@ -336,38 +333,34 @@ func (r *SeaweedReconciler) ensureSecuritySecret(ctx context.Context, m *seaweed
 	return ReconcileResult(nil)
 }
 
-// existingJWTSigningKeys returns the JWT signing keys already provisioned for
-// m, so a reconcile preserves them instead of rotating. It prefers the
-// security Secret and falls back to the legacy ConfigMap (operator versions
-// before security.toml moved to a Secret), keeping keys stable across the
-// upgrade. fromLegacyConfigMap is true only when the keys came from that
-// ConfigMap, signalling the caller to clean it up. Empty strings mean none
-// exist yet — the caller generates fresh ones.
-func (r *SeaweedReconciler) existingJWTSigningKeys(ctx context.Context, m *seaweedv1.Seaweed, name string) (write, read string, fromLegacyConfigMap bool, err error) {
+// existingJWTSigningKeys returns the jwt.filer_signing write key already
+// provisioned for m, so a reconcile preserves it instead of rotating. It
+// prefers the security Secret and falls back to the legacy ConfigMap (operator
+// versions before security.toml moved to a Secret), keeping the key stable
+// across the upgrade. fromLegacyConfigMap is true only when the key came from
+// that ConfigMap, signalling the caller to clean it up. An empty string means
+// none exists yet — the caller generates a fresh one.
+func (r *SeaweedReconciler) existingJWTSigningKeys(ctx context.Context, m *seaweedv1.Seaweed, name string) (write string, fromLegacyConfigMap bool, err error) {
 	key := client.ObjectKey{Name: name, Namespace: m.Namespace}
 
 	secret := &corev1.Secret{}
 	err = r.Get(ctx, key, secret)
 	if err == nil {
-		toml := string(secret.Data["security.toml"])
-		return extractTOMLKey(toml, "jwt.filer_signing", "key"),
-			extractTOMLKey(toml, "jwt.filer_signing.read", "key"), false, nil
+		return extractTOMLKey(string(secret.Data["security.toml"]), "jwt.filer_signing", "key"), false, nil
 	}
 	if !apierrors.IsNotFound(err) {
-		return "", "", false, err
+		return "", false, err
 	}
 
 	cm := &corev1.ConfigMap{}
 	err = r.Get(ctx, key, cm)
 	if err == nil {
-		toml := cm.Data["security.toml"]
-		return extractTOMLKey(toml, "jwt.filer_signing", "key"),
-			extractTOMLKey(toml, "jwt.filer_signing.read", "key"), true, nil
+		return extractTOMLKey(cm.Data["security.toml"], "jwt.filer_signing", "key"), true, nil
 	}
 	if apierrors.IsNotFound(err) {
-		return "", "", false, nil
+		return "", false, nil
 	}
-	return "", "", false, err
+	return "", false, err
 }
 
 // deleteLegacySecurityConfigMap removes the pre-Secret security.toml ConfigMap
@@ -383,24 +376,23 @@ func (r *SeaweedReconciler) deleteLegacySecurityConfigMap(ctx context.Context, n
 	return nil
 }
 
-// renderSecurityTOML emits the [jwt.filer_signing*] sections always (filer
-// needs them to register the IAM gRPC service, admin needs them to sign
-// Bearer tokens) and the [grpc.*] mTLS sections only when withTLS is true.
+// renderSecurityTOML emits the [jwt.filer_signing] section always (the filer
+// needs it to register the IAM gRPC service, admin needs it to sign Bearer
+// tokens) and the [grpc.*] mTLS sections only when withTLS is true.
 //
-// The volume-side [jwt.signing*] sections are intentionally omitted: shipping
-// them would make every volume server reject unsigned reads/writes, which
-// the operator does not currently wire up end-to-end.
-func renderSecurityTOML(jwtFilerWrite, jwtFilerRead string, withTLS bool) string {
+// [jwt.filer_signing.read] is intentionally omitted, for the same reason as
+// the volume-side [jwt.signing*] sections: emitting it makes the filer reject
+// every unsigned GET, but the operator never signs read JWTs for any client.
+// The readiness/liveness probe is a plain GET /, so a read-signing key would
+// answer it with 401 and crashloop the filer.
+func renderSecurityTOML(jwtFilerWrite string, withTLS bool) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, `# generated by seaweedfs-operator — do not edit
 # this file is read by master, volume server, filer, and admin
 
 [jwt.filer_signing]
 key = %q
-
-[jwt.filer_signing.read]
-key = %q
-`, jwtFilerWrite, jwtFilerRead)
+`, jwtFilerWrite)
 
 	if !withTLS {
 		return b.String()

--- a/internal/controller/controller_tls_test.go
+++ b/internal/controller/controller_tls_test.go
@@ -67,7 +67,7 @@ func TestSecurityConfigNeeded(t *testing.T) {
 
 func TestRenderSecurityTOML(t *testing.T) {
 	t.Run("without TLS only emits jwt sections", func(t *testing.T) {
-		got := renderSecurityTOML("write-key", "read-key", false)
+		got := renderSecurityTOML("write-key", false)
 		if !strings.Contains(got, "[jwt.filer_signing]") {
 			t.Errorf("expected [jwt.filer_signing] section, got %q", got)
 		}
@@ -80,7 +80,7 @@ func TestRenderSecurityTOML(t *testing.T) {
 	})
 
 	t.Run("with TLS emits jwt and grpc sections", func(t *testing.T) {
-		got := renderSecurityTOML("write-key", "read-key", true)
+		got := renderSecurityTOML("write-key", true)
 		if !strings.Contains(got, "[jwt.filer_signing]") {
 			t.Errorf("expected [jwt.filer_signing] section, got %q", got)
 		}
@@ -92,12 +92,18 @@ func TestRenderSecurityTOML(t *testing.T) {
 		}
 	})
 
-	t.Run("never emits volume jwt.signing", func(t *testing.T) {
-		// Shipping [jwt.signing] would force volume servers to enforce
-		// signed reads/writes; the operator does not wire that up
-		// end-to-end. Catch any future regression that re-introduces it.
+	t.Run("never emits read-signing or volume jwt.signing", func(t *testing.T) {
+		// Shipping [jwt.filer_signing.read] makes the filer reject every
+		// unsigned GET — including the readiness/liveness probe, which
+		// crashloops the pod. [jwt.signing] would do the same to volume
+		// servers. The operator signs neither read JWT for any client, so
+		// neither section may ship. Catch any regression that re-introduces
+		// them.
 		for _, withTLS := range []bool{false, true} {
-			got := renderSecurityTOML("write-key", "read-key", withTLS)
+			got := renderSecurityTOML("write-key", withTLS)
+			if strings.Contains(got, "[jwt.filer_signing.read]") {
+				t.Errorf("withTLS=%v: unexpected [jwt.filer_signing.read] section, got %q", withTLS, got)
+			}
 			if strings.Contains(got, "[jwt.signing]") {
 				t.Errorf("withTLS=%v: unexpected [jwt.signing] section, got %q", withTLS, got)
 			}
@@ -191,8 +197,13 @@ func TestEnsureSecuritySecret_MigratesLegacyConfigMap(t *testing.T) {
 		t.Fatalf("expected migrated Secret: %v", err)
 	}
 	got := string(secret.Data["security.toml"])
-	if !strings.Contains(got, `key = "legacy-write"`) || !strings.Contains(got, `key = "legacy-read"`) {
-		t.Errorf("expected legacy JWT keys preserved, got %q", got)
+	if !strings.Contains(got, `key = "legacy-write"`) {
+		t.Errorf("expected legacy write key preserved, got %q", got)
+	}
+	// The legacy read key is intentionally dropped: [jwt.filer_signing.read]
+	// crashloops the filer probe and nothing signs read JWTs.
+	if strings.Contains(got, `key = "legacy-read"`) || strings.Contains(got, "[jwt.filer_signing.read]") {
+		t.Errorf("expected legacy read key dropped, got %q", got)
 	}
 
 	cm := &corev1.ConfigMap{}


### PR DESCRIPTION
## Problem

Fixes #306.

On a clean, first-time install with **no TLS**, the filer never becomes Ready. Its readiness *and* liveness probes fail with **HTTP 401**, so the pod crashloops and filer/S3 never come up:

```
Readiness probe failed: HTTP probe failed with statuscode: 401
filer log: response method:GET URL:/ with httpStatus:401 and JSON:{"error":"wrong jwt"}
```

## Root cause

Even without TLS, the operator provisions a `security.toml` for any CR with a filer (`securityConfigNeeded` is true when `Spec.Filer != nil`) and mounts it into the filer via `-config_dir`. `renderSecurityTOML` always emitted **`[jwt.filer_signing.read]`**, which makes the filer require a signed JWT on every GET/read. But the readiness/liveness probe is an unauthenticated `GET /` on the filer HTTP port, so the filer answers `401 "wrong jwt"` → probe fails → `CrashLoopBackOff`.

This is a regression from 0.1.22 / 1.0.19, which did not ship the read-signing section.

## Fix

Stop emitting `[jwt.filer_signing.read]` (and stop generating/preserving the now-unused read key).

The read-signing key is **never consumed anywhere** in the operator — only the **write** key (`jwt.filer_signing`) is read, by the admin/IAM Bearer-token path (`loadFilerAdminSigningKey`). Shipping a read-signing key the operator never signs requests with is pure liability — the same reasoning that already keeps the volume-side `[jwt.signing]` sections out of the rendered config. The write key only gates writes (POST/PUT/DELETE), so the `GET /` probe is unaffected by it.

Existing broken clusters self-heal: the next reconcile rewrites the `security.toml` Secret without the read section, and the crashlooping filer picks it up on its next restart.

## Tests

- `TestFilerProbeNotRejectedByReadJWT` — new regression guard: asserts the operator never builds a filer probed with an unauthenticated read while the mounted `security.toml` requires read JWTs. Failed before the fix, passes after.
- `TestRenderSecurityTOML/never_emits_read-signing_or_volume_jwt.signing` — extended to also forbid `[jwt.filer_signing.read]`.
- `TestEnsureSecuritySecret_MigratesLegacyConfigMap` — updated: the legacy read key is now intentionally dropped on migration, write key still preserved.

All controller package tests pass; `go vet ./internal/...` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced JWT signing key preservation in security configuration to prevent filer container probe failures when JWT-signed reads are enforced
  * Streamlined JWT key retention logic to preserve only write signing keys, reducing configuration overhead

* **Tests**
  * Added test coverage to validate filer container health probes function correctly when JWT-signed read operations are required

<!-- end of auto-generated comment: release notes by coderabbit.ai -->