### PR TITLE
CI: helm-install smoke waits for the cluster to actually come Ready

### DIFF
--- a/test/helm/install_smoke.sh
+++ b/test/helm/install_smoke.sh
@@ -33,6 +33,8 @@
 #   IMAGE_TAG          (default: v0.0.1)
 #   RECONCILE_WAIT     (default: 30 — seconds to wait between applying
 #                      sample CRs and inspecting operator logs)
+#   READY_TIMEOUT      (default: 10m — how long to wait for the Seaweed CR
+#                      to reach its Ready condition)
 
 set -euo pipefail
 
@@ -44,6 +46,7 @@ CHART_DIR="${CHART_DIR:-$REPO_ROOT/deploy/helm}"
 IMAGE_REPOSITORY="${IMAGE_REPOSITORY:-ghcr.io/seaweedfs/seaweedfs-operator}"
 IMAGE_TAG="${IMAGE_TAG:-v0.0.1}"
 RECONCILE_WAIT="${RECONCILE_WAIT:-30}"
+READY_TIMEOUT="${READY_TIMEOUT:-10m}"
 
 log() { printf '[smoke] %s\n' "$*"; }
 fail() { printf '[smoke] FAIL: %s\n' "$*" >&2; exit 1; }
@@ -90,6 +93,32 @@ kubectl wait deployment.apps/"$DEPLOYMENT" \
 # would trip a missing servicemonitor RBAC rule.
 log "applying sample Seaweed CR"
 kubectl apply -f "$REPO_ROOT/config/samples/seaweed_v1_seaweed.yaml"
+
+# The chart defaults give a no-TLS cluster with a filer — the exact shape
+# that regressed once, when the operator mounted a security.toml requiring
+# JWT-signed reads and the filer's unauthenticated readiness/liveness probe
+# was 401'd into CrashLoopBackOff. Until now this smoke only scraped the
+# operator log for RBAC errors, so a filer that never came up went
+# unnoticed. The operator only flips the CR to Ready once every component's
+# pods are Ready, so waiting on that condition turns a component-never-Ready
+# regression red here, on the path users actually run (`helm install`).
+SEAWEED_CR="$REPO_ROOT/config/samples/seaweed_v1_seaweed.yaml"
+SEAWEED_NAME="$(kubectl get -f "$SEAWEED_CR" -o jsonpath='{.metadata.name}')"
+SEAWEED_NS="$(kubectl get -f "$SEAWEED_CR" -o jsonpath='{.metadata.namespace}')"
+SEAWEED_NS="${SEAWEED_NS:-default}"
+log "waiting up to ${READY_TIMEOUT} for Seaweed/${SEAWEED_NAME} to become Ready"
+if ! kubectl wait "seaweed/${SEAWEED_NAME}" --namespace "$SEAWEED_NS" \
+    --for=condition=Ready --timeout="$READY_TIMEOUT"; then
+  log "Seaweed CR did not reach Ready; dumping cluster state:"
+  kubectl get pods -n "$SEAWEED_NS" -o wide >&2 || true
+  kubectl describe "seaweed/${SEAWEED_NAME}" -n "$SEAWEED_NS" >&2 || true
+  # The operator log is the most useful artifact here — it carries the
+  # reconcile errors behind a component never reaching Ready. We exit
+  # before the RBAC-scrape section below, so dump it now.
+  log "dumping operator logs:"
+  kubectl logs -n "$NAMESPACE" deployment.apps/"$DEPLOYMENT" --tail=-1 >&2 || true
+  fail "Seaweed cluster did not become Ready after helm install with chart defaults"
+fi
 
 # Apply a basic Bucket CR. This drives the BucketReconciler all the
 # way through its full reconcile sequence (List, Get, finalizer


### PR DESCRIPTION
## Why

Follow-up to #307 (the filer probe-401 crashloop fix). While tracing why CI never caught #306, I found the gap is **not a missing test** — `test/e2e/cluster_startup_test.go` is a no-TLS master+volume+filer CR that waits for Ready, it's active, and `integration-test.yml` runs it on push-to-master. The problem is enforcement plus a weak smoke:

- The every-PR check (`make test`) runs under **envtest** — apiserver + etcd, **no kubelet** — so pods never run and a probe-induced `CrashLoopBackOff` is invisible.
- The `helm install` smoke (`test/helm/install_smoke.sh`) deploys the operator with chart defaults and applies the sample Seaweed CR (a **no-TLS cluster with a filer** — the exact #306 shape), but then only **greps the operator log for RBAC errors**. A filer that came up and never reached Ready left it green.

## Change

Make the smoke wait on the Seaweed CR's `Ready` condition after applying it. The operator only flips a Seaweed CR to `Ready` once **every component's pods are Ready** (`seaweed_controller.go`), so a component-never-Ready regression — including a filer 401'd into `CrashLoopBackOff` — now turns this smoke **red on the path users actually run** (`helm install` with chart defaults).

- Timeout defaults to 10m (overridable via `READY_TIMEOUT`) — the sample CR brings up master+volume+filer+s3 and pulls `:latest`, so the ceiling is generous; it only bites on a genuine regression or true stall.
- On failure it dumps pods + `kubectl describe seaweed` for triage.

## What this does and doesn't fix

This adds a real PR-time signal on the user path (complementing the cluster-free unit guard added in #307, which runs in every `make test`). It does **not** make the check merge/release-blocking — the durable fix for that is repo-side **branch protection**: mark the integration-test and helm-install-smoke jobs as required status checks, since the correct test already existed and ran but didn't gate the 1.0.27 release. That's a settings change, not a file.

## Stacking

Based on `fix/filer-readiness-probe-jwt-401` (#307), not `master`, so this PR's own helm-install smoke runs against the **fixed** operator and stays green. Retarget to `master` once #307 merges. (If based on `master` today, this smoke would correctly go red — the bug is still there.)