### PR TITLE
Periodically re-reconcile Ready buckets and lifecycle policies to heal filer drift

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -78,6 +78,11 @@ func main() {
 		"Cadence for refreshing status.usage on Bucket resources. "+
 			"Set to 0 to disable. Defaults to 5m. Each tick issues one collection.list "+
 			"call per Seaweed cluster that owns Buckets, then patches per-bucket status.")
+	var bucketResyncInterval time.Duration
+	flag.DurationVar(&bucketResyncInterval, "bucket-resync-interval", controller.DefaultBucketResyncInterval,
+		"Steady-state cadence for re-reconciling Ready Bucket and BucketLifecyclePolicy "+
+			"resources so filer state lost out-of-band (cluster rebuild, filer reset, manual "+
+			"delete) is reapplied without an operator restart. Set to 0 to disable. Defaults to 5m.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -157,16 +162,18 @@ func main() {
 		Scheme:               mgr.GetScheme(),
 		Recorder:             mgr.GetEventRecorderFor("bucket-controller"),
 		UsageRefreshInterval: bucketUsageInterval,
+		ResyncInterval:       bucketResyncInterval,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Bucket")
 		os.Exit(1)
 	}
 
 	if err = (&controller.BucketLifecyclePolicyReconciler{
-		Client:   mgr.GetClient(),
-		Log:      ctrl.Log.WithName("controller").WithName("BucketLifecyclePolicy"),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor("bucketlifecyclepolicy-controller"),
+		Client:         mgr.GetClient(),
+		Log:            ctrl.Log.WithName("controller").WithName("BucketLifecyclePolicy"),
+		Scheme:         mgr.GetScheme(),
+		Recorder:       mgr.GetEventRecorderFor("bucketlifecyclepolicy-controller"),
+		ResyncInterval: bucketResyncInterval,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "BucketLifecyclePolicy")
 		os.Exit(1)

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 	"time"
@@ -203,6 +204,10 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 func (r *BucketReconciler) reconcileBucket(ctx context.Context, bucket *seaweedv1.Bucket, bucketName string, admin BucketAdmin) (ctrl.Result, error) {
 	log := r.Log.WithValues("bucket", types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name})
 
+	// Snapshot status so the success path can skip a redundant write when a
+	// resync pass finds no drift. failPhase paths persist their own status.
+	baseStatus := bucket.Status.DeepCopy()
+
 	exists, err := admin.BucketExists(ctx, bucketName)
 	if err != nil {
 		return r.failPhase(ctx, bucket, seaweedv1.BucketPhaseFailed, "ExistsCheckFailed", err.Error())
@@ -348,8 +353,13 @@ func (r *BucketReconciler) reconcileBucket(ctx context.Context, bucket *seaweedv
 	r.clearCondition(bucket, seaweedv1.BucketConditionBucketAlreadyExists)
 	r.clearCondition(bucket, seaweedv1.BucketConditionDeleteBlockedByRetention)
 
-	if err := r.Status().Update(ctx, bucket); err != nil {
-		return ctrl.Result{}, err
+	// Persist status only when it actually changed, so a steady-state resync
+	// pass (no drift) issues no Status().Update — avoiding both the apiserver
+	// round trip per bucket and the update event that would re-trigger us.
+	if !reflect.DeepEqual(*baseStatus, bucket.Status) {
+		if err := r.Status().Update(ctx, bucket); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 	// Pull ourselves back periodically. There is no watch on the SeaweedFS
 	// filer, so this requeue is the only way drift — a bucket deleted

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -54,6 +54,18 @@ const (
 	// dependency (the filer, an IAM identity) is missing but expected to
 	// arrive shortly.
 	requeueAfterTransient = 30 * time.Second
+
+	// DefaultBucketResyncInterval is the steady-state cadence at which a
+	// Ready Bucket re-enters Reconcile. The reconciler holds no watch on
+	// the SeaweedFS filer, so a bucket that disappears out-of-band — a
+	// cluster rebuild, a filer-store reset, a manual delete — is invisible
+	// until something re-triggers Reconcile. Without a periodic requeue the
+	// only such trigger is a spec change or an operator restart, which is
+	// why a lost bucket used to stay missing until the operator was
+	// bounced. The requeue re-runs the existence check and recreates the
+	// bucket, so recovery is automatic. main.go wires this as the default
+	// for BucketReconciler.ResyncInterval.
+	DefaultBucketResyncInterval = 5 * time.Minute
 )
 
 // BucketReconciler reconciles Bucket resources by translating spec changes
@@ -74,6 +86,14 @@ type BucketReconciler struct {
 	// loop. Zero disables the loop entirely; the default in main.go is
 	// DefaultUsageRefreshInterval (5 minutes).
 	UsageRefreshInterval time.Duration
+
+	// ResyncInterval is the steady-state cadence at which a successfully
+	// reconciled (Ready) Bucket re-enters Reconcile, so a bucket lost
+	// out-of-band (cluster rebuild, filer reset, manual delete) is
+	// re-detected and recreated without restarting the operator. Zero
+	// disables the periodic requeue; watches and the transient-error
+	// backoff still apply. main.go defaults it to DefaultBucketResyncInterval.
+	ResyncInterval time.Duration
 }
 
 // +kubebuilder:rbac:groups=seaweed.seaweedfs.com,resources=buckets,verbs=get;list;watch;create;update;patch;delete
@@ -331,7 +351,11 @@ func (r *BucketReconciler) reconcileBucket(ctx context.Context, bucket *seaweedv
 	if err := r.Status().Update(ctx, bucket); err != nil {
 		return ctrl.Result{}, err
 	}
-	return ctrl.Result{}, nil
+	// Pull ourselves back periodically. There is no watch on the SeaweedFS
+	// filer, so this requeue is the only way drift — a bucket deleted
+	// out-of-band — gets re-detected and healed. r.ResyncInterval == 0
+	// leaves Result zero-valued (requeue disabled).
+	return ctrl.Result{RequeueAfter: r.ResyncInterval}, nil
 }
 
 // handleDeletion drives the reclaim-policy path. Retain just removes the

--- a/internal/controller/bucket_controller_test.go
+++ b/internal/controller/bucket_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"google.golang.org/grpc"
@@ -478,6 +479,68 @@ func TestReconcile_ExistingBucketRefusesAdoption(t *testing.T) {
 		if strings.HasPrefix(c, "Create:") {
 			t.Errorf("unexpected Create call: %s", c)
 		}
+	}
+}
+
+// TestReconcile_ReadyBucketRequeuesForDrift pins the periodic resync: a
+// Ready bucket must request a RequeueAfter equal to ResyncInterval so the
+// reconciler keeps re-verifying external state it cannot watch.
+func TestReconcile_ReadyBucketRequeuesForDrift(t *testing.T) {
+	bucket := newTestBucket("photos")
+	bucket.Finalizers = []string{BucketFinalizer}
+
+	fa := newFakeAdmin()
+	r, _ := testReconciler(t, fa, newTestSeaweed(), bucket)
+	r.ResyncInterval = 2 * time.Minute
+
+	key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
+	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if res.RequeueAfter != 2*time.Minute {
+		t.Fatalf("RequeueAfter=%v, want the 2m resync cadence", res.RequeueAfter)
+	}
+}
+
+// TestReconcile_RecreatesBucketLostOutOfBand is the regression guard for the
+// "bucket stays missing until the operator restarts" report: once a bucket is
+// Ready, a subsequent reconcile must recreate it if it vanished from the
+// cluster out-of-band (e.g. a SeaweedFS rebuild) rather than trusting status.
+func TestReconcile_RecreatesBucketLostOutOfBand(t *testing.T) {
+	bucket := newTestBucket("photos")
+	bucket.Finalizers = []string{BucketFinalizer}
+
+	fa := newFakeAdmin()
+	r, cli := testReconciler(t, fa, newTestSeaweed(), bucket)
+	r.ResyncInterval = 2 * time.Minute
+
+	key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
+
+	// First pass provisions the bucket and marks it Ready.
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("initial reconcile: %v", err)
+	}
+	got := &seaweedv1.Bucket{}
+	if err := cli.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	if got.Status.Phase != seaweedv1.BucketPhaseReady {
+		t.Fatalf("phase=%q want Ready", got.Status.Phase)
+	}
+
+	// The bucket disappears from the cluster while the CR stays Ready.
+	fa.existsResp["photos"] = false
+	createsBefore := countCalls(fa.calls, "Create:photos")
+
+	// The periodic requeue brings us back into Reconcile; the existence
+	// check now misses, so the bucket is recreated — no restart needed.
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("drift reconcile: %v", err)
+	}
+	if got := countCalls(fa.calls, "Create:photos"); got != createsBefore+1 {
+		t.Fatalf("expected bucket recreated after out-of-band loss; Create:photos calls %d -> %d\ncalls:\n%s",
+			createsBefore, got, strings.Join(fa.calls, "\n"))
 	}
 }
 

--- a/internal/controller/bucket_controller_test.go
+++ b/internal/controller/bucket_controller_test.go
@@ -544,6 +544,50 @@ func TestReconcile_RecreatesBucketLostOutOfBand(t *testing.T) {
 	}
 }
 
+// TestReconcile_SteadyStateResyncDoesNotWriteStatus pins that a resync pass
+// finding no drift issues no Status().Update: the periodic requeue must not
+// churn the apiserver or re-trigger the controller through its own update
+// event once a bucket has settled at Ready.
+func TestReconcile_SteadyStateResyncDoesNotWriteStatus(t *testing.T) {
+	bucket := newTestBucket("photos")
+	bucket.Finalizers = []string{BucketFinalizer}
+
+	fa := newFakeAdmin()
+	r, cli := testReconciler(t, fa, newTestSeaweed(), bucket)
+	r.ResyncInterval = 2 * time.Minute
+
+	key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
+
+	// First pass provisions the bucket and marks it Ready (a real status change).
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("initial reconcile: %v", err)
+	}
+	settled := &seaweedv1.Bucket{}
+	if err := cli.Get(context.Background(), key, settled); err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	if settled.Status.Phase != seaweedv1.BucketPhaseReady {
+		t.Fatalf("precondition: phase=%q want Ready", settled.Status.Phase)
+	}
+
+	// A second pass finds no drift; status is identical, so nothing is written
+	// — but the resync cadence is still requested.
+	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	if err != nil {
+		t.Fatalf("steady-state reconcile: %v", err)
+	}
+	if res.RequeueAfter != 2*time.Minute {
+		t.Fatalf("RequeueAfter=%v, want the resync cadence preserved on a no-op pass", res.RequeueAfter)
+	}
+	got := &seaweedv1.Bucket{}
+	if err := cli.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	if got.ResourceVersion != settled.ResourceVersion {
+		t.Errorf("steady-state reconcile wrote status: resourceVersion %s -> %s", settled.ResourceVersion, got.ResourceVersion)
+	}
+}
+
 func TestReconcile_RenameRefused(t *testing.T) {
 	bucket := newTestBucket("photos")
 	bucket.Spec.Name = "renamed"

--- a/internal/controller/bucketlifecyclepolicy_controller.go
+++ b/internal/controller/bucketlifecyclepolicy_controller.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -56,6 +57,16 @@ type BucketLifecyclePolicyReconciler struct {
 	// AdminFactory creates a BucketAdmin for the target Seaweed cluster.
 	// Tests inject a fake; production wires NewSwadminBucketAdmin.
 	AdminFactory BucketAdminFactory
+
+	// ResyncInterval is the steady-state cadence at which a Ready policy
+	// re-enters Reconcile. Like the bucket itself, the applied lifecycle
+	// XML lives on the filer with no watch, so a config lost out-of-band
+	// (cluster rebuild, filer reset) is invisible until something
+	// re-triggers Reconcile. The periodic requeue re-applies it without an
+	// operator restart; the no-op status guard keeps a steady-state pass
+	// from churning. Zero disables the requeue. main.go defaults it to
+	// DefaultBucketResyncInterval.
+	ResyncInterval time.Duration
 }
 
 // +kubebuilder:rbac:groups=seaweed.seaweedfs.com,resources=bucketlifecyclepolicies,verbs=get;list;watch;create;update;patch;delete
@@ -185,7 +196,9 @@ func (r *BucketLifecyclePolicyReconciler) reconcilePolicy(ctx context.Context, p
 	policy.Status.AppliedRules = int32(len(policy.Spec.Rules))
 	policy.Status.Phase = seaweedv1.BucketPhaseReady
 	r.setCondition(policy, seaweedv1.BucketLifecyclePolicyConditionReady, metav1.ConditionTrue, "Reconciled", "")
-	return ctrl.Result{}, nil
+	// Pull ourselves back periodically to re-detect drift on the filer,
+	// which we don't watch. r.ResyncInterval == 0 disables the requeue.
+	return ctrl.Result{RequeueAfter: r.ResyncInterval}, nil
 }
 
 // handleDeletion clears the lifecycle configuration when reclaimPolicy is Delete

--- a/internal/controller/bucketlifecyclepolicy_controller_test.go
+++ b/internal/controller/bucketlifecyclepolicy_controller_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"google.golang.org/grpc"
@@ -236,6 +237,56 @@ func TestLifecyclePolicyIdempotent(t *testing.T) {
 	// and re-trigger the controller).
 	if got := getLifecyclePolicy(t, cli, lifecyclePolicyKey).ResourceVersion; got != rv {
 		t.Errorf("steady-state reconcile wrote status: resourceVersion %s -> %s", rv, got)
+	}
+}
+
+// TestLifecyclePolicyReadyRequeuesForDrift pins the periodic resync: a Ready
+// policy must request a RequeueAfter equal to ResyncInterval so the reconciler
+// keeps re-verifying filer state it cannot watch.
+func TestLifecyclePolicyReadyRequeuesForDrift(t *testing.T) {
+	fa := newFakeAdmin()
+	sw, bucket := newLifecycleTestObjects()
+	r, _ := testLifecycleReconciler(t, fa, sw, bucket, newTestLifecyclePolicy())
+	r.ResyncInterval = 2 * time.Minute
+
+	// First pass adds the finalizer (Requeue:true); the second applies and
+	// settles on the resync cadence.
+	res := reconcileLifecycleN(t, r, lifecyclePolicyKey, 2)
+	if res.RequeueAfter != 2*time.Minute {
+		t.Fatalf("RequeueAfter=%v, want the 2m resync cadence", res.RequeueAfter)
+	}
+}
+
+// TestLifecyclePolicyReappliesConfigLostOutOfBand is the regression guard for
+// drift recovery: once a policy is Ready, a later reconcile must reapply the
+// lifecycle XML if it vanished from the filer out-of-band (e.g. a cluster
+// rebuild) rather than trusting status.
+func TestLifecyclePolicyReappliesConfigLostOutOfBand(t *testing.T) {
+	fa := newFakeAdmin()
+	sw, bucket := newLifecycleTestObjects()
+	r, cli := testLifecycleReconciler(t, fa, sw, bucket, newTestLifecyclePolicy())
+	r.ResyncInterval = 2 * time.Minute
+
+	// First two passes add the finalizer and apply the configuration.
+	reconcileLifecycleN(t, r, lifecyclePolicyKey, 2)
+	if p := getLifecyclePolicy(t, cli, lifecyclePolicyKey); p.Status.Phase != seaweedv1.BucketPhaseReady {
+		t.Fatalf("precondition: phase=%q want Ready", p.Status.Phase)
+	}
+	applied := countCalls(fa.calls, "SetLifecycle:")
+	if applied == 0 {
+		t.Fatal("precondition: expected an initial SetLifecycle")
+	}
+
+	// The lifecycle config disappears from the filer while the CR stays Ready.
+	delete(fa.lifecycle, "my-bucket")
+
+	// The periodic requeue brings us back; the read now misses the config, so
+	// it is reapplied — no operator restart.
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: lifecyclePolicyKey}); err != nil {
+		t.Fatalf("drift reconcile: %v", err)
+	}
+	if got := countCalls(fa.calls, "SetLifecycle:"); got != applied+1 {
+		t.Fatalf("expected lifecycle reapplied after out-of-band loss; SetLifecycle calls %d -> %d", applied, got)
 	}
 }
 


