### PR TITLE
Forward merged annotations to every component pod template

### DIFF
--- a/internal/controller/controller_filer_statefulset.go
+++ b/internal/controller/controller_filer_statefulset.go
@@ -44,7 +44,7 @@ func buildFilerStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string {
 func (r *SeaweedReconciler) createFilerStatefulSet(m *seaweedv1.Seaweed) *appsv1.StatefulSet {
 	labels := labelsForFiler(m.Name)
 	podLabels := mergePodLabels(labels, m.BaseFilerSpec().Labels())
-	annotations := m.Spec.Filer.Annotations
+	annotations := m.BaseFilerSpec().Annotations()
 	ports := []corev1.ContainerPort{
 		{
 			ContainerPort: seaweedv1.FilerHTTPPort,

--- a/internal/controller/controller_master_statefulset.go
+++ b/internal/controller/controller_master_statefulset.go
@@ -48,7 +48,7 @@ func buildMasterStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string 
 func (r *SeaweedReconciler) createMasterStatefulSet(m *seaweedv1.Seaweed) *appsv1.StatefulSet {
 	labels := labelsForMaster(m.Name)
 	podLabels := mergePodLabels(labels, m.BaseMasterSpec().Labels())
-	annotations := m.Spec.Master.Annotations
+	annotations := m.BaseMasterSpec().Annotations()
 	ports := []corev1.ContainerPort{
 		{
 			ContainerPort: seaweedv1.MasterHTTPPort,

--- a/internal/controller/controller_s3.go
+++ b/internal/controller/controller_s3.go
@@ -319,7 +319,7 @@ func (r *SeaweedReconciler) buildS3Deployment(m *seaweedv1.Seaweed) *appsv1.Depl
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      podLabels,
-					Annotations: m.Spec.S3.Annotations,
+					Annotations: m.BaseS3Spec().Annotations(),
 				},
 				Spec: podSpec,
 			},

--- a/internal/controller/controller_sftp.go
+++ b/internal/controller/controller_sftp.go
@@ -329,7 +329,7 @@ func (r *SeaweedReconciler) buildSFTPDeployment(m *seaweedv1.Seaweed) *appsv1.De
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      podLabels,
-					Annotations: m.Spec.SFTP.Annotations,
+					Annotations: m.BaseSFTPSpec().Annotations(),
 				},
 				Spec: podSpec,
 			},

--- a/internal/controller/controller_volume_statefulset.go
+++ b/internal/controller/controller_volume_statefulset.go
@@ -330,7 +330,7 @@ func (r *SeaweedReconciler) buildFlatVolumePodSpec(m *seaweedv1.Seaweed, disks v
 func (r *SeaweedReconciler) createVolumeServerStatefulSet(m *seaweedv1.Seaweed) *appsv1.StatefulSet {
 	labels := labelsForVolumeServer(m.Name)
 	podLabels := mergePodLabels(labels, m.BaseVolumeSpec().Labels())
-	annotations := m.Spec.Volume.Annotations
+	annotations := m.BaseVolumeSpec().Annotations()
 	replicas := int32(m.Spec.Volume.Replicas)
 	rollingUpdatePartition := int32(0)
 
@@ -374,7 +374,7 @@ func (r *SeaweedReconciler) createVolumeServerStatefulSet(m *seaweedv1.Seaweed) 
 func (r *SeaweedReconciler) createVolumeServerDaemonSet(m *seaweedv1.Seaweed) *appsv1.DaemonSet {
 	labels := labelsForVolumeServer(m.Name)
 	podLabels := mergePodLabels(labels, m.BaseVolumeSpec().Labels())
-	annotations := m.Spec.Volume.Annotations
+	annotations := m.BaseVolumeSpec().Annotations()
 
 	disks := volumeServerDisksFor(m)
 	volumePodSpec := r.buildFlatVolumePodSpec(m, disks, "$(POD_IP)")
@@ -405,10 +405,10 @@ func (r *SeaweedReconciler) createVolumeServerDaemonSet(m *seaweedv1.Seaweed) *a
 func (r *SeaweedReconciler) createVolumeServerTopologyStatefulSet(m *seaweedv1.Seaweed, topologyName string, topologySpec *seaweedv1.VolumeTopologySpec) *appsv1.StatefulSet {
 	labels := labelsForVolumeServerTopology(m.Name, topologyName)
 	// 3-tier inheritance for topology pods: cluster + volume + topology, with
-	// the topology winning on collisions. BaseVolumeSpec().Labels() already
-	// returns cluster+volume merged.
+	// the topology winning on collisions. BaseVolumeSpec() accessors already
+	// return cluster+volume merged.
 	podLabels := mergePodLabels(labels, mergeLabels(m.BaseVolumeSpec().Labels(), topologySpec.Labels))
-	annotations := mergeAnnotations(m.Spec.Annotations, topologySpec.Annotations)
+	annotations := mergeAnnotations(m.BaseVolumeSpec().Annotations(), topologySpec.Annotations)
 	ports := []corev1.ContainerPort{
 		{
 			ContainerPort: seaweedv1.VolumeHTTPPort,

--- a/internal/controller/pod_annotations_test.go
+++ b/internal/controller/pod_annotations_test.go
@@ -1,0 +1,174 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+)
+
+// Every component's pod template must carry cluster-level annotations merged
+// with component-level ones (component wins on collision), so Helm-style
+// checksum annotations trigger rollouts uniformly across components. The
+// checksum/secrets key mirrors that motivating pattern.
+func TestPodTemplateAnnotations_MergeClusterAndComponent(t *testing.T) {
+	cluster := map[string]string{
+		"cluster-scope":    "cluster",
+		"checksum/secrets": "cluster-sum",
+	}
+	component := map[string]string{
+		"component-scope":  "component",
+		"checksum/secrets": "component-sum",
+	}
+	want := map[string]string{
+		"cluster-scope":    "cluster",
+		"component-scope":  "component",
+		"checksum/secrets": "component-sum",
+	}
+
+	componentSpec := seaweedv1.ComponentSpec{Annotations: component}
+	volumeConfig := seaweedv1.VolumeServerConfig{
+		ComponentSpec: componentSpec,
+		ResourceRequirements: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("1Gi"),
+			},
+		},
+	}
+	newSeaweed := func() *seaweedv1.Seaweed {
+		return &seaweedv1.Seaweed{
+			ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
+			Spec: seaweedv1.SeaweedSpec{
+				Annotations: cluster,
+				Master:      &seaweedv1.MasterSpec{Replicas: 1},
+				Filer:       &seaweedv1.FilerSpec{Replicas: 1},
+			},
+		}
+	}
+	r := &SeaweedReconciler{}
+
+	cases := []struct {
+		name  string
+		build func() map[string]string
+	}{
+		{"master", func() map[string]string {
+			m := newSeaweed()
+			m.Spec.Master.ComponentSpec = componentSpec
+			return r.createMasterStatefulSet(m).Spec.Template.Annotations
+		}},
+		{"filer", func() map[string]string {
+			m := newSeaweed()
+			m.Spec.Filer.ComponentSpec = componentSpec
+			return r.createFilerStatefulSet(m).Spec.Template.Annotations
+		}},
+		{"volume statefulset", func() map[string]string {
+			m := newSeaweed()
+			m.Spec.Volume = &seaweedv1.VolumeSpec{Replicas: 1, VolumeServerConfig: volumeConfig}
+			return r.createVolumeServerStatefulSet(m).Spec.Template.Annotations
+		}},
+		{"volume daemonset", func() map[string]string {
+			m := newSeaweed()
+			m.Spec.Volume = &seaweedv1.VolumeSpec{
+				Kind:               seaweedv1.VolumeServerDaemonSet,
+				HostPath:           []seaweedv1.VolumeServerHostPath{{Path: "/mnt/disk0"}},
+				VolumeServerConfig: seaweedv1.VolumeServerConfig{ComponentSpec: componentSpec},
+			}
+			return r.createVolumeServerDaemonSet(m).Spec.Template.Annotations
+		}},
+		{"admin", func() map[string]string {
+			m := newSeaweed()
+			m.Spec.Admin = &seaweedv1.AdminSpec{ComponentSpec: componentSpec}
+			return r.createAdminStatefulSet(m).Spec.Template.Annotations
+		}},
+		{"worker", func() map[string]string {
+			m := newSeaweed()
+			m.Spec.Admin = &seaweedv1.AdminSpec{}
+			m.Spec.Worker = &seaweedv1.WorkerSpec{Replicas: 1, ComponentSpec: componentSpec}
+			return r.createWorkerDeployment(m).Spec.Template.Annotations
+		}},
+		{"s3", func() map[string]string {
+			m := newSeaweed()
+			m.Spec.S3 = &seaweedv1.S3GatewaySpec{Replicas: 1, ComponentSpec: componentSpec}
+			return r.buildS3Deployment(m).Spec.Template.Annotations
+		}},
+		{"sftp", func() map[string]string {
+			m := newSeaweed()
+			m.Spec.SFTP = &seaweedv1.SFTPSpec{Replicas: 1, ComponentSpec: componentSpec}
+			return r.buildSFTPDeployment(m).Spec.Template.Annotations
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.build(); !reflect.DeepEqual(got, want) {
+				t.Errorf("pod template annotations = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+// Topology pods layer a third tier on top: cluster + volume + topology, with
+// the topology winning on collisions — the same order their labels use.
+func TestVolumeTopologyPodTemplateAnnotations_ThreeTierMerge(t *testing.T) {
+	topology := &seaweedv1.VolumeTopologySpec{
+		VolumeServerConfig: seaweedv1.VolumeServerConfig{
+			ComponentSpec: seaweedv1.ComponentSpec{
+				Annotations: map[string]string{"topology-scope": "topology", "shared": "topology"},
+			},
+			ResourceRequirements: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+		Replicas:   1,
+		Rack:       "rack1",
+		DataCenter: "dc1",
+	}
+	m := &seaweedv1.Seaweed{
+		ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
+		Spec: seaweedv1.SeaweedSpec{
+			Annotations: map[string]string{"cluster-scope": "cluster", "shared": "cluster"},
+			Master:      &seaweedv1.MasterSpec{Replicas: 1},
+			Volume: &seaweedv1.VolumeSpec{
+				VolumeServerConfig: seaweedv1.VolumeServerConfig{
+					ComponentSpec: seaweedv1.ComponentSpec{
+						Annotations: map[string]string{"volume-scope": "volume", "shared": "volume"},
+					},
+				},
+			},
+			VolumeTopology: map[string]*seaweedv1.VolumeTopologySpec{"rack1": topology},
+		},
+	}
+	want := map[string]string{
+		"cluster-scope":  "cluster",
+		"volume-scope":   "volume",
+		"topology-scope": "topology",
+		"shared":         "topology",
+	}
+
+	r := &SeaweedReconciler{}
+	got := r.createVolumeServerTopologyStatefulSet(m, "rack1", topology).Spec.Template.Annotations
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("topology pod template annotations = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
Fixes #325

Helm's checksum-annotation pattern (annotating pods with a hash of a Secret/ConfigMap to force a rollout when it changes) only worked for `admin`, because components handled `annotations` inconsistently:

- `admin` and `worker` put the merged cluster + component annotations on the pod template
- `master`, `filer`, and `volume` used only the raw component annotations, ignoring cluster-level `spec.annotations`
- `s3` and `sftp` did the same (and in released images dropped pod annotations entirely)
- volume topology StatefulSets merged cluster + topology annotations but skipped the `spec.volume` tier, unlike their labels

Every component pod template now uses the same merged `Base*Spec().Annotations()` accessor that `admin` uses (component wins on key collisions), and topology pods get the same 3-tier cluster + volume + topology merge their labels already had.

Added table-driven tests pinning the merge for all nine pod-template builders: master, filer, volume StatefulSet/DaemonSet/topology, admin, worker, s3, and sftp.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected workload pod annotations to consistently combine cluster-level and component-level settings.
  * Ensured topology-specific annotations are applied correctly and override conflicting values.
  * Improved annotation handling across master, filer, volume, admin, worker, S3, and SFTP workloads.

* **Tests**
  * Added coverage validating annotation merging and precedence across supported workload types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->