### PR TITLE
Let a Bucket CR adopt a pre-existing bucket via spec.adoptExisting

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,8 +501,14 @@ Supported per-bucket configuration:
 - `reclaimPolicy`: `Retain` (default) leaves data untouched on CR
   delete; `Delete` removes the bucket on CR delete (refused while
   Object Lock retention applies). `Delete` only removes a bucket this
-  CR actually created — a CR whose adoption was refused
+  CR actually created or adopted — a CR whose adoption was refused
   (`BucketAlreadyExists`) never deletes a bucket another resource owns.
+- `adoptExisting`: `false` (default) refuses a pre-existing bucket of
+  the same name (condition `BucketAlreadyExists`, phase `Failed`);
+  `true` adopts it and reconciles the spec onto it. This is the
+  recovery path when a CR deleted under `Retain` is reapplied — the
+  normal GitOps flow after an accidental deletion. Adoption confers
+  full ownership, including deletion under `reclaimPolicy: Delete`.
 - Cross-namespace `clusterRef` is **denied by default**: it resolves only
   when a [`ResourceReferenceGrant`](#cross-namespace-references-resourcereferencegrant)
   in the target `Seaweed`'s namespace permits it. The bucket stays
@@ -542,9 +548,9 @@ API. The two are complementary: COSI is the right choice when an
 application needs a bucket-claim lifecycle bound to a workload, while
 the `Bucket` CRD is the right choice for cluster- or platform-team-owned
 buckets with quotas, placement, and IAM grants. The controller never
-adopts or modifies a bucket created by the COSI driver — collisions are
-surfaced as `BucketAlreadyExists` in `status` rather than silently
-overwriting.
+adopts or modifies a bucket created by the COSI driver unless
+`adoptExisting: true` explicitly opts in — collisions are surfaced as
+`BucketAlreadyExists` in `status` rather than silently overwriting.
 
 #### Bucket lifecycle policies
 

--- a/api/v1/bucket_types.go
+++ b/api/v1/bucket_types.go
@@ -218,6 +218,19 @@ type BucketSpec struct {
 	// +kubebuilder:default:=Retain
 	ReclaimPolicy BucketReclaimPolicy `json:"reclaimPolicy,omitempty"`
 
+	// AdoptExisting lets this CR take ownership of a bucket that already
+	// exists on the cluster under the same name — typically one left
+	// behind by a previous Bucket CR deleted under reclaimPolicy: Retain.
+	// When false (the default) a pre-existing bucket is refused with a
+	// BucketAlreadyExists condition and the bucket is left untouched.
+	// Adoption confers full ownership: the spec is reconciled onto the
+	// existing bucket (owner, access, versioning, quota, placement) and
+	// reclaimPolicy: Delete will delete the bucket and its data when the
+	// CR is deleted.
+	// +optional
+	// +kubebuilder:default:=false
+	AdoptExisting bool `json:"adoptExisting,omitempty"`
+
 	// Versioning is the desired versioning state. Defaults to Off. Once
 	// Enabled or Suspended, a bucket cannot be returned to Off — use
 	// Suspended to halt new versions while keeping the version history.
@@ -328,7 +341,7 @@ const (
 	BucketConditionDeleteBlockedByRetention = "DeleteBlockedByRetention"
 	// BucketConditionBucketAlreadyExists is set when a bucket with the
 	// requested name already exists in the cluster and was not created by
-	// this operator. Adoption is deliberately not supported.
+	// this resource. Adoption is refused unless spec.adoptExisting opts in.
 	BucketConditionBucketAlreadyExists = "BucketAlreadyExists"
 	// BucketConditionOwnerMissing is set when the spec.owner identity
 	// does not exist in the IAM service. The controller retries.

--- a/config/crd/bases/seaweed.seaweedfs.com_buckets.yaml
+++ b/config/crd/bases/seaweed.seaweedfs.com_buckets.yaml
@@ -77,6 +77,9 @@ spec:
                 x-kubernetes-list-map-keys:
                 - user
                 x-kubernetes-list-type: map
+              adoptExisting:
+                default: false
+                type: boolean
               anonymousRead:
                 default: false
                 type: boolean

--- a/config/samples/seaweed_v1_bucket_full.yaml
+++ b/config/samples/seaweed_v1_bucket_full.yaml
@@ -8,6 +8,7 @@ spec:
     name: seaweed1
     namespace: default
   reclaimPolicy: Retain
+  adoptExisting: false
   versioning: Enabled
   objectLock: false
   quota:

--- a/deploy/helm/templates/crd-seaweed.yaml
+++ b/deploy/helm/templates/crd-seaweed.yaml
@@ -961,6 +961,9 @@ spec:
                   x-kubernetes-list-map-keys:
                     - user
                   x-kubernetes-list-type: map
+                adoptExisting:
+                  default: false
+                  type: boolean
                 anonymousRead:
                   default: false
                   type: boolean

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -226,15 +226,17 @@ func (r *BucketReconciler) reconcileBucket(ctx context.Context, bucket *seaweedv
 			return r.failPhase(ctx, bucket, seaweedv1.BucketPhaseFailed, "BucketAlreadyExists",
 				fmt.Sprintf("bucket %q already exists; set spec.adoptExisting: true to adopt it", bucketName))
 		}
-		log.Info("adopting existing bucket", "name", bucketName)
-		r.recordEvent(bucket, corev1.EventTypeNormal, "BucketAdopted",
-			fmt.Sprintf("adopted existing bucket %q on cluster %q", bucketName, bucket.Spec.ClusterRef.Name))
+		r.adoptBucket(log, bucket, bucketName)
 	}
 
 	if !exists {
 		switch err := admin.CreateBucket(ctx, bucketName, bucket.Spec.Owner, bucket.Spec.ObjectLock); {
 		case err == nil:
 			log.Info("created bucket", "name", bucketName, "owner", bucket.Spec.Owner, "withLock", bucket.Spec.ObjectLock)
+			// Claim ownership now, not at the end of the pass: if a later
+			// step fails, failPhase persists this claim, so the next pass
+			// doesn't mistake our own bucket for a foreign one.
+			bucket.Status.BucketName = bucketName
 		case errors.Is(err, ErrBucketAlreadyExists):
 			// Lost a race: another agent created the bucket between the
 			// exists check and create. Same ownership question as above,
@@ -244,9 +246,7 @@ func (r *BucketReconciler) reconcileBucket(ctx context.Context, bucket *seaweedv
 					fmt.Sprintf("bucket %q was created by another agent between exists check and create; set spec.adoptExisting: true to adopt it", bucketName))
 				return r.failPhase(ctx, bucket, seaweedv1.BucketPhaseFailed, "BucketAlreadyExists", err.Error())
 			}
-			log.Info("adopting existing bucket", "name", bucketName)
-			r.recordEvent(bucket, corev1.EventTypeNormal, "BucketAdopted",
-				fmt.Sprintf("adopted existing bucket %q on cluster %q", bucketName, bucket.Spec.ClusterRef.Name))
+			r.adoptBucket(log, bucket, bucketName)
 		default:
 			return r.failPhase(ctx, bucket, seaweedv1.BucketPhaseFailed, "CreateFailed", err.Error())
 		}
@@ -462,12 +462,25 @@ func (r *BucketReconciler) clearCondition(bucket *seaweedv1.Bucket, condType str
 	meta.RemoveStatusCondition(&bucket.Status.Conditions, condType)
 }
 
+// adoptBucket takes ownership of an existing bucket. Status.BucketName is
+// claimed immediately rather than at the end of the pass so that a failure
+// in a later step still persists ownership via failPhase — otherwise the
+// next pass would re-read our own bucket as foreign and, depending on
+// spec.adoptExisting, either strand at BucketAlreadyExists or emit a
+// duplicate BucketAdopted event.
+func (r *BucketReconciler) adoptBucket(log logr.Logger, bucket *seaweedv1.Bucket, bucketName string) {
+	log.Info("adopting existing bucket", "name", bucketName)
+	r.recordEvent(bucket, corev1.EventTypeNormal, "BucketAdopted",
+		fmt.Sprintf("adopted existing bucket %q on cluster %q", bucketName, bucket.Spec.ClusterRef.Name))
+	bucket.Status.BucketName = bucketName
+}
+
 // recordEvent emits an event when a Recorder is wired; tests leave it nil.
-func (r *BucketReconciler) recordEvent(bucket *seaweedv1.Bucket, eventtype, reason, message string) {
+func (r *BucketReconciler) recordEvent(bucket *seaweedv1.Bucket, eventType, reason, message string) {
 	if r.Recorder == nil {
 		return
 	}
-	r.Recorder.Event(bucket, eventtype, reason, message)
+	r.Recorder.Event(bucket, eventType, reason, message)
 }
 
 func closeBucketAdmin(admin BucketAdmin, log logr.Logger) {

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -213,28 +214,42 @@ func (r *BucketReconciler) reconcileBucket(ctx context.Context, bucket *seaweedv
 		return r.failPhase(ctx, bucket, seaweedv1.BucketPhaseFailed, "ExistsCheckFailed", err.Error())
 	}
 
-	// Detect adoption attempt: bucket exists on the filer but our status
-	// has never recorded its name. Refuse; users must remove the foreign
-	// bucket manually before this CR can own it.
+	// A bucket that exists on the filer while our status has never
+	// recorded a name is one this CR did not create — either a foreign
+	// bucket or one left behind by a previous CR deleted under Retain.
+	// Deny by default; spec.adoptExisting opts in to taking ownership.
 	if exists && bucket.Status.BucketName == "" {
-		r.setCondition(bucket, seaweedv1.BucketConditionBucketAlreadyExists, metav1.ConditionTrue, "AlreadyExists",
-			fmt.Sprintf("a bucket named %q already exists on cluster %q and was not created by this resource; adoption is not supported",
-				bucketName, bucket.Spec.ClusterRef.Name))
-		return r.failPhase(ctx, bucket, seaweedv1.BucketPhaseFailed, "BucketAlreadyExists",
-			fmt.Sprintf("bucket %q already exists; refusing to adopt", bucketName))
+		if !bucket.Spec.AdoptExisting {
+			r.setCondition(bucket, seaweedv1.BucketConditionBucketAlreadyExists, metav1.ConditionTrue, "AlreadyExists",
+				fmt.Sprintf("a bucket named %q already exists on cluster %q and was not created by this resource; set spec.adoptExisting: true to adopt it",
+					bucketName, bucket.Spec.ClusterRef.Name))
+			return r.failPhase(ctx, bucket, seaweedv1.BucketPhaseFailed, "BucketAlreadyExists",
+				fmt.Sprintf("bucket %q already exists; set spec.adoptExisting: true to adopt it", bucketName))
+		}
+		log.Info("adopting existing bucket", "name", bucketName)
+		r.recordEvent(bucket, corev1.EventTypeNormal, "BucketAdopted",
+			fmt.Sprintf("adopted existing bucket %q on cluster %q", bucketName, bucket.Spec.ClusterRef.Name))
 	}
 
 	if !exists {
-		if err := admin.CreateBucket(ctx, bucketName, bucket.Spec.Owner, bucket.Spec.ObjectLock); err != nil {
-			if errors.Is(err, ErrBucketAlreadyExists) {
-				// Lost a race; fall through and treat as adoption-refused.
+		switch err := admin.CreateBucket(ctx, bucketName, bucket.Spec.Owner, bucket.Spec.ObjectLock); {
+		case err == nil:
+			log.Info("created bucket", "name", bucketName, "owner", bucket.Spec.Owner, "withLock", bucket.Spec.ObjectLock)
+		case errors.Is(err, ErrBucketAlreadyExists):
+			// Lost a race: another agent created the bucket between the
+			// exists check and create. Same ownership question as above,
+			// same answer.
+			if !bucket.Spec.AdoptExisting {
 				r.setCondition(bucket, seaweedv1.BucketConditionBucketAlreadyExists, metav1.ConditionTrue, "AlreadyExists",
-					fmt.Sprintf("bucket %q was created by another agent between exists check and create", bucketName))
+					fmt.Sprintf("bucket %q was created by another agent between exists check and create; set spec.adoptExisting: true to adopt it", bucketName))
 				return r.failPhase(ctx, bucket, seaweedv1.BucketPhaseFailed, "BucketAlreadyExists", err.Error())
 			}
+			log.Info("adopting existing bucket", "name", bucketName)
+			r.recordEvent(bucket, corev1.EventTypeNormal, "BucketAdopted",
+				fmt.Sprintf("adopted existing bucket %q on cluster %q", bucketName, bucket.Spec.ClusterRef.Name))
+		default:
 			return r.failPhase(ctx, bucket, seaweedv1.BucketPhaseFailed, "CreateFailed", err.Error())
 		}
-		log.Info("created bucket", "name", bucketName, "owner", bucket.Spec.Owner, "withLock", bucket.Spec.ObjectLock)
 	}
 
 	// Object Lock: enable when requested and not already on. Versioning is
@@ -445,6 +460,14 @@ func (r *BucketReconciler) setCondition(bucket *seaweedv1.Bucket, condType strin
 
 func (r *BucketReconciler) clearCondition(bucket *seaweedv1.Bucket, condType string) {
 	meta.RemoveStatusCondition(&bucket.Status.Conditions, condType)
+}
+
+// recordEvent emits an event when a Recorder is wired; tests leave it nil.
+func (r *BucketReconciler) recordEvent(bucket *seaweedv1.Bucket, eventtype, reason, message string) {
+	if r.Recorder == nil {
+		return
+	}
+	r.Recorder.Event(bucket, eventtype, reason, message)
 }
 
 func closeBucketAdmin(admin BucketAdmin, log logr.Logger) {

--- a/internal/controller/bucket_controller_test.go
+++ b/internal/controller/bucket_controller_test.go
@@ -482,6 +482,154 @@ func TestReconcile_ExistingBucketRefusesAdoption(t *testing.T) {
 	}
 }
 
+// TestReconcile_RecreatedCRRefusesAdoptionByDefault reproduces the
+// delete-then-reapply dead-end: a Bucket CR is provisioned, deleted under
+// Retain (the bucket survives on the filer), and the same manifest is
+// reapplied. The fresh CR has an empty status, so the reconciler sees a
+// pre-existing bucket it did not create and refuses — Phase=Failed,
+// BucketAlreadyExists=True — even though the bucket was created by an
+// identical CR one lifecycle ago. The refusal stays the default; recovery
+// requires opting in via spec.adoptExisting.
+func TestReconcile_RecreatedCRRefusesAdoptionByDefault(t *testing.T) {
+	bucket := newTestBucket("project1")
+	fa := newFakeAdmin()
+	r, cli := testReconciler(t, fa, newTestSeaweed(), bucket)
+	key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
+
+	// First life: provision to Ready.
+	reconcileUntilStable(t, r, key, 5)
+	got := &seaweedv1.Bucket{}
+	if err := cli.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	if got.Status.Phase != seaweedv1.BucketPhaseReady {
+		t.Fatalf("precondition: phase=%q want Ready", got.Status.Phase)
+	}
+
+	// Delete the CR. Retain leaves the bucket on the filer; the reconcile
+	// pass under deletion drops the finalizer and the fake client reaps.
+	if err := cli.Delete(context.Background(), got); err != nil {
+		t.Fatalf("delete bucket CR: %v", err)
+	}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("deletion reconcile: %v", err)
+	}
+	if err := cli.Get(context.Background(), key, &seaweedv1.Bucket{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected CR gone after deletion reconcile, got err=%v", err)
+	}
+	if !fa.existsResp["project1"] {
+		t.Fatal("precondition: bucket must survive CR deletion under Retain")
+	}
+
+	// Second life: reapply the same manifest. Status starts empty, so the
+	// existence check reads as a foreign bucket.
+	if err := cli.Create(context.Background(), newTestBucket("project1")); err != nil {
+		t.Fatalf("recreate bucket CR: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key}); err != nil {
+			t.Fatalf("reconcile after recreate: %v", err)
+		}
+	}
+
+	got = &seaweedv1.Bucket{}
+	if err := cli.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("get recreated bucket: %v", err)
+	}
+	if got.Status.Phase != seaweedv1.BucketPhaseFailed {
+		t.Fatalf("phase=%q want Failed", got.Status.Phase)
+	}
+	cond := meta.FindStatusCondition(got.Status.Conditions, seaweedv1.BucketConditionBucketAlreadyExists)
+	if cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Fatalf("expected BucketAlreadyExists=True, got %+v", cond)
+	}
+}
+
+// TestReconcile_RecreatedCRAdoptExistingRecovers is the recovery path for
+// the same lifecycle: with spec.adoptExisting: true the reapplied CR takes
+// ownership of the surviving bucket instead of failing — no Create call,
+// spec reconciled onto the existing bucket, Ready with BucketName recorded.
+func TestReconcile_RecreatedCRAdoptExistingRecovers(t *testing.T) {
+	bucket := newTestBucket("project1")
+	fa := newFakeAdmin()
+	r, cli := testReconciler(t, fa, newTestSeaweed(), bucket)
+	key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
+
+	reconcileUntilStable(t, r, key, 5)
+	got := &seaweedv1.Bucket{}
+	if err := cli.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	if err := cli.Delete(context.Background(), got); err != nil {
+		t.Fatalf("delete bucket CR: %v", err)
+	}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("deletion reconcile: %v", err)
+	}
+	if !fa.existsResp["project1"] {
+		t.Fatal("precondition: bucket must survive CR deletion under Retain")
+	}
+
+	recreated := newTestBucket("project1")
+	recreated.Spec.AdoptExisting = true
+	recreated.Spec.Owner = "media-team"
+	if err := cli.Create(context.Background(), recreated); err != nil {
+		t.Fatalf("recreate bucket CR: %v", err)
+	}
+	createsBefore := countCalls(fa.calls, "Create:project1")
+	reconcileUntilStable(t, r, key, 5)
+
+	got = &seaweedv1.Bucket{}
+	if err := cli.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("get recreated bucket: %v", err)
+	}
+	if got.Status.Phase != seaweedv1.BucketPhaseReady {
+		t.Fatalf("phase=%q want Ready; conditions=%+v", got.Status.Phase, got.Status.Conditions)
+	}
+	if got.Status.BucketName != "project1" {
+		t.Errorf("status.bucketName=%q want project1", got.Status.BucketName)
+	}
+	if meta.FindStatusCondition(got.Status.Conditions, seaweedv1.BucketConditionBucketAlreadyExists) != nil {
+		t.Errorf("BucketAlreadyExists condition must be absent after adoption")
+	}
+	// Adoption must not recreate the bucket, but must still reconcile spec.
+	if n := countCalls(fa.calls, "Create:project1"); n != createsBefore {
+		t.Errorf("adoption must not call Create; calls %d -> %d", createsBefore, n)
+	}
+	if n := countCalls(fa.calls, "Owner:project1:media-team"); n == 0 {
+		t.Errorf("expected spec reconciled onto adopted bucket; calls:\n%s", strings.Join(fa.calls, "\n"))
+	}
+}
+
+// TestReconcile_AdoptExistingCreateRaceAdopts covers the narrow window where
+// another agent creates the bucket between the exists check and create: with
+// adoptExisting the race resolves to adoption instead of Failed.
+func TestReconcile_AdoptExistingCreateRaceAdopts(t *testing.T) {
+	bucket := newTestBucket("photos")
+	bucket.Spec.AdoptExisting = true
+	bucket.Finalizers = []string{BucketFinalizer}
+
+	fa := newFakeAdmin()
+	fa.createErr = ErrBucketAlreadyExists // exists check says no, create says yes
+	r, cli := testReconciler(t, fa, newTestSeaweed(), bucket)
+	key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	got := &seaweedv1.Bucket{}
+	if err := cli.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	if got.Status.Phase != seaweedv1.BucketPhaseReady {
+		t.Fatalf("phase=%q want Ready; conditions=%+v", got.Status.Phase, got.Status.Conditions)
+	}
+	if got.Status.BucketName != "photos" {
+		t.Errorf("status.bucketName=%q want photos", got.Status.BucketName)
+	}
+}
+
 // TestReconcile_ReadyBucketRequeuesForDrift pins the periodic resync: a
 // Ready bucket must request a RequeueAfter equal to ResyncInterval so the
 // reconciler keeps re-verifying external state it cannot watch.

--- a/internal/controller/bucket_controller_test.go
+++ b/internal/controller/bucket_controller_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"strings"
 	"testing"
@@ -627,6 +628,88 @@ func TestReconcile_AdoptExistingCreateRaceAdopts(t *testing.T) {
 	}
 	if got.Status.BucketName != "photos" {
 		t.Errorf("status.bucketName=%q want photos", got.Status.BucketName)
+	}
+}
+
+// TestReconcile_TransientFailureAfterCreateKeepsOwnership pins the ordering
+// of the ownership claim: CreateBucket succeeds, a later step fails, and the
+// persisted failure status must already record BucketName — otherwise the
+// next pass reads the bucket this CR just created as foreign and strands at
+// BucketAlreadyExists.
+func TestReconcile_TransientFailureAfterCreateKeepsOwnership(t *testing.T) {
+	bucket := newTestBucket("photos")
+	bucket.Spec.Versioning = seaweedv1.VersioningEnabled
+	bucket.Finalizers = []string{BucketFinalizer}
+
+	fa := newFakeAdmin()
+	fa.versioningErr = errors.New("transient filer error")
+	r, cli := testReconciler(t, fa, newTestSeaweed(), bucket)
+	key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := &seaweedv1.Bucket{}
+	if err := cli.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	if got.Status.Phase != seaweedv1.BucketPhaseFailed {
+		t.Fatalf("precondition: phase=%q want Failed", got.Status.Phase)
+	}
+	if got.Status.BucketName != "photos" {
+		t.Fatalf("status.bucketName=%q want photos persisted with the failure", got.Status.BucketName)
+	}
+
+	// The hiccup clears; the retry must converge to Ready instead of
+	// refusing its own bucket.
+	fa.versioningErr = nil
+	reconcileUntilStable(t, r, key, 5)
+	got = &seaweedv1.Bucket{}
+	if err := cli.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	if got.Status.Phase != seaweedv1.BucketPhaseReady {
+		t.Fatalf("phase=%q want Ready; conditions=%+v", got.Status.Phase, got.Status.Conditions)
+	}
+	if meta.FindStatusCondition(got.Status.Conditions, seaweedv1.BucketConditionBucketAlreadyExists) != nil {
+		t.Errorf("BucketAlreadyExists must not be set for a bucket this CR created")
+	}
+}
+
+// TestReconcile_TransientFailureAfterAdoptionKeepsOwnership is the same
+// guarantee on the adoption path: once adopted, a transient failure must not
+// leave the CR re-adopting (or re-announcing) the bucket on every retry.
+func TestReconcile_TransientFailureAfterAdoptionKeepsOwnership(t *testing.T) {
+	bucket := newTestBucket("photos")
+	bucket.Spec.AdoptExisting = true
+	bucket.Spec.Versioning = seaweedv1.VersioningEnabled
+	bucket.Finalizers = []string{BucketFinalizer}
+
+	fa := newFakeAdmin()
+	fa.existsResp["photos"] = true
+	fa.versioningErr = errors.New("transient filer error")
+	r, cli := testReconciler(t, fa, newTestSeaweed(), bucket)
+	key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := &seaweedv1.Bucket{}
+	if err := cli.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	if got.Status.BucketName != "photos" {
+		t.Fatalf("status.bucketName=%q want photos persisted with the failure", got.Status.BucketName)
+	}
+
+	fa.versioningErr = nil
+	reconcileUntilStable(t, r, key, 5)
+	got = &seaweedv1.Bucket{}
+	if err := cli.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	if got.Status.Phase != seaweedv1.BucketPhaseReady {
+		t.Fatalf("phase=%q want Ready; conditions=%+v", got.Status.Phase, got.Status.Conditions)
 	}
 }
 


### PR DESCRIPTION
Fixes #318

## Problem

Deleting a Bucket CR under `reclaimPolicy: Retain` intentionally leaves the bucket on the filer, but reapplying the same manifest failed permanently:

```
Type:    Ready
Status:  False
Reason:  BucketAlreadyExists
Phase:   Failed
```

The fresh CR starts with an empty `status.bucketName`, so the reconciler treated the bucket its own previous incarnation created as foreign and refused to adopt it. That made CR deletion effectively irreversible without out-of-band intervention — painful in GitOps flows (Argo CD) where reapplying the manifest is the normal recovery path.

Reproduced in `TestReconcile_RecreatedCRRefusesAdoptionByDefault`, which walks the exact lifecycle from the report: provision → delete CR (bucket survives) → reapply → `Phase=Failed`, `BucketAlreadyExists=True`.

## Fix

New opt-in field, mirroring the adoption-policy pattern established by ACK and the acquire semantics of Config Connector / Azure Service Operator, while keeping this operator's deny-by-default:

```yaml
spec:
  adoptExisting: true
```

- **Default unchanged**: a pre-existing bucket is still refused, but the condition message now names the remediation (`set spec.adoptExisting: true to adopt it`) instead of `adoption is not supported`.
- **With the opt-in**: the reconciler takes ownership of the existing bucket, reconciles the spec onto it (owner, access, versioning, quota, placement), records `status.bucketName`, and emits a `BucketAdopted` event. Adoption confers full ownership, including deletion under `reclaimPolicy: Delete`.
- The create race (bucket appears between the exists check and `s3.bucket.create`) resolves the same way: refuse by default, adopt with the opt-in.

## Testing

- `TestReconcile_RecreatedCRRefusesAdoptionByDefault` — reproduces the reported dead-end and pins the safe default.
- `TestReconcile_RecreatedCRAdoptExistingRecovers` — same lifecycle with the opt-in: Ready, no `Create` call, spec reconciled onto the adopted bucket.
- `TestReconcile_AdoptExistingCreateRaceAdopts` — race window resolves to adoption.
- Full controller suite passes under envtest (real apiserver with the regenerated CRD).

CRD manifests and the Helm CRD bundle regenerated; README and the full sample updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `adoptExisting` setting for bucket reconciliation (off by default).
  * When enabled, existing buckets can be adopted (including create-race scenarios) and emits a `BucketAdopted` event.

* **Bug Fixes**
  * Adoption/modification of pre-existing buckets is now strictly gated by `adoptExisting`.
  * Improved handling for coexistence and collisions by reporting `BucketAlreadyExists` instead of unintended behavior.
  * Retry behavior now preserves bucket ownership/state to converge to `Ready`.

* **Documentation**
  * Clarified bucket deletion/adoption semantics and coexistence rules.

* **Tests**
  * Added coverage for adoption, collision outcomes, and transient failure retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->