### PR TITLE
Stop steady-state reconciles from emitting 409 creates and 404 deletes

### DIFF
--- a/internal/controller/controller_s3.go
+++ b/internal/controller/controller_s3.go
@@ -100,7 +100,7 @@ func (r *SeaweedReconciler) ensureS3Gateway(ctx context.Context, m *seaweedv1.Se
 			sm := &monitorv1.ServiceMonitor{
 				ObjectMeta: metav1.ObjectMeta{Name: m.Name + "-s3", Namespace: m.Namespace},
 			}
-			if err := r.Delete(ctx, sm); err != nil && !apierrors.IsNotFound(err) {
+			if _, err := r.deleteIfExists(ctx, sm); err != nil {
 				return ReconcileResult(err)
 			}
 		}
@@ -118,7 +118,7 @@ func (r *SeaweedReconciler) ensureS3Gateway(ctx context.Context, m *seaweedv1.Se
 		ing := &networkingv1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{Name: m.Name + "-s3-ingress", Namespace: m.Namespace},
 		}
-		if err := r.Delete(ctx, ing); err != nil && !apierrors.IsNotFound(err) {
+		if _, err := r.deleteIfExists(ctx, ing); err != nil {
 			return ReconcileResult(err)
 		}
 	}
@@ -127,30 +127,31 @@ func (r *SeaweedReconciler) ensureS3Gateway(ctx context.Context, m *seaweedv1.Se
 
 // deleteS3Gateway deletes the full set of resources the S3 gateway
 // reconciler would otherwise create: Deployment, Service, optional
-// Ingress, optional ServiceMonitor. All calls are IsNotFound-safe.
+// Ingress, optional ServiceMonitor. Deletes are existence-guarded, so
+// the steady-state "no gateway" pass stays read-only.
 func (r *SeaweedReconciler) deleteS3Gateway(ctx context.Context, m *seaweedv1.Seaweed) error {
 	name := m.Name + "-s3"
 	// Deployment
 	dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: m.Namespace}}
-	if err := r.Delete(ctx, dep); err != nil && !apierrors.IsNotFound(err) {
+	if _, err := r.deleteIfExists(ctx, dep); err != nil {
 		return err
 	}
 	// Service
 	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: m.Namespace}}
-	if err := r.Delete(ctx, svc); err != nil && !apierrors.IsNotFound(err) {
+	if _, err := r.deleteIfExists(ctx, svc); err != nil {
 		return err
 	}
 	// Ingress (only the per-component one; legacy HostSuffix Ingress
 	// is reconciled elsewhere and must be left alone).
 	ing := &networkingv1.Ingress{ObjectMeta: metav1.ObjectMeta{Name: name + "-ingress", Namespace: m.Namespace}}
-	if err := r.Delete(ctx, ing); err != nil && !apierrors.IsNotFound(err) {
+	if _, err := r.deleteIfExists(ctx, ing); err != nil {
 		return err
 	}
 	// ServiceMonitor — gate on the CRD so we do not fail on clusters
 	// without Prometheus Operator installed.
 	if r.serviceMonitorCRDAvailable() {
 		sm := &monitorv1.ServiceMonitor{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: m.Namespace}}
-		if err := r.Delete(ctx, sm); err != nil && !apierrors.IsNotFound(err) {
+		if _, err := r.deleteIfExists(ctx, sm); err != nil {
 			return err
 		}
 	}

--- a/internal/controller/controller_sftp.go
+++ b/internal/controller/controller_sftp.go
@@ -97,7 +97,7 @@ func (r *SeaweedReconciler) ensureSFTPGateway(ctx context.Context, m *seaweedv1.
 			sm := &monitorv1.ServiceMonitor{
 				ObjectMeta: metav1.ObjectMeta{Name: m.Name + "-sftp", Namespace: m.Namespace},
 			}
-			if err := r.Delete(ctx, sm); err != nil && !apierrors.IsNotFound(err) {
+			if _, err := r.deleteIfExists(ctx, sm); err != nil {
 				return ReconcileResult(err)
 			}
 		}
@@ -111,7 +111,7 @@ func (r *SeaweedReconciler) ensureSFTPGateway(ctx context.Context, m *seaweedv1.
 		ing := &networkingv1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{Name: m.Name + "-sftp-ingress", Namespace: m.Namespace},
 		}
-		if err := r.Delete(ctx, ing); err != nil && !apierrors.IsNotFound(err) {
+		if _, err := r.deleteIfExists(ctx, ing); err != nil {
 			return ReconcileResult(err)
 		}
 	}
@@ -120,24 +120,25 @@ func (r *SeaweedReconciler) ensureSFTPGateway(ctx context.Context, m *seaweedv1.
 
 // deleteSFTPGateway deletes the full set of resources the SFTP gateway
 // reconciler creates: Deployment, Service, optional Ingress, optional
-// ServiceMonitor. All calls are IsNotFound-safe.
+// ServiceMonitor. Deletes are existence-guarded, so the steady-state
+// "no gateway" pass stays read-only.
 func (r *SeaweedReconciler) deleteSFTPGateway(ctx context.Context, m *seaweedv1.Seaweed) error {
 	name := m.Name + "-sftp"
 	dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: m.Namespace}}
-	if err := r.Delete(ctx, dep); err != nil && !apierrors.IsNotFound(err) {
+	if _, err := r.deleteIfExists(ctx, dep); err != nil {
 		return err
 	}
 	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: m.Namespace}}
-	if err := r.Delete(ctx, svc); err != nil && !apierrors.IsNotFound(err) {
+	if _, err := r.deleteIfExists(ctx, svc); err != nil {
 		return err
 	}
 	ing := &networkingv1.Ingress{ObjectMeta: metav1.ObjectMeta{Name: name + "-ingress", Namespace: m.Namespace}}
-	if err := r.Delete(ctx, ing); err != nil && !apierrors.IsNotFound(err) {
+	if _, err := r.deleteIfExists(ctx, ing); err != nil {
 		return err
 	}
 	if r.serviceMonitorCRDAvailable() {
 		sm := &monitorv1.ServiceMonitor{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: m.Namespace}}
-		if err := r.Delete(ctx, sm); err != nil && !apierrors.IsNotFound(err) {
+		if _, err := r.deleteIfExists(ctx, sm); err != nil {
 			return err
 		}
 	}

--- a/internal/controller/controller_util.go
+++ b/internal/controller/controller_util.go
@@ -33,9 +33,12 @@ const (
 // MergeFn is to resolve conflicts
 type MergeFn func(existing, desired runtime.Object) error
 
-// CreateOrUpdate create an object to the Kubernetes cluster for controller, if the object to create is existed,
-// call mergeFn to merge the change in new object to the existing object, then update the existing object.
-// The object will also be adopted by the given controller.
+// CreateOrUpdate ensures an object exists in the desired state for the
+// controller. It reads first — a cache hit in production — and only issues a
+// Create when the object is missing, so a converged cluster does not emit an
+// AlreadyExists conflict per object per reconcile. When the object exists,
+// mergeFn merges the desired changes into it and an Update is issued only if
+// the merge changed anything.
 func (r *SeaweedReconciler) CreateOrUpdate(obj runtime.Object, mergeFn MergeFn) (runtime.Object, error) {
 
 	// controller-runtime/client will mutate the object pointer in-place,
@@ -43,36 +46,50 @@ func (r *SeaweedReconciler) CreateOrUpdate(obj runtime.Object, mergeFn MergeFn) 
 	// to avoid the in-place mutation here and hereafter.
 	desired := obj.DeepCopyObject().(client.Object)
 
-	// 1. try to create and see if there is any conflicts
-	err := r.Create(context.TODO(), desired)
-	if errors.IsAlreadyExists(err) {
-		// 2. object has already existed, merge our desired changes to it
-		existing, err := r.EmptyClone(obj)
-
-		if err != nil {
+	existing, err := r.EmptyClone(obj)
+	if err != nil {
+		return nil, err
+	}
+	getErr := r.Get(context.TODO(), client.ObjectKeyFromObject(desired), existing.(client.Object))
+	if errors.IsNotFound(getErr) {
+		createErr := r.Create(context.TODO(), desired)
+		if !errors.IsAlreadyExists(createErr) {
+			return desired, createErr
+		}
+		// Created concurrently, or the informer cache lagged a prior
+		// create — re-read and fall through to the merge path.
+		if err := r.Get(context.TODO(), client.ObjectKeyFromObject(desired), existing.(client.Object)); err != nil {
 			return nil, err
 		}
-		err = r.Get(context.TODO(), client.ObjectKeyFromObject(desired), existing.(client.Object))
-		if err != nil {
-			return nil, err
-		}
-
-		mutated := existing.DeepCopyObject().(client.Object)
-		// 4. invoke mergeFn to mutate a copy of the existing object
-		if err := mergeFn(mutated, desired); err != nil {
-			return nil, err
-		}
-
-		// 5. check if the copy is actually mutated
-		if !apiequality.Semantic.DeepEqual(existing, mutated) {
-			err := r.Update(context.TODO(), mutated)
-			return mutated, err
-		}
-
-		return mutated, nil
+	} else if getErr != nil {
+		return nil, getErr
 	}
 
-	return desired, err
+	mutated := existing.DeepCopyObject().(client.Object)
+	// invoke mergeFn to mutate a copy of the existing object
+	if err := mergeFn(mutated, desired); err != nil {
+		return nil, err
+	}
+
+	// only issue an Update if the merge actually changed something
+	if !apiequality.Semantic.DeepEqual(existing, mutated) {
+		err := r.Update(context.TODO(), mutated)
+		return mutated, err
+	}
+
+	return mutated, nil
+}
+
+// deleteIfExists issues a Delete only when the object exists, so reconciling
+// an absent optional component costs a read — a cache hit in production —
+// instead of emitting a NotFound error per pass. obj must have Name and
+// Namespace set. It reports whether the object still existed, so callers can
+// requeue and wait for deletion to finish.
+func (r *SeaweedReconciler) deleteIfExists(ctx context.Context, obj client.Object) (existed bool, err error) {
+	if err := r.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+		return false, client.IgnoreNotFound(err)
+	}
+	return true, client.IgnoreNotFound(r.Delete(ctx, obj))
 }
 
 func (r *SeaweedReconciler) addSpecToAnnotation(d *appsv1.Deployment) error {

--- a/internal/controller/controller_volume.go
+++ b/internal/controller/controller_volume.go
@@ -9,7 +9,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
@@ -65,25 +64,13 @@ func (r *SeaweedReconciler) ensureVolumeServers(ctx context.Context, seaweedCR *
 	return
 }
 
-// deleteVolumeWorkloadIfExists removes a prior flat volume workload that shares
-// the <cr>-volume name, so switching spec.volume.kind doesn't leave both the
-// StatefulSet and DaemonSet running. obj must have Name and Namespace set. It
-// reports whether the workload still existed, so callers can requeue and wait
-// for deletion to finish before creating the new kind.
-func (r *SeaweedReconciler) deleteVolumeWorkloadIfExists(ctx context.Context, obj client.Object) (existed bool, err error) {
-	if err := r.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
-		return false, client.IgnoreNotFound(err)
-	}
-	return true, client.IgnoreNotFound(r.Delete(ctx, obj))
-}
-
 func (r *SeaweedReconciler) ensureVolumeServerStatefulSet(ctx context.Context, seaweedCR *seaweedv1.Seaweed) (bool, ctrl.Result, error) {
 	log := r.Log.WithValues("sw-volume-statefulset", seaweedCR.Name)
 
 	// Remove a DaemonSet left from a previous kind=DaemonSet config, and wait
 	// for it to clear before creating the StatefulSet so they don't overlap.
 	staleDaemonSet := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: seaweedCR.Name + "-volume", Namespace: seaweedCR.Namespace}}
-	if existed, err := r.deleteVolumeWorkloadIfExists(ctx, staleDaemonSet); err != nil {
+	if existed, err := r.deleteIfExists(ctx, staleDaemonSet); err != nil {
 		return ReconcileResult(err)
 	} else if existed {
 		log.Info("waiting for prior volume DaemonSet deletion before creating StatefulSet")
@@ -129,7 +116,7 @@ func (r *SeaweedReconciler) ensureVolumeServerDaemonSet(ctx context.Context, sea
 	// Remove a StatefulSet left from a previous kind=StatefulSet config, and
 	// wait for it to clear before creating the DaemonSet so they don't overlap.
 	staleStatefulSet := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: seaweedCR.Name + "-volume", Namespace: seaweedCR.Namespace}}
-	if existed, err := r.deleteVolumeWorkloadIfExists(ctx, staleStatefulSet); err != nil {
+	if existed, err := r.deleteIfExists(ctx, staleStatefulSet); err != nil {
 		return ReconcileResult(err)
 	} else if existed {
 		log.Info("waiting for prior volume StatefulSet deletion before creating DaemonSet")

--- a/internal/controller/controller_worker.go
+++ b/internal/controller/controller_worker.go
@@ -6,7 +6,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -58,7 +57,8 @@ func (r *SeaweedReconciler) ensureWorkerDeployment(ctx context.Context, seaweedC
 
 // cleanupLegacyWorkerStatefulSet removes the StatefulSet + headless peer
 // Service that earlier operator versions created for workers. Safe to call
-// on every reconcile: both deletes are IsNotFound-tolerant.
+// on every reconcile: deletes are issued only when the legacy objects
+// still exist, so the steady-state pass stays read-only.
 //
 // When a delete actually fires (i.e. the resource existed), we return
 // done=true with a short requeue so the API server can cascade the
@@ -69,27 +69,20 @@ func (r *SeaweedReconciler) ensureWorkerDeployment(ctx context.Context, seaweedC
 // registering with admin as duplicate workers until GC completes.
 func (r *SeaweedReconciler) cleanupLegacyWorkerStatefulSet(ctx context.Context, seaweedCR *seaweedv1.Seaweed) (bool, ctrl.Result, error) {
 	name := seaweedCR.Name + "-worker"
-	deleted := false
 
 	sts := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: seaweedCR.Namespace}}
-	if err := r.Delete(ctx, sts); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return ReconcileResult(err)
-		}
-	} else {
-		deleted = true
+	stsExisted, err := r.deleteIfExists(ctx, sts)
+	if err != nil {
+		return ReconcileResult(err)
 	}
 
 	peer := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: name + "-peer", Namespace: seaweedCR.Namespace}}
-	if err := r.Delete(ctx, peer); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return ReconcileResult(err)
-		}
-	} else {
-		deleted = true
+	peerExisted, err := r.deleteIfExists(ctx, peer)
+	if err != nil {
+		return ReconcileResult(err)
 	}
 
-	if deleted {
+	if stsExisted || peerExisted {
 		return true, ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 	}
 	return ReconcileResult(nil)

--- a/internal/controller/steady_state_envtest_test.go
+++ b/internal/controller/steady_state_envtest_test.go
@@ -1,0 +1,216 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+)
+
+// writeCountingClient wraps a client.Client and tallies write calls plus the
+// 4xx-class responses the apiserver returns for them — the same signal
+// rest_client_requests_total exposes to API-client error-rate alerting.
+// Reads pass through uncounted: in production they are served from the
+// informer cache and never reach the apiserver.
+type writeCountingClient struct {
+	client.Client
+	creates             int
+	updates             int
+	deletes             int
+	createAlreadyExists int // 409
+	deleteNotFound      int // 404
+}
+
+func (c *writeCountingClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	c.creates++
+	err := c.Client.Create(ctx, obj, opts...)
+	if apierrors.IsAlreadyExists(err) {
+		c.createAlreadyExists++
+	}
+	return err
+}
+
+func (c *writeCountingClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	c.updates++
+	return c.Client.Update(ctx, obj, opts...)
+}
+
+func (c *writeCountingClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	c.deletes++
+	err := c.Client.Delete(ctx, obj, opts...)
+	if apierrors.IsNotFound(err) {
+		c.deleteNotFound++
+	}
+	return err
+}
+
+func (c *writeCountingClient) reset() {
+	c.creates, c.updates, c.deletes = 0, 0, 0
+	c.createAlreadyExists, c.deleteNotFound = 0, 0
+}
+
+// TestReconcile_ConvergedClusterEmitsNoFailedWrites drives the full Seaweed
+// reconcile loop against a real apiserver until it converges, then asserts
+// that a steady-state pass issues no Create answered with 409 AlreadyExists
+// and no Delete answered with 404 NotFound. A converged pass should probe by
+// read (a cache hit in production) and stay write-silent, so client
+// error-rate alerting sees near-zero 4xx from the operator.
+func TestReconcile_ConvergedClusterEmitsNoFailedWrites(t *testing.T) {
+	_, cli := mustEnvtest(t)
+	ctx := context.Background()
+
+	ns := newTestNamespace(t, ctx, cli, "steady")
+	t.Cleanup(func() {
+		_ = cli.Delete(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	})
+
+	// Master + volume + filer, no S3/SFTP: the absent optional gateways make
+	// every pass run the teardown prune, which is where the 404s came from.
+	// ConcurrentStart skips the master pod-readiness wait — envtest runs no
+	// kubelets, so no pod would ever report Running.
+	concurrentStart := true
+	diskCount := int32(1)
+	cr := &seaweedv1.Seaweed{
+		ObjectMeta: metav1.ObjectMeta{Name: "steady", Namespace: ns},
+		Spec: seaweedv1.SeaweedSpec{
+			Image:                 "chrislusf/seaweedfs:latest",
+			VolumeServerDiskCount: &diskCount,
+			Master: &seaweedv1.MasterSpec{
+				Replicas:        1,
+				ConcurrentStart: &concurrentStart,
+			},
+			Volume: &seaweedv1.VolumeSpec{
+				Replicas: 1,
+				VolumeServerConfig: seaweedv1.VolumeServerConfig{
+					ResourceRequirements: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("1Gi"),
+						},
+					},
+				},
+			},
+			Filer: &seaweedv1.FilerSpec{Replicas: 1},
+		},
+	}
+	if err := cli.Create(ctx, cr); err != nil {
+		t.Fatalf("create Seaweed CR: %v", err)
+	}
+
+	counting := &writeCountingClient{Client: cli}
+	r := &SeaweedReconciler{
+		Client: counting,
+		Log:    logf.FromContext(ctx),
+		Scheme: cli.Scheme(),
+	}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: cr.Name, Namespace: ns}}
+
+	// Converge: the first pass creates every owned object, the following
+	// passes stamp last-applied annotations via the merge path.
+	for i := 0; i < 3; i++ {
+		if _, err := r.Reconcile(ctx, req); err != nil {
+			t.Fatalf("convergence reconcile %d: %v", i+1, err)
+		}
+	}
+
+	counting.reset()
+	if _, err := r.Reconcile(ctx, req); err != nil {
+		t.Fatalf("steady-state reconcile: %v", err)
+	}
+
+	if counting.createAlreadyExists != 0 {
+		t.Errorf("steady-state reconcile issued %d Create calls answered with 409 AlreadyExists, want 0", counting.createAlreadyExists)
+	}
+	if counting.deleteNotFound != 0 {
+		t.Errorf("steady-state reconcile issued %d Delete calls answered with 404 NotFound, want 0", counting.deleteNotFound)
+	}
+	if counting.creates != 0 {
+		t.Errorf("steady-state reconcile issued %d Create calls, want 0: every owned object already exists", counting.creates)
+	}
+	if counting.deletes != 0 {
+		t.Errorf("steady-state reconcile issued %d Delete calls, want 0: absent components should be probed by read", counting.deletes)
+	}
+}
+
+// TestCreateOrUpdate_ReadsBeforeWriting pins the helper's write behavior at
+// the API level: a missing object costs exactly one Create, an unchanged
+// object costs no write at all, and a drifted object costs exactly one
+// Update that lands.
+func TestCreateOrUpdate_ReadsBeforeWriting(t *testing.T) {
+	_, cli := mustEnvtest(t)
+	ctx := context.Background()
+
+	ns := newTestNamespace(t, ctx, cli, "createorupdate")
+	t.Cleanup(func() {
+		_ = cli.Delete(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	})
+
+	counting := &writeCountingClient{Client: cli}
+	r := &SeaweedReconciler{
+		Client: counting,
+		Log:    logf.FromContext(ctx),
+		Scheme: cli.Scheme(),
+	}
+
+	cm := func(v string) *corev1.ConfigMap {
+		return &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "cou", Namespace: ns},
+			Data:       map[string]string{"k": v},
+		}
+	}
+
+	if _, err := r.CreateOrUpdateConfigMap(cm("v1")); err != nil {
+		t.Fatalf("initial pass: %v", err)
+	}
+	if counting.creates != 1 || counting.updates != 0 {
+		t.Errorf("missing object: got %d creates / %d updates, want 1 / 0", counting.creates, counting.updates)
+	}
+
+	counting.reset()
+	if _, err := r.CreateOrUpdateConfigMap(cm("v1")); err != nil {
+		t.Fatalf("no-op pass: %v", err)
+	}
+	if counting.creates != 0 || counting.createAlreadyExists != 0 || counting.updates != 0 {
+		t.Errorf("unchanged object: got %d creates (%d conflicted) / %d updates, want no writes",
+			counting.creates, counting.createAlreadyExists, counting.updates)
+	}
+
+	counting.reset()
+	if _, err := r.CreateOrUpdateConfigMap(cm("v2")); err != nil {
+		t.Fatalf("drift pass: %v", err)
+	}
+	if counting.creates != 0 || counting.updates != 1 {
+		t.Errorf("drifted object: got %d creates / %d updates, want 0 / 1", counting.creates, counting.updates)
+	}
+	var got corev1.ConfigMap
+	if err := cli.Get(ctx, types.NamespacedName{Name: "cou", Namespace: ns}, &got); err != nil {
+		t.Fatalf("readback: %v", err)
+	}
+	if got.Data["k"] != "v2" {
+		t.Errorf("update did not land: Data[k]=%q, want %q", got.Data["k"], "v2")
+	}
+}


### PR DESCRIPTION
Fixes #330

On a converged cluster, every reconcile pass issued an unconditional `Create` for each owned object (answered with 409 AlreadyExists) and an unconditional `Delete` for each absent optional component (answered with 404 NotFound). The operator tolerated both, so reconciliation succeeded — but the apiserver recorded a steady ~22 err/min stream of 4xx responses that dominated `rest_client_requests_total` and fired false-positive `KubernetesApiClientErrors` P1s.

## Changes

- **`CreateOrUpdate` reads first.** The shared helper now does Get → Create-if-missing → merge/Update-if-changed, instead of Create → handle-AlreadyExists. In production the Get is served from the informer cache, so a converged pass issues no write at all per object. A Create that still races to AlreadyExists (stale cache) falls through to the merge path.
- **Deletes are existence-guarded.** The S3/SFTP gateway teardown (which runs every pass when `spec.s3`/`spec.sftp` is unset), the metricsPort/ingress toggle-off deletes, and the legacy worker StatefulSet cleanup now probe by read and only issue `Delete` when the object exists. The existing `deleteVolumeWorkloadIfExists` already had this shape; it is promoted to a shared `deleteIfExists` helper used by all of these paths.

List-driven prunes (component ingresses, backup mirrors, backup GC) only delete objects a List returned, so they were already quiet and are unchanged.

## Reproduction and test

New envtest test drives the full `Reconcile` loop against a real apiserver through a write-counting client wrapper. Before the fix, one converged pass on a master+volume+filer CR issued:

```
steady-state reconcile issued 10 Create calls answered with 409 AlreadyExists, want 0
steady-state reconcile issued 6 Delete calls answered with 404 NotFound, want 0
```

(the issue's audit table shows the same pattern, plus the ServiceMonitor pair that envtest skips because the Prometheus CRDs are absent)

After the fix, the converged pass issues zero Creates and zero Deletes. A second test pins `CreateOrUpdate` write behavior at the API level: a missing object costs exactly one Create, an unchanged object costs no write, a drifted object costs exactly one Update that lands.

No RBAC changes: every guarded verb already required `get` on the same resources.

Relationship to prior work: #227 slowed the cadence of these errors but not the per-pass pattern; #197 silenced ServiceMonitor errors only when the CRD is absent. This removes the pattern itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved controller reconciliation when gateways, monitoring, ingress, and legacy workloads are disabled or removed.
  * Prevented unnecessary deletion attempts and reduced resource-not-found errors during steady-state operation.
  * Avoided unnecessary resource updates when configuration has not changed.

* **Tests**
  * Added coverage verifying that stable reconciliations produce no unnecessary or failed writes.
  * Added tests for efficient create-or-update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->