### PR TITLE
Add support for cert-manager in helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,9 @@ test-e2e:
 # rendered YAML) by also catching helm-template syntax bugs, missing
 # CRD includes, broken ServiceAccount bindings, and conditional gates
 # the static test isn't aware of — failure modes invisible to the
-# kustomize-based test-e2e suite, which never deploys the chart.
+# kustomize-based test-e2e suite, which never deploys the chart. A
+# second lap upgrades to webhook.certManager.enabled=true to cover the
+# cert-manager certificate path.
 .PHONY: test-helm-install
 test-helm-install: kind-prepare kind-load
 	IMAGE_TAG=$(VERSION) test/helm/install_smoke.sh

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -1,6 +1,6 @@
 # seaweedfs-operator
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.4](https://img.shields.io/badge/AppVersion-1.0.4-informational?style=flat-square)
+![Version: 0.1.35](https://img.shields.io/badge/Version-0.1.35-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.32](https://img.shields.io/badge/AppVersion-1.0.32-informational?style=flat-square)
 
 A Helm chart for the seaweedfs-operator
 
@@ -12,38 +12,55 @@ A Helm chart for the seaweedfs-operator
 
 ## Values
 
-| Key                             | Type   | Default                         | Description                                                                                                                                                                                                          |
-|---------------------------------|--------|---------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| commonAnnotations               | object | `{}`                            | Annotations for all the deployed objects                                                                                                                                                                             |
-| commonLabels                    | object | `{}`                            | Labels for all the deployed objects                                                                                                                                                                                  |
-| fullnameOverride                | string | `""`                            | String to fully override common.names.fullname template                                                                                                                                                              |
-| global                          | object | `{"imageRegistry":""}`          | Global Docker image parameters. global.imageRegistry, when set, overrides the registry of every image in the chart; leave empty to use each image's own. |
-| grafanaDashboard.enabled        | bool   | `true`                          | Enable or disable Grafana Dashboard configmap                                                                                                                                                                        |
-| image.pullPolicy                | string | `"Always"`                      | Specify a imagePullPolicy # Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent' # ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images                                         |
-| image.registry                  | string | `"chrislusf"`                   |                                                                                                                                                                                                                      |
-| image.repository                | string | `"seaweedfs-operator"`          |                                                                                                                                                                                                                      |
-| image.tag                       | string | `""`                            | tag of image to use. Defaults to appVersion in Chart.yaml                                                                                                                                                            |
-| nameOverride                    | string | `""`                            | String to partially override common.names.fullname template (will maintain the release name)                                                                                                                         |
-| port.name                       | string | `"http"`                        | name of the container port to use for the Kubernete service and ingress                                                                                                                                              |
-| port.number                     | int    | `8080`                          | container port number to use for the Kubernete service and ingress                                                                                                                                                   |
-| rbac.serviceAccount.annotations | object | `{}`                            | Annotations to add to the service account                                                                                                                                                                            |
-| rbac.serviceAccount.automount   | bool   | `true`                          | Automount service account token for the server service account                                                                                                                                                       |
-| rbac.serviceAccount.create      | bool   | `true`                          | Specifies whether a service account should be created                                                                                                                                                                |
-| rbac.serviceAccount.name        | string | `""`                            | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. If set to "default", no ServiceAccount will be created and the default one will be used |
-| replicaCount                    | int    | `1`                             | Set number of pod replicas                                                                                                                                                                                           |
-| resources.limits.cpu            | string | `"500m"`                        | seaweedfs-operator containers' cpu limit (maximum allowed CPU)                                                                                                                                                       |
-| resources.limits.memory         | string | `"500Mi"`                       | seaweedfs-operator containers' memory limit (maximum allowed memory)                                                                                                                                                 |
-| resources.requests.cpu          | string | `"100m"`                        | seaweedfs-operator containers' cpu request (how much is requested by default)                                                                                                                                        |
-| resources.requests.memory       | string | `"50Mi"`                        | seaweedfs-operator containers' memory request (how much is requested by default)                                                                                                                                     |
-| service.port                    | int    | `8080`                          | port to use for Kubernetes service                                                                                                                                                                                   |
-| service.portName                | string | `"http"`                        | name of the port to use for Kubernetes service                                                                                                                                                                       |
-| serviceMonitor.additionalLabels | object | `{}`                            | Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with                                                                                                |
-| serviceMonitor.enabled          | bool   | `false`                         | Enable or disable ServiceMonitor for prometheus metrics                                                                                                                                                              |
-| serviceMonitor.honorLabels      | bool   | `true`                          | Specify honorLabels parameter to add the scrape endpoint                                                                                                                                                             |
-| serviceMonitor.interval         | string | `"10s"`                         | Specify the interval at which metrics should be scraped                                                                                                                                                              |
-| serviceMonitor.scrapeTimeout    | string | `"10s"`                         | Specify the timeout after which the scrape is ended                                                                                                                                                                  |
-| webhook.enabled                 | bool   | `true`                          | Enable or disable webhooks                                                                                                                                                                                           |
-| webhook.initContainer.image     | string | `"curlimages/curl:8.8.0"`       | Image used by the webhook readiness init container when patching certificates                                                                                                                                        |
-
-----------------------------------------------
-Autogenerated from chart metadata using [helm-docs v1.11.3](https://github.com/norwoodj/helm-docs/releases/v1.11.3)
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| bucketUsage | object | `{"refreshInterval":""}` | Bucket usage stats refresh configuration. The operator periodically calls collection.list per Seaweed cluster and patches status.usage on each Bucket. Leave refreshInterval empty to use the in-binary default (5m). Set to "0s" to disable the loop entirely. |
+| commonAnnotations | object | `{}` | Annotations for all the deployed objects |
+| commonLabels | object | `{}` | Labels for all the deployed objects |
+| crds.create | bool | `true` | Install the Seaweed CRD as part of the release. Set to false when the CRD is managed out-of-band (e.g., cluster-scoped GitOps or a shared CRD across namespaces) so `helm install/upgrade` won't try to create or adopt it. |
+| fullnameOverride | string | `""` | String to fully override common.names.fullname template |
+| global | object | `{"imageRegistry":""}` | Global Docker image parameters. global.imageRegistry, when set, overrides the registry of every image in the chart; leave empty to use each image's own. |
+| grafanaDashboard.enabled | bool | `true` | Enable or disable Grafana Dashboard configmap |
+| image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy # Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent' # ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images |
+| image.registry | string | `"chrislusf"` |  |
+| image.repository | string | `"seaweedfs-operator"` |  |
+| image.tag | string | `""` | tag of image to use. Defaults to appVersion in Chart.yaml |
+| nameOverride | string | `""` | String to partially override common.names.fullname template (will maintain the release name) |
+| nodeSelector | object | `{}` |  |
+| podSecurityContext.fsGroup | int | `65532` |  |
+| podSecurityContext.runAsNonRoot | bool | `true` |  |
+| podSecurityContext.runAsUser | int | `65532` |  |
+| port.name | string | `"http"` | name of the container port to use for the Kubernete service and ingress |
+| port.number | int | `8080` | container port number to use for the Kubernete service and ingress |
+| rbac.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| rbac.serviceAccount.automount | bool | `true` | Automount service account token for the server service account |
+| rbac.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| rbac.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template If set to "default", no ServiceAccount will be created and the default one will be used |
+| replicaCount | int | `1` | Set number of pod replicas |
+| resources.limits.cpu | string | `"500m"` | seaweedfs-operator containers' cpu limit (maximum allowed CPU) |
+| resources.limits.memory | string | `"500Mi"` | seaweedfs-operator containers' memory limit (maximum allowed memory) |
+| resources.requests.cpu | string | `"100m"` | seaweedfs-operator containers' cpu request (how much is requested by default) |
+| resources.requests.memory | string | `"50Mi"` | seaweedfs-operator containers' memory request (how much is requested by default) |
+| securityContext.allowPrivilegeEscalation | bool | `false` |  |
+| securityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| securityContext.readOnlyRootFilesystem | bool | `true` |  |
+| securityContext.runAsNonRoot | bool | `true` |  |
+| service.port | int | `8080` | port to use for Kubernetes service |
+| service.portName | string | `"http"` | name of the port to use for Kubernetes service |
+| serviceMonitor.additionalLabels | object | `{}` | Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with |
+| serviceMonitor.enabled | bool | `false` | Enable or disable ServiceMonitor for prometheus metrics |
+| serviceMonitor.honorLabels | bool | `true` | Specify honorLabels parameter to add the scrape endpoint |
+| serviceMonitor.interval | string | `"10s"` | Specify the interval at which metrics should be scraped |
+| serviceMonitor.scrapeTimeout | string | `"10s"` | Specify the timeout after which the scrape is ended |
+| tolerations | list | `[]` |  |
+| webhook.certManager.enabled | bool | `false` | Use cert-manager to provision the webhook TLS certificate instead of the built-in certgen Jobs. Requires cert-manager to be installed in the cluster. When enabled the certgen Jobs and their RBAC are not created. |
+| webhook.certManager.issuerRef | object | `{}` | Point the webhook serving Certificate at an existing Issuer or ClusterIssuer instead of the self-signed Issuer created by default. The issuer must populate ca.crt in the issued secret so cert-manager can inject the CA into the webhook configurations; CA, Vault, and self-signed issuers do, ACME issuers such as Let's Encrypt do not. |
+| webhook.certgen.registry | string | `"registry.k8s.io"` |  |
+| webhook.certgen.repository | string | `"ingress-nginx/kube-webhook-certgen"` |  |
+| webhook.certgen.tag | string | `"v20231011-8b53cabe0"` |  |
+| webhook.enabled | bool | `true` | Enable or disable webhooks |
+| webhook.initContainer | object | `{"image":"curlimages/curl:8.8.0"}` | Configuration for webhook certificate jobs |
+| webhook.initContainer.image | string | `"curlimages/curl:8.8.0"` | Image for webhook readiness check init container |
+| webhook.podSecurityContext | object | `{"fsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod security context for webhook jobs ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
+| webhook.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | Container security context for webhook jobs |

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -177,3 +177,18 @@ Validating webhook configuration name
 {{- $suffix := "-validating-webhook-configuration" -}}
 {{- printf "%s%s" (include "seaweedfs-operator.fullname" . | trunc (int (sub 63 (len $suffix))) | trimSuffix "-") $suffix -}}
 {{- end -}}
+
+{{/*
+cert-manager resource names
+*/}}
+{{- define "seaweedfs-operator.webhookIssuerName" -}}
+{{- printf "%s-webhook-selfsigned-issuer" (include "seaweedfs-operator.fullname" .) -}}
+{{- end -}}
+
+{{- define "seaweedfs-operator.webhookCertificateName" -}}
+{{- printf "%s-webhook-cert" (include "seaweedfs-operator.fullname" .) -}}
+{{- end -}}
+
+{{- define "seaweedfs-operator.webhookCertificateSecretName" -}}
+{{- printf "%s-webhook-server-cert" (include "seaweedfs-operator.fullname" .) -}}
+{{- end -}}

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -81,10 +81,17 @@ spec:
       - name: cert
         secret:
           defaultMode: 420
-          secretName: {{ include "seaweedfs-operator.fullname" . }}-webhook-server-cert
+          secretName: {{ include "seaweedfs-operator.webhookCertificateSecretName" . }}
           items:
+          {{- if .Values.webhook.certManager.enabled }}
+          - key: tls.crt
+            path: tls.crt
+          - key: tls.key
+            path: tls.key
+          {{- else }}
           - key: cert
             path: tls.crt
           - key: key
             path: tls.key
+          {{- end }}
       {{- end }}

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -77,13 +77,14 @@ spec:
         {{- end }}
       terminationGracePeriodSeconds: 10
       {{- if .Values.webhook.enabled }}
+      {{- $certManager := default dict .Values.webhook.certManager }}
       volumes:
       - name: cert
         secret:
           defaultMode: 420
           secretName: {{ include "seaweedfs-operator.webhookCertificateSecretName" . }}
           items:
-          {{- if .Values.webhook.certManager.enabled }}
+          {{- if $certManager.enabled }}
           - key: tls.crt
             path: tls.crt
           - key: tls.key

--- a/deploy/helm/templates/webhook/certificate.yaml
+++ b/deploy/helm/templates/webhook/certificate.yaml
@@ -1,0 +1,41 @@
+{{- if and .Values.webhook.enabled .Values.webhook.certManager.enabled -}}
+---
+{{- if not .Values.webhook.certManager.issuerRef }}
+# Self-signed Issuer — signs the webhook serving certificate directly.
+# Created automatically when no issuerRef is provided.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "seaweedfs-operator.webhookIssuerName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "seaweedfs-operator.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+---
+{{- end }}
+# Serving Certificate — mounted by the operator pod for TLS on the webhook endpoint.
+# cert-manager injects the CA bundle into the webhook configurations via the
+# cert-manager.io/inject-ca-from annotation on those resources.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "seaweedfs-operator.webhookCertificateName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "seaweedfs-operator.labels" . | nindent 4 }}
+spec:
+  dnsNames:
+    - {{ include "seaweedfs-operator.fullname" . }}-webhook
+    - {{ include "seaweedfs-operator.fullname" . }}-webhook.{{ .Release.Namespace }}.svc
+    - {{ include "seaweedfs-operator.fullname" . }}-webhook.{{ .Release.Namespace }}.svc.cluster.local
+  secretName: {{ include "seaweedfs-operator.webhookCertificateSecretName" . }}
+  issuerRef:
+    {{- if .Values.webhook.certManager.issuerRef }}
+    {{- toYaml .Values.webhook.certManager.issuerRef | nindent 4 }}
+    {{- else }}
+    name: {{ include "seaweedfs-operator.webhookIssuerName" . }}
+    kind: Issuer
+    group: cert-manager.io
+    {{- end }}
+{{- end -}}

--- a/deploy/helm/templates/webhook/certificate.yaml
+++ b/deploy/helm/templates/webhook/certificate.yaml
@@ -1,6 +1,7 @@
-{{- if and .Values.webhook.enabled .Values.webhook.certManager.enabled -}}
+{{- $certManager := default dict .Values.webhook.certManager -}}
+{{- if and .Values.webhook.enabled $certManager.enabled -}}
 ---
-{{- if not .Values.webhook.certManager.issuerRef }}
+{{- if not $certManager.issuerRef }}
 # Self-signed Issuer — signs the webhook serving certificate directly.
 # Created automatically when no issuerRef is provided.
 apiVersion: cert-manager.io/v1
@@ -31,8 +32,8 @@ spec:
     - {{ include "seaweedfs-operator.fullname" . }}-webhook.{{ .Release.Namespace }}.svc.cluster.local
   secretName: {{ include "seaweedfs-operator.webhookCertificateSecretName" . }}
   issuerRef:
-    {{- if .Values.webhook.certManager.issuerRef }}
-    {{- toYaml .Values.webhook.certManager.issuerRef | nindent 4 }}
+    {{- if $certManager.issuerRef }}
+    {{- toYaml $certManager.issuerRef | nindent 4 }}
     {{- else }}
     name: {{ include "seaweedfs-operator.webhookIssuerName" . }}
     kind: Issuer

--- a/deploy/helm/templates/webhook/job-update-webhook-certificates.yaml
+++ b/deploy/helm/templates/webhook/job-update-webhook-certificates.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.webhook.enabled -}}
+{{- if and .Values.webhook.enabled (not .Values.webhook.certManager.enabled) -}}
 ---
 apiVersion: batch/v1
 kind: Job

--- a/deploy/helm/templates/webhook/job-update-webhook-certificates.yaml
+++ b/deploy/helm/templates/webhook/job-update-webhook-certificates.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.webhook.enabled (not .Values.webhook.certManager.enabled) -}}
+{{- $certManager := default dict .Values.webhook.certManager -}}
+{{- if and .Values.webhook.enabled (not $certManager.enabled) -}}
 ---
 apiVersion: batch/v1
 kind: Job

--- a/deploy/helm/templates/webhook/mutating-webhook.yaml
+++ b/deploy/helm/templates/webhook/mutating-webhook.yaml
@@ -7,6 +7,10 @@ metadata:
   name: {{ include "seaweedfs-operator.mutatingWebhookName" . }}
   labels:
     {{- include "seaweedfs-operator.labels" . | nindent 4 }}
+  {{- if .Values.webhook.certManager.enabled }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "seaweedfs-operator.webhookCertificateName" . }}
+  {{- end }}
 webhooks:
 - clientConfig:
     service:

--- a/deploy/helm/templates/webhook/mutating-webhook.yaml
+++ b/deploy/helm/templates/webhook/mutating-webhook.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.webhook.enabled }}
+{{- $certManager := default dict .Values.webhook.certManager }}
 
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -7,7 +8,7 @@ metadata:
   name: {{ include "seaweedfs-operator.mutatingWebhookName" . }}
   labels:
     {{- include "seaweedfs-operator.labels" . | nindent 4 }}
-  {{- if .Values.webhook.certManager.enabled }}
+  {{- if $certManager.enabled }}
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "seaweedfs-operator.webhookCertificateName" . }}
   {{- end }}

--- a/deploy/helm/templates/webhook/validating-webhook.yaml
+++ b/deploy/helm/templates/webhook/validating-webhook.yaml
@@ -7,6 +7,10 @@ metadata:
   name: {{ include "seaweedfs-operator.validatingWebhookName" . }}
   labels:
     {{- include "seaweedfs-operator.labels" . | nindent 4 }}
+  {{- if .Values.webhook.certManager.enabled }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "seaweedfs-operator.webhookCertificateName" . }}
+  {{- end }}
 webhooks:
 - clientConfig:
     service:

--- a/deploy/helm/templates/webhook/validating-webhook.yaml
+++ b/deploy/helm/templates/webhook/validating-webhook.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.webhook.enabled }}
+{{- $certManager := default dict .Values.webhook.certManager }}
 
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -7,7 +8,7 @@ metadata:
   name: {{ include "seaweedfs-operator.validatingWebhookName" . }}
   labels:
     {{- include "seaweedfs-operator.labels" . | nindent 4 }}
-  {{- if .Values.webhook.certManager.enabled }}
+  {{- if $certManager.enabled }}
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "seaweedfs-operator.webhookCertificateName" . }}
   {{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -129,6 +129,20 @@ webhook:
     registry: registry.k8s.io
     repository: ingress-nginx/kube-webhook-certgen
     tag: v20231011-8b53cabe0
+  certManager:
+    # -- Use cert-manager to provision the webhook TLS certificate instead of
+    # the built-in certgen Jobs. Requires cert-manager to be installed in the
+    # cluster. When enabled the certgen Jobs and their RBAC are not created.
+    enabled: false
+    # -- Override the issuerRef used for the webhook serving Certificate.
+    # When empty (default) a self-signed CA Issuer is created automatically.
+    # Set this to point at an existing Issuer or ClusterIssuer in your cluster.
+    # Example:
+    #   issuerRef:
+    #     name: my-issuer
+    #     kind: ClusterIssuer
+    #     group: cert-manager.io
+    issuerRef: {}
 
 ## seaweedfs-operator containers' resource requests and limits.
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -134,14 +134,15 @@ webhook:
     # the built-in certgen Jobs. Requires cert-manager to be installed in the
     # cluster. When enabled the certgen Jobs and their RBAC are not created.
     enabled: false
-    # -- Override the issuerRef used for the webhook serving Certificate.
-    # When empty (default) a self-signed CA Issuer is created automatically.
-    # Set this to point at an existing Issuer or ClusterIssuer in your cluster.
     # Example:
     #   issuerRef:
     #     name: my-issuer
     #     kind: ClusterIssuer
-    #     group: cert-manager.io
+    # -- Point the webhook serving Certificate at an existing Issuer or
+    # ClusterIssuer instead of the self-signed Issuer created by default.
+    # The issuer must populate ca.crt in the issued secret so cert-manager
+    # can inject the CA into the webhook configurations; CA, Vault, and
+    # self-signed issuers do, ACME issuers such as Let's Encrypt do not.
     issuerRef: {}
 
 ## seaweedfs-operator containers' resource requests and limits.

--- a/test/helm/install_smoke.sh
+++ b/test/helm/install_smoke.sh
@@ -4,7 +4,10 @@
 # deploy/helm/ with **default values** (i.e., what a real user gets from
 # `helm install seaweedfs/seaweedfs-operator`), applies a Seaweed CR
 # and a Bucket CR to exercise both controllers, then asserts the
-# operator emits no RBAC permission errors during reconcile.
+# operator emits no RBAC permission errors during reconcile. A second
+# lap upgrades the release with webhook.certManager.enabled=true to
+# exercise the cert-manager certificate path against the cert-manager
+# instance `make kind-prepare` installs.
 #
 # Why this exists: the existing test-e2e suite deploys via `make deploy`
 # (kustomize-based, uses config/rbac/role.yaml — the kubebuilder-generated
@@ -125,3 +128,42 @@ if [ -n "$RBAC_ERRORS" ]; then
 fi
 
 log "PASS — operator reconciled cleanly with chart-default RBAC"
+
+# Second lap: flip the webhook certificates over to cert-manager. The
+# upgrade swaps the certgen hook Jobs for an Issuer/Certificate pair,
+# cert-manager takes over the existing serving-cert Secret, and
+# cainjector replaces the caBundle on both webhook configurations.
+# The webhooks use failurePolicy=Fail, so a successful admission below
+# proves the full TLS chain converged on the cert-manager certificate.
+log "upgrading release to cert-manager-managed webhook certificates"
+helm upgrade "$RELEASE" "$CHART_DIR" \
+  --namespace "$NAMESPACE" \
+  --reuse-values \
+  --set webhook.certManager.enabled=true \
+  --wait --timeout 5m
+
+# The Certificate shares the Deployment's fullname prefix.
+CERTIFICATE="$DEPLOYMENT-webhook-cert"
+log "waiting for Certificate $CERTIFICATE to become Ready"
+kubectl -n "$NAMESPACE" wait certificates.cert-manager.io/"$CERTIFICATE" \
+  --for=condition=Ready --timeout 2m
+
+# `kubectl apply` skips the write (and therefore the webhooks) when the
+# manifest is unchanged, so mutate an annotation to force an UPDATE
+# through admission. Retry while cainjector and the rolled pods
+# converge on the new certificate.
+log "verifying webhook admission through the cert-manager certificate"
+ADMITTED=""
+for attempt in $(seq 1 24); do
+  if kubectl annotate -f "$REPO_ROOT/config/samples/seaweed_v1_seaweed.yaml" \
+       smoke-test/cert-manager="attempt-$attempt" --overwrite >/dev/null 2>&1; then
+    ADMITTED=1
+    break
+  fi
+  sleep 5
+done
+if [ -z "$ADMITTED" ]; then
+  fail "admission kept failing after switching webhook certificates to cert-manager"
+fi
+
+log "PASS — webhooks admitted CRs with the cert-manager certificate"


### PR DESCRIPTION
Fix for [Issue](https://github.com/seaweedfs/seaweedfs-operator/issues/323)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional cert-manager integration for webhook TLS certificates.
  - Supports self-signed certificates or an existing Issuer/ClusterIssuer.
  - Automatically provisions webhook certificates and secret wiring, including CA injection annotations when enabled.

- **Improvements**
  - Preserves the existing certificate-generation workflow when cert-manager is disabled.
  - Updates webhook deployment mounting to use the correct certificate/secret layout depending on cert-manager being enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->