### PR TITLE
Release 1.0.33 to ship spec.adoptExisting bucket adoption (#320)

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: seaweedfs-operator
 description: A Helm chart for the seaweedfs-operator
 type: application
-version: 0.1.35
-appVersion: "1.0.32"
+version: 0.1.36
+appVersion: "1.0.33"
 maintainers:
   - name: chrislusf
     url: https://github.com/chrislusf


### PR DESCRIPTION
## Summary

Fixes #320.

The `spec.adoptExisting` bucket-adoption path landed in #319 but **was never released**. The newest released operator image is `1.0.32`, which predates the feature: its reconciler hard-refuses any pre-existing bucket with `BucketAlreadyExists` ("adoption is not supported" / "refusing to adopt") regardless of the flag. That is exactly the behavior reported in #320 — the messages quoted in the issue are the 1.0.32 strings, not the ones in `master`.

This PR cuts the release that ships the fix:
- `appVersion` `1.0.32` → `1.0.33` (operator image containing the adoption logic)
- chart `version` `0.1.35` → `0.1.36`

The Helm chart's operator image tag defaults to `appVersion`, so bumping it releases the operator binary that carries the adoption logic **together with** the CRD that carries the `spec.adoptExisting` field — closing the version skew the reporter hit.

## Why this is the fix

The reporter's cluster had a CRD that knows `adoptExisting` (the field shows in `kubectl describe` and re-apply persists `true`) but an operator **binary** at `1.0.32` that does not read it. On `master`:

- `internal/controller/bucket_controller.go` branches on `bucket.Spec.AdoptExisting`: when a bucket exists and the CR never recorded ownership, `adoptExisting: true` calls `adoptBucket` (claims `status.bucketName`, emits `BucketAdopted`) and reconciles the spec onto the existing bucket; `false` refuses with `BucketAlreadyExists`.
- `api/v1/bucket_types.go` defines the field and the generated CRDs (`config/crd/bases/...` and `deploy/helm/templates/crd-seaweed.yaml`) include it.

No code change is required — the logic is present, tested, and passing (`TestReconcile_RecreatedCRAdoptExistingRecovers`, `TestReconcile_AdoptExistingCreateRaceAdopts`, `TestReconcile_TransientFailureAfterAdoptionKeepsOwnership`, and the refusal-by-default cases). It just needs to ship.

## Note on the "false on first apply, true on second apply" symptom

That is the API server briefly serving a stale OpenAPI/pruning schema immediately after the CRD gains a new field: the first apply prunes the unknown field, the second (after the schema cache refreshes) keeps it. It is self-healing and not something the operator binary can change. Installing the 1.0.33 chart applies the CRD and the matching operator together, so a fresh install won't exhibit the skew.

## Test plan
- `go build ./...` — clean
- `go test ./internal/controller/ -run TestReconcile` — pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application release metadata to version 1.0.33.
  * Updated the deployment package version to 0.1.36.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->