### PR DESCRIPTION
## Problem

Fixes #280 (the reopened case from [this comment](https://github.com/seaweedfs/seaweedfs-operator/issues/280#issuecomment-4706180562)).

After upgrading SeaweedFS to v4.35, the filer lost its bucket entries. The `Bucket` CRs all stayed `Ready`, but only a subset of buckets actually existed in S3 — and the missing ones only came back after a `rollout restart` of the operator.

### Root cause

The `Bucket` reconciler was **edge-triggered only**: its success path returned `ctrl.Result{}, nil` with no requeue. Controller-runtime then only re-runs `Reconcile` when the CR's spec/metadata changes or the operator restarts. Critically, the controller holds **no watch on the SeaweedFS filer**, so a bucket that disappears out-of-band (cluster rebuild, filer-store reset, manual delete) is invisible until something else re-enters `Reconcile`.

That explains exactly what was observed:

- **Healed without a restart** → buckets whose CRs got an event (new PR → new/changed `Bucket` CR) → reconcile → recreated.
- **Not healed** → older, unchanged CRs → no event → never re-checked → stayed missing.
- **`rollout restart` fixes everything** → restart re-lists every CR → all reconciled → all recreated.

The usage-refresh loop didn't help: it only patches `status.usage`, and a missing bucket is indistinguishable from an empty one in `collection.list`.

