### PR TITLE
Make spec.anonymousRead actually grant anonymous read access

### DIFF
--- a/api/v1/bucket_types.go
+++ b/api/v1/bucket_types.go
@@ -276,8 +276,14 @@ type BucketSpec struct {
 	// +optional
 	Placement *BucketPlacement `json:"placement,omitempty"`
 
-	// AnonymousRead exposes the bucket for unauthenticated read via a
-	// public-read bucket policy. Defaults to false.
+	// AnonymousRead grants the reserved "anonymous" identity — the one
+	// unauthenticated S3 requests resolve to — Read on this bucket,
+	// allowing objects to be downloaded by URL without credentials.
+	// Setting it back to false revokes the grant. Defaults to false.
+	//
+	// List is not granted, so anonymous callers cannot enumerate the
+	// bucket. For that, add an access entry for user "anonymous" with the
+	// List action; its actions merge with the Read granted here.
 	// +optional
 	// +kubebuilder:default:=false
 	AnonymousRead bool `json:"anonymousRead,omitempty"`

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -52,6 +52,11 @@ const (
 	// Stored as a comma-joined sorted list of identity names.
 	AnnotationAppliedAccess = "bucket.seaweed.seaweedfs.com/applied-access"
 
+	// AnonymousIdentity is the reserved IAM identity unauthenticated S3
+	// requests resolve to; its bucket grants are what the S3 gateway
+	// consults to authorize anonymous access.
+	AnonymousIdentity = "anonymous"
+
 	// requeueAfterTransient is the backoff used when an external
 	// dependency (the filer, an IAM identity) is missing but expected to
 	// arrive shortly.
@@ -314,10 +319,17 @@ func (r *BucketReconciler) reconcileBucket(ctx context.Context, bucket *seaweedv
 	// list (recorded as an annotation). Users no longer in spec have
 	// their bucket grants stripped; users in spec get their actions
 	// (re)set to the requested set.
+	// anonymousRead goes through the same map so it revokes by the same
+	// path, and merges with an explicit "anonymous" grant instead of the
+	// two overwriting each other — SetAccess replaces all of an identity's
+	// actions on the bucket.
 	prevUsers := readAppliedAccessAnnotation(bucket)
 	desired := map[string]string{}
 	for _, g := range bucket.Spec.Access {
 		desired[g.User] = joinActions(g.Actions)
+	}
+	if bucket.Spec.AnonymousRead {
+		desired[AnonymousIdentity] = withAnonymousRead(desired[AnonymousIdentity])
 	}
 	for user, actions := range desired {
 		if err := admin.SetAccess(ctx, bucketName, user, actions); err != nil {
@@ -553,6 +565,24 @@ func joinActions(actions []seaweedv1.BucketAccessAction) string {
 	}
 	sort.Strings(parts)
 	return strings.Join(parts, ",")
+}
+
+// withAnonymousRead unions Read into a comma-joined action list, sorted like
+// joinActions so the grant is stable across passes. "none" (joinActions'
+// empty form) counts as no actions, not as an action name.
+func withAnonymousRead(actions string) string {
+	set := map[string]bool{string(seaweedv1.BucketAccessRead): true}
+	for _, a := range strings.Split(actions, ",") {
+		if a = strings.TrimSpace(a); a != "" && !strings.EqualFold(a, "none") {
+			set[a] = true
+		}
+	}
+	out := make([]string, 0, len(set))
+	for a := range set {
+		out = append(out, a)
+	}
+	sort.Strings(out)
+	return strings.Join(out, ",")
 }
 
 // placementArgs flattens the BucketPlacement struct into the argv form

--- a/internal/controller/bucket_controller_test.go
+++ b/internal/controller/bucket_controller_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"errors"
+	"reflect"
 	"sort"
 	"strings"
 	"testing"
@@ -1065,8 +1066,11 @@ func TestReconcile_AnonymousReadGrantsAnonymousIdentity(t *testing.T) {
 
 	reconcileUntilStable(t, r, key, 5)
 
-	if !hasCall(fa.calls, "Access:photos:anonymous:Read") {
-		t.Errorf("anonymousRead did not grant the anonymous identity Read; calls=%v", fa.calls)
+	// Exactly one grant, carrying Read and nothing else — a second call or a
+	// stray List would both widen anonymous access past what is documented.
+	want := []string{"Access:photos:anonymous:Read"}
+	if got := callsFor(fa.calls, "Access:photos:anonymous:"); !reflect.DeepEqual(got, want) {
+		t.Errorf("anonymous access calls = %v want %v; calls=%v", got, want, fa.calls)
 	}
 
 	// Must be recorded as applied so disabling the flag later revokes.
@@ -1125,16 +1129,13 @@ func TestReconcile_AnonymousReadMergesWithExplicitAccessGrant(t *testing.T) {
 
 	reconcileUntilStable(t, r, key, 5)
 
-	if !hasCall(fa.calls, "Access:photos:anonymous:List,Read") {
-		t.Errorf("anonymous grant was not merged with spec.access; calls=%v", fa.calls)
+	// One merged call, not two that would each strip the other's actions.
+	want := []string{"Access:photos:anonymous:List,Read"}
+	if got := callsFor(fa.calls, "Access:photos:anonymous:"); !reflect.DeepEqual(got, want) {
+		t.Errorf("anonymous access calls = %v want %v; calls=%v", got, want, fa.calls)
 	}
-	if !hasCall(fa.calls, "Access:photos:alice:Write") {
+	if got := callsFor(fa.calls, "Access:photos:alice:"); !hasCall(got, "Access:photos:alice:Write") {
 		t.Errorf("unrelated grant was disturbed; calls=%v", fa.calls)
-	}
-	for _, c := range fa.calls {
-		if c == "Access:photos:anonymous:Read" {
-			t.Errorf("anonymous received a second, conflicting grant; calls=%v", fa.calls)
-		}
 	}
 }
 
@@ -1145,6 +1146,19 @@ func hasCall(calls []string, want string) bool {
 		}
 	}
 	return false
+}
+
+// callsFor returns every recorded call carrying prefix, so a test can assert
+// the complete set of calls made against one identity rather than just the
+// presence of one.
+func callsFor(calls []string, prefix string) []string {
+	var out []string
+	for _, c := range calls {
+		if strings.HasPrefix(c, prefix) {
+			out = append(out, c)
+		}
+	}
+	return out
 }
 
 func TestWithAnonymousRead(t *testing.T) {

--- a/internal/controller/bucket_controller_test.go
+++ b/internal/controller/bucket_controller_test.go
@@ -1053,6 +1053,116 @@ func TestReconcile_AccessRevokesRemovedUsers(t *testing.T) {
 	}
 }
 
+// anonymousRead was stored but never read by the reconciler, so buckets
+// created with it still refused unauthenticated GETs.
+func TestReconcile_AnonymousReadGrantsAnonymousIdentity(t *testing.T) {
+	bucket := newTestBucket("photos")
+	bucket.Spec.AnonymousRead = true
+
+	fa := newFakeAdmin()
+	r, cli := testReconciler(t, fa, newTestSeaweed(), bucket)
+	key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
+
+	reconcileUntilStable(t, r, key, 5)
+
+	if !hasCall(fa.calls, "Access:photos:anonymous:Read") {
+		t.Errorf("anonymousRead did not grant the anonymous identity Read; calls=%v", fa.calls)
+	}
+
+	// Must be recorded as applied so disabling the flag later revokes.
+	got := &seaweedv1.Bucket{}
+	if err := cli.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	if got.Annotations[AnnotationAppliedAccess] != "anonymous" {
+		t.Errorf("applied-access annotation = %q want %q",
+			got.Annotations[AnnotationAppliedAccess], "anonymous")
+	}
+}
+
+// Disabling the flag must strip the grant, not leave the bucket world-readable.
+func TestReconcile_AnonymousReadDisabledRevokesGrant(t *testing.T) {
+	bucket := newTestBucket("photos")
+	bucket.Spec.AnonymousRead = false
+	bucket.Annotations = map[string]string{AnnotationAppliedAccess: "anonymous"}
+	bucket.Status.BucketName = "photos"
+	bucket.Finalizers = []string{BucketFinalizer}
+
+	fa := newFakeAdmin()
+	fa.existsResp["photos"] = true
+	r, cli := testReconciler(t, fa, newTestSeaweed(), bucket)
+	key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
+
+	reconcileUntilStable(t, r, key, 5)
+
+	if !hasCall(fa.calls, "Access:photos:anonymous:none") {
+		t.Errorf("disabling anonymousRead did not revoke the anonymous grant; calls=%v", fa.calls)
+	}
+
+	got := &seaweedv1.Bucket{}
+	if err := cli.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	if got.Annotations[AnnotationAppliedAccess] != "" {
+		t.Errorf("applied-access annotation = %q want empty",
+			got.Annotations[AnnotationAppliedAccess])
+	}
+}
+
+// SetAccess strips every existing action for the bucket, so a flag-driven and
+// an explicit "anonymous" grant must merge into one call, not overwrite.
+func TestReconcile_AnonymousReadMergesWithExplicitAccessGrant(t *testing.T) {
+	bucket := newTestBucket("photos")
+	bucket.Spec.AnonymousRead = true
+	bucket.Spec.Access = []seaweedv1.BucketAccessGrant{
+		{User: "anonymous", Actions: []seaweedv1.BucketAccessAction{seaweedv1.BucketAccessList}},
+		{User: "alice", Actions: []seaweedv1.BucketAccessAction{seaweedv1.BucketAccessWrite}},
+	}
+
+	fa := newFakeAdmin()
+	r, _ := testReconciler(t, fa, newTestSeaweed(), bucket)
+	key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
+
+	reconcileUntilStable(t, r, key, 5)
+
+	if !hasCall(fa.calls, "Access:photos:anonymous:List,Read") {
+		t.Errorf("anonymous grant was not merged with spec.access; calls=%v", fa.calls)
+	}
+	if !hasCall(fa.calls, "Access:photos:alice:Write") {
+		t.Errorf("unrelated grant was disturbed; calls=%v", fa.calls)
+	}
+	for _, c := range fa.calls {
+		if c == "Access:photos:anonymous:Read" {
+			t.Errorf("anonymous received a second, conflicting grant; calls=%v", fa.calls)
+		}
+	}
+}
+
+func hasCall(calls []string, want string) bool {
+	for _, c := range calls {
+		if c == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestWithAnonymousRead(t *testing.T) {
+	cases := map[string]string{
+		"":              "Read",
+		"none":          "Read",
+		"Read":          "Read",
+		"List":          "List,Read",
+		"Write,List":    "List,Read,Write",
+		"Read, Tagging": "Read,Tagging",
+	}
+	for in, want := range cases {
+		if got := withAnonymousRead(in); got != want {
+			t.Errorf("withAnonymousRead(%q) = %q want %q", in, got, want)
+		}
+	}
+}
+
 func TestQuantityToMiB(t *testing.T) {
 	cases := map[string]struct {
 		q       string


### PR DESCRIPTION
Closes #334

## Problem

`spec.anonymousRead` was a no-op. The field was declared in `api/v1/bucket_types.go`, served by the CRD, and defaulted to `false` — but `grep -rn AnonymousRead internal/ cmd/` returned zero hits. Nothing in the reconciler ever read it.

So the bucket was created and every other field (owner, access, quota, placement) was applied, while the anonymous flag was silently dropped — matching the report: "bucket created successfully but I can't download file from browser without credential."

Reproduced by test: with `anonymousRead: true`, the reconciler emitted only `Exists:photos`, `Create:photos` — no access call at all.

## Fix

Unauthenticated S3 requests resolve to the reserved `anonymous` identity, and the gateway authorizes them off that identity's bucket-scoped actions — the same thing upstream `weed shell s3.anonymous.set` manipulates. `GetObjectHandler`/`HeadObjectHandler` bind to `ACTION_READ`, so a `Read` grant is exactly what a browser download needs.

The operator already had the right primitive (`admin.SetAccess`, whose `setBucketActions` is equivalent to upstream's), so the flag folds into the existing declarative access map:

```go
if bucket.Spec.AnonymousRead {
    desired[AnonymousIdentity] = withAnonymousRead(desired[AnonymousIdentity])
}
```

Routing it through that map rather than adding a separate call buys two things:

- **Revocation is free.** Flipping the flag off drops `anonymous` from `desired` while it is still in the applied-access annotation, so the existing revoke loop strips the grant. A one-off call would have left buckets world-readable forever.
- **No fight with `spec.access`.** `SetAccess` replaces *all* of an identity's actions on a bucket, so if someone hand-wrote an `anonymous` entry (a plausible workaround while the field was broken), two separate calls would clobber each other on every pass. `withAnonymousRead` unions instead, and sorts to match `joinActions` so the grant is stable across resyncs.

### Read, not List

`Read` only, deliberately. It matches the field name and is what the reported symptom needs; `List` would expose bucket enumeration, a meaningfully larger blast radius than "read". Users who want a publicly listable bucket can add an explicit `anonymous` entry with `List`, which now merges cleanly. This is documented on the field.

The field's doc comment also described a public-read *bucket policy* mechanism that was never implemented; corrected to describe what actually happens.

## Tests

Four added in `bucket_controller_test.go` — grant, revoke-on-disable, merge-with-explicit-grant, and a table test for the helper. The grant and merge tests were verified to genuinely fail without the fix.

## Notes

- `make manifests` produces no CRD diff: the repo generates with `crd:maxDescLen=0`, which strips descriptions, so the doc changes are Go-source-only.
- The e2e suite fails locally in `BeforeSuite` at `make kind-load` (no kind cluster available in this environment), unrelated to this change. All other packages pass, `go vet` and `gofmt` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for granting buckets anonymous read access via the `anonymousRead` setting.
  * Anonymous read permissions are merged into existing access grants to avoid duplicate/conflicting rules.
  * Anonymous access grants read access only; listing contents requires an explicit list grant.
* **Documentation**
  * Expanded documentation on how unauthenticated (S3 anonymous) requests map to anonymous read permissions, including revocation when disabled.
* **Bug Fixes**
  * Ensures anonymous read grants are correctly applied, revoked, and reconciled when bucket access settings change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->