### PR TITLE
Scrape admin metrics at /metrics, not behind urlPrefix

### DIFF
--- a/internal/controller/controller_admin_servicemonitor.go
+++ b/internal/controller/controller_admin_servicemonitor.go
@@ -19,7 +19,11 @@ func (r *SeaweedReconciler) createAdminServiceMonitor(m *seaweedv1.Seaweed) *mon
 		Spec: monitorv1.ServiceMonitorSpec{
 			Endpoints: []monitorv1.Endpoint{
 				{
-					Path: adminRoutePath(m.BaseAdminSpec().ExtraArgs(), "/metrics"),
+					// `-metricsPort` starts its own listener on the default
+					// net/http mux, so metrics stay at `/metrics` regardless of
+					// any `-urlPrefix`, which only wraps the admin UI router on
+					// the admin HTTP port.
+					Path: "/metrics",
 					Port: "admin-metrics",
 				},
 			},

--- a/internal/controller/controller_admin_servicemonitor_test.go
+++ b/internal/controller/controller_admin_servicemonitor_test.go
@@ -1,0 +1,52 @@
+package controller
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+)
+
+// The admin metrics listener started by `-metricsPort` runs on its own port and
+// on the default net/http mux, so it always serves `/metrics` at the root. A
+// `-urlPrefix` only affects the admin UI router on the admin HTTP port, and
+// applying it to the scrape path makes Prometheus 404.
+func TestCreateAdminServiceMonitorMetricsPathIgnoresURLPrefix(t *testing.T) {
+	metricsPort := int32(9327)
+	cases := []struct {
+		name      string
+		extraArgs []string
+	}{
+		{"no prefix", nil},
+		{"with prefix", []string{"-urlPrefix=/seaweedfs"}},
+		{"nested prefix", []string{"--urlPrefix", "/ops/admin"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &seaweedv1.Seaweed{
+				ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
+				Spec: seaweedv1.SeaweedSpec{
+					Master: &seaweedv1.MasterSpec{Replicas: 1},
+					Admin: &seaweedv1.AdminSpec{
+						MetricsPort:   &metricsPort,
+						ComponentSpec: seaweedv1.ComponentSpec{ExtraArgs: tc.extraArgs},
+					},
+				},
+			}
+
+			r := &SeaweedReconciler{}
+			sm := r.createAdminServiceMonitor(m)
+
+			if len(sm.Spec.Endpoints) != 1 {
+				t.Fatalf("expected 1 endpoint, got %d", len(sm.Spec.Endpoints))
+			}
+			if got := sm.Spec.Endpoints[0].Path; got != "/metrics" {
+				t.Errorf("endpoint path = %q, want %q", got, "/metrics")
+			}
+			if got := sm.Spec.Endpoints[0].Port; got != "admin-metrics" {
+				t.Errorf("endpoint port = %q, want %q", got, "admin-metrics")
+			}
+		})
+	}
+}

--- a/internal/controller/controller_admin_statefulset.go
+++ b/internal/controller/controller_admin_statefulset.go
@@ -55,11 +55,14 @@ func buildAdminStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string {
 }
 
 // adminURLPrefix scans weed admin ExtraArgs for a -urlPrefix flag and returns
-// its value normalized to a leading slash with no trailing slash. The admin
-// server mounts every route — including `/health` and `/metrics` — behind
-// `http.StripPrefix(urlPrefix, r)` when this flag is set (see upstream
-// weed/command/admin.go), so any k8s probes or ServiceMonitor endpoints must
-// target the prefixed path or they will 404.
+// its value normalized to a leading slash with no trailing slash. When set, the
+// admin server mounts its router behind `http.StripPrefix(urlPrefix, r)` (see
+// upstream weed/command/admin.go), so k8s probes hitting the admin HTTP port
+// must target the prefixed path or they will 404.
+//
+// This applies only to the admin HTTP port. `-metricsPort` starts a separate
+// listener on the default net/http mux, which serves `/metrics` at the root and
+// is never prefixed.
 //
 // Parsing follows the same semantics as upstream's fla9 parser (a clone of
 // Go's `flag` package): a string flag always consumes the next arg as its