`BucketLifecyclePolicy` had the **same blind spot** — it manages the lifecycle XML on the filer with no watch and also returned `ctrl.Result{}, nil` on success.

## Fix

Mirror the `Seaweed` controller's existing safety-net cadence (which already pulls itself back via `RequeueAfter` for drift it might otherwise miss). Both filer-backed controllers now return `RequeueAfter` on their success path, so a `Ready` resource periodically re-runs its existence/apply check and re-provisions whatever drifted away — no operator restart required.

- New `--bucket-resync-interval` flag, `DefaultBucketResyncInterval = 5m`, `0` to disable. Shared by the `Bucket` and `BucketLifecyclePolicy` controllers.
- `ResyncInterval` defaults to `0` in unit tests (no requeue), so existing convergence-based tests are unaffected; production gets the default from `main.go`.
- The lifecycle controller's existing no-op status guard means a steady-state pass that finds no drift writes nothing and emits no event — the periodic requeue doesn't churn.

Recovery time drops from "until someone notices and restarts the operator" to ≤ the resync interval (default 5 min).

## Tests

- `TestReconcile_ReadyBucketRequeuesForDrift` / `TestLifecyclePolicyReadyRequeuesForDrift` — pin the requeue cadence.
- `TestReconcile_RecreatesBucketLostOutOfBand` / `TestLifecyclePolicyReappliesConfigLostOutOfBand` — regression guards: reach `Ready`, drop the bucket/config from the cluster out-of-band, reconcile again, assert it's recreated/reapplied.

`go build ./...`, `go vet`, and the full `internal/...` + `cmd/...` unit suites pass. (Only the live-cluster `test/e2e` suite fails locally, on environment — unrelated to this change.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--bucket-resync-interval` to control how often Ready bucket and bucket lifecycle policy reconciliations run in steady state.
  * The system now periodically re-verifies and recovers from out-of-band bucket and lifecycle configuration changes.

* **Bug Fixes**
  * Reduced unnecessary status writes by only updating bucket status when it actually changes.

* **Tests**
  * Added regression coverage for periodic drift recovery, requeue cadence behavior, and ensuring status isn’t rewritten when no drift is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->