### PR TITLE
Auto-create kubelet host directories so the CSI driver works on k3s

### DIFF
--- a/api/v1/seaweedcsidriver_types.go
+++ b/api/v1/seaweedcsidriver_types.go
@@ -223,9 +223,10 @@ type CSIControllerSpec struct {
 type CSINodeSpec struct {
 	// KubeletPath is the host kubelet root directory the node plugin mounts
 	// to expose volumes and register its socket. Override on distributions
-	// that relocate it (k3s: /var/lib/rancher/k3s/agent/kubelet, MicroK8s:
-	// /var/snap/microk8s/common/var/lib/kubelet, k0s:
-	// /var/lib/k0s/kubelet). Defaults to /var/lib/kubelet.
+	// that relocate it (MicroK8s: /var/snap/microk8s/common/var/lib/kubelet,
+	// k0s: /var/lib/k0s/kubelet). Modern k3s keeps the default (older releases
+	// nested it under the data dir but moved back because CSI plugins expect
+	// the standard path). Defaults to /var/lib/kubelet.
 	// +optional
 	// +kubebuilder:default:="/var/lib/kubelet"
 	KubeletPath string `json:"kubeletPath,omitempty"`

--- a/config/samples/seaweed_v1_seaweedcsidriver.yaml
+++ b/config/samples/seaweed_v1_seaweedcsidriver.yaml
@@ -15,7 +15,8 @@ spec:
   controller:
     replicas: 1
   node:
-    # Override on distros that relocate the kubelet root (k3s, MicroK8s).
+    # Override on distros that relocate the kubelet root (MicroK8s, k0s).
+    # Modern k3s keeps the default below.
     kubeletPath: /var/lib/kubelet
   storageClass:
     name: seaweedfs

--- a/internal/controller/seaweedcsidriver_objects.go
+++ b/internal/controller/seaweedcsidriver_objects.go
@@ -53,7 +53,6 @@ const (
 
 var (
 	mountPropagationBidirectional = corev1.MountPropagationBidirectional
-	hostPathDirectory             = corev1.HostPathDirectory
 	hostPathDirectoryOrCreate     = corev1.HostPathDirectoryOrCreate
 )
 
@@ -382,11 +381,14 @@ func buildNodeDaemonSet(driver *seaweedv1.SeaweedCSIDriver, ds *appsv1.DaemonSet
 	pod.Tolerations = tolerateAll(driver.Spec.Node.Tolerations)
 	pod.ImagePullSecrets = driver.Spec.ImagePullSecrets
 	pod.Containers = []corev1.Container{plugin, registrar, liveness}
+	// Every kubelet-root subdirectory is DirectoryOrCreate: some distributions
+	// (notably k3s) do not pre-create plugins/plugins_registry, so requiring
+	// them to exist would force manual per-node setup before the driver works.
 	pod.Volumes = []corev1.Volume{
 		hostPathVolume("registration-dir", kube+"/plugins_registry", &hostPathDirectoryOrCreate),
 		hostPathVolume("plugin-dir", pluginDir, &hostPathDirectoryOrCreate),
-		hostPathVolume("plugins-dir", kube+"/plugins", &hostPathDirectory),
-		hostPathVolume("pods-mount-dir", kube+"/pods", &hostPathDirectory),
+		hostPathVolume("plugins-dir", kube+"/plugins", &hostPathDirectoryOrCreate),
+		hostPathVolume("pods-mount-dir", kube+"/pods", &hostPathDirectoryOrCreate),
 		hostPathVolume("device-dir", "/dev", nil),
 		{Name: "cache", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 		hostPathVolume("mount-socket-dir", mountSocketDir(driver), &hostPathDirectoryOrCreate),
@@ -428,9 +430,11 @@ func buildMountDaemonSet(driver *seaweedv1.SeaweedCSIDriver, ds *appsv1.DaemonSe
 	pod.Tolerations = tolerateAll(driver.Spec.MountService.Tolerations)
 	pod.ImagePullSecrets = driver.Spec.ImagePullSecrets
 	pod.Containers = []corev1.Container{mount}
+	// Match the node plugin: auto-create the shared kubelet-root bind mounts so
+	// the mount service also runs on distros that do not pre-create them.
 	pod.Volumes = []corev1.Volume{
-		hostPathVolume("plugins-dir", kube+"/plugins", &hostPathDirectory),
-		hostPathVolume("pods-mount-dir", kube+"/pods", &hostPathDirectory),
+		hostPathVolume("plugins-dir", kube+"/plugins", &hostPathDirectoryOrCreate),
+		hostPathVolume("pods-mount-dir", kube+"/pods", &hostPathDirectoryOrCreate),
 		hostPathVolume("device-dir", "/dev", nil),
 		{Name: "cache", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 		hostPathVolume("mount-socket-dir", mountSocketDir(driver), &hostPathDirectoryOrCreate),

--- a/internal/controller/seaweedcsidriver_objects_test.go
+++ b/internal/controller/seaweedcsidriver_objects_test.go
@@ -191,11 +191,12 @@ func TestBuildNodeDaemonSet(t *testing.T) {
 	assert.Equal(t, "/csi/csi.sock", envValue(t, reg.Env, "ADDRESS").Value, "registrar wants a path, not a unix:// url")
 	assert.Equal(t, "/var/lib/kubelet/plugins/seaweedfs-csi-driver/csi.sock", envValue(t, reg.Env, "DRIVER_REG_SOCK_PATH").Value)
 
-	// host-path volume types
-	assert.Equal(t, corev1.HostPathDirectoryOrCreate, *volumeByName(t, pod.Volumes, "registration-dir").HostPath.Type)
-	assert.Equal(t, corev1.HostPathDirectoryOrCreate, *volumeByName(t, pod.Volumes, "plugin-dir").HostPath.Type)
+	// Every kubelet-root host path auto-creates so the node plugin needs no
+	// manual per-node setup on distros (k3s) that omit plugins/plugins_registry.
+	for _, name := range []string{"registration-dir", "plugin-dir", "plugins-dir", "pods-mount-dir"} {
+		assert.Equal(t, corev1.HostPathDirectoryOrCreate, *volumeByName(t, pod.Volumes, name).HostPath.Type, name)
+	}
 	assert.Equal(t, "/var/lib/kubelet/plugins/seaweedfs-csi-driver", volumeByName(t, pod.Volumes, "plugin-dir").HostPath.Path)
-	assert.Equal(t, corev1.HostPathDirectory, *volumeByName(t, pod.Volumes, "plugins-dir").HostPath.Type)
 }
 
 func TestBuildNodeDaemonSetCustomKubeletPath(t *testing.T) {
@@ -254,6 +255,8 @@ func TestBuildMountDaemonSet(t *testing.T) {
 		m := mountByName(t, mountC.VolumeMounts, name)
 		require.NotNil(t, m.MountPropagation, name)
 		assert.Equal(t, corev1.MountPropagationBidirectional, *m.MountPropagation, name)
+		// shared kubelet-root bind mounts auto-create, matching the node plugin
+		assert.Equal(t, corev1.HostPathDirectoryOrCreate, *volumeByName(t, pod.Volumes, name).HostPath.Type, name)
 	}
 }
 


### PR DESCRIPTION
## Problem

Fixes #316.

On k3s (and some other distributions) `/var/lib/kubelet/plugins_registry` and `/var/lib/kubelet/plugins` are **not** pre-created by the kubelet. The CSI node plugin mounted the shared kubelet directories with `HostPathDirectory`, which requires the path to already exist. As a result the node plugin failed to register until an operator manually created `plugins_registry` on **every** node — exactly what the reporter had to do after migrating to the CSI plugin on `k3s v1.35.5+k3s1`.

## Fix

Switch every kubelet-root host path in the node and mount DaemonSets to `HostPathDirectoryOrCreate`, so the driver provisions the directory layout it needs with zero manual per-node setup on any distribution:

| volume | path | before | after |
|--------|------|--------|-------|
| `registration-dir` | `<kubelet>/plugins_registry` | DirectoryOrCreate | DirectoryOrCreate |
| `plugin-dir` | `<kubelet>/plugins/<driver>` | DirectoryOrCreate | DirectoryOrCreate |
| `plugins-dir` | `<kubelet>/plugins` | **Directory** | **DirectoryOrCreate** |
| `pods-mount-dir` | `<kubelet>/pods` | **Directory** | **DirectoryOrCreate** |

`registration-dir` was already `DirectoryOrCreate`, but the node plugin still could not start because `plugins-dir` blocked the pod from mounting on a fresh node. `DirectoryOrCreate` is a no-op when the directory already exists, so this is safe on distributions that do pre-create these paths.

## Docs correction

The `KubeletPath` guidance previously told k3s users to set `/var/lib/rancher/k3s/agent/kubelet`. Modern k3s keeps the standard `/var/lib/kubelet` root — older releases nested it under the data dir but [moved back because CSI plugins expect the default path](https://github.com/k3s-io/k3s/discussions/3802). Following the old hint would actually break current k3s, so the field doc comment and the sample now point k3s users at the default and keep the relocate hints only for MicroK8s and k0s, which genuinely move the root.

## Testing

- `go build ./...`, `go vet`, and `go test ./internal/controller/` all pass.
- Unit tests updated: `TestBuildNodeDaemonSet` and `TestBuildMountDaemonSet` now assert every kubelet-root host path is `DirectoryOrCreate`.
- No CRD regeneration needed — CRDs are generated with `crd:maxDescLen=0`, so the doc-comment change does not alter generated manifests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Kubernetes setups that don’t pre-create kubelet-related directories, including modern k3s installs.
  * Node and mount components now automatically create required subdirectories when needed, reducing setup failures.
  * Updated documentation and samples to clarify which environments may need a custom kubelet path and what the default behavior is.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->