@@ -107,7 +110,6 @@ func adminURLPrefix(extraArgs []string) string {
 
 // adminRoutePath returns `route` prefixed with any `-urlPrefix` supplied via
 // the admin ExtraArgs. `route` must already start with a `/`.
-// See issue #204.
 func adminRoutePath(extraArgs []string, route string) string {
 	return adminURLPrefix(extraArgs) + route
 }

--- a/internal/controller/controller_admin_statefulset_test.go
+++ b/internal/controller/controller_admin_statefulset_test.go
@@ -18,15 +18,14 @@ func TestAdminRoutePath(t *testing.T) {
 		want      string
 	}{
 		{"no prefix health", nil, "/health", "/health"},
-		{"no prefix metrics", nil, "/metrics", "/metrics"},
 		{"empty args", []string{}, "/health", "/health"},
 		{"unrelated flag", []string{"-master=m:9333"}, "/health", "/health"},
 		{"single dash equals", []string{"-urlPrefix=/seaweedfs"}, "/health", "/seaweedfs/health"},
-		{"double dash equals", []string{"--urlPrefix=/seaweedfs"}, "/metrics", "/seaweedfs/metrics"},
+		{"double dash equals", []string{"--urlPrefix=/seaweedfs"}, "/health", "/seaweedfs/health"},
 		{"space separated", []string{"-urlPrefix", "/seaweedfs"}, "/health", "/seaweedfs/health"},
 		{"missing leading slash", []string{"-urlPrefix=seaweedfs"}, "/health", "/seaweedfs/health"},
 		{"trailing slash", []string{"-urlPrefix=/seaweedfs/"}, "/health", "/seaweedfs/health"},
-		{"nested prefix", []string{"-urlPrefix=/ops/admin"}, "/metrics", "/ops/admin/metrics"},
+		{"nested prefix", []string{"-urlPrefix=/ops/admin"}, "/health", "/ops/admin/health"},
 		{"empty value", []string{"-urlPrefix="}, "/health", "/health"},
 		{"last occurrence wins", []string{"-urlPrefix=/a", "-urlPrefix=/b"}, "/health", "/b/health"},
 		{"prefix among other args", []string{"-foo=bar", "-urlPrefix=/x", "-baz"}, "/health", "/x/health"},


### PR DESCRIPTION
Fixes #332.

## Problem

With `spec.admin.extraArgs: ["-urlPrefix=/seaweedfs"]` and `spec.admin.metricsPort: 9327`, the generated ServiceMonitor scrapes `/seaweedfs/metrics` and Prometheus gets a 404.

## Root cause

`-urlPrefix` only applies to the admin UI router, which upstream wraps in `http.StripPrefix(urlPrefix, r)` on the **admin HTTP port**:

```go
// weed/command/admin.go
if urlPrefix != "" {
    stripped := http.StripPrefix(urlPrefix, r)
    ...
}
```

`-metricsPort` is a completely separate listener started before that router is built:

```go
// weed/command/admin.go
go stats_collect.StartMetricsServer(*a.metricsHttpIp, *a.metricsHttpPort)

// weed/stats/metrics.go
func StartMetricsServer(ip string, port int) {
    if port == 0 { return }
    http.Handle("/metrics", promhttp.HandlerFor(Gather, promhttp.HandlerOpts{}))
    glog.Fatal(http.ListenAndServe(JoinHostPort(ip, port), nil))
}
```

It registers `/metrics` on the default `net/http` mux and never sees the prefix. The ServiceMonitor endpoint already targets that separate `admin-metrics` port, so the path must stay at the root — this is Option 2 from the issue, and it matches every other component's ServiceMonitor (master, filer, s3, volume, sftp, worker all use a bare `/metrics`).

The prefixing was introduced in 243040f under the assumption that "the admin mux serves both `/health` and `/metrics` on the same router", which is not the case.

## Changes

- `createAdminServiceMonitor` uses a plain `/metrics` path again.
- Corrected the `adminURLPrefix` doc comment that claimed the prefix covers `/metrics`; it now states the metrics listener is separate and unprefixed.
- Added `TestCreateAdminServiceMonitorMetricsPathIgnoresURLPrefix` covering no prefix, `-urlPrefix=/seaweedfs`, and a nested space-separated prefix.
- Retargeted the two `TestAdminRoutePath` cases that used `/metrics` to `/health`, since `adminRoutePath` now only serves admin-HTTP-port routes.

Health probes are unchanged — they still go through `adminRoutePath`, because they do hit the prefixed router on the admin HTTP port.

## Testing

`go build ./...`, `go vet`, and `go test ./internal/controller/` all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed admin metrics monitoring to consistently scrape the `/metrics` endpoint, regardless of configured URL prefixes.
  * Preserved correct URL-prefix behavior for health-check routes.

* **Documentation**
  * Clarified how URL prefixes apply to admin HTTP routes and how metrics remain available at the root path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->