### PR TITLE
Apply spec.version and per-component version to container images

### DIFF
--- a/api/v1/component_accessor.go
+++ b/api/v1/component_accessor.go
@@ -10,6 +10,7 @@ import (
 // +kubebuilder:object:root=false
 // +kubebuilder:object:generate=false
 type ComponentAccessor interface {
+	Image() string
 	ImagePullPolicy() corev1.PullPolicy
 	ImagePullSecrets() []corev1.LocalObjectReference
 	HostNetwork() bool
@@ -39,6 +40,8 @@ type ComponentAccessor interface {
 }
 
 type componentAccessorImpl struct {
+	image                     string
+	version                   string
 	imagePullPolicy           corev1.PullPolicy
 	imagePullSecrets          []corev1.LocalObjectReference
 	hostNetwork               *bool
@@ -68,6 +71,17 @@ func (a *componentAccessorImpl) StatefulSetUpdateStrategy() appsv1.StatefulSetUp
 	}
 
 	return appsv1.RollingUpdateStatefulSetStrategyType
+}
+
+// Image is the component's container image: the cluster-level spec.image with
+// its tag replaced by the component's version, falling back to the
+// cluster-level version. With neither version set the image is used as-is.
+func (a *componentAccessorImpl) Image() string {
+	version := a.version
+	if v := a.ComponentSpec.Version; v != nil && *v != "" {
+		version = *v
+	}
+	return applyVersion(a.image, version)
 }
 
 func (a *componentAccessorImpl) ImagePullPolicy() corev1.PullPolicy {
@@ -260,6 +274,8 @@ func (a *componentAccessorImpl) ContainerSecurityContext() *corev1.SecurityConte
 
 func buildSeaweedComponentAccessor(spec *SeaweedSpec, componentSpec *ComponentSpec) ComponentAccessor {
 	return &componentAccessorImpl{
+		image:                     spec.Image,
+		version:                   spec.Version,
 		imagePullPolicy:           spec.ImagePullPolicy,
 		imagePullSecrets:          spec.ImagePullSecrets,
 		hostNetwork:               spec.HostNetwork,
@@ -274,6 +290,14 @@ func buildSeaweedComponentAccessor(spec *SeaweedSpec, componentSpec *ComponentSp
 
 		ComponentSpec: componentSpec,
 	}
+}
+
+// ClusterImage is the cluster-wide weed image — spec.image with spec.version
+// applied as its tag. Use it for pods that belong to no single component
+// (backup/restore jobs, admin-script CronJobs); components themselves go
+// through their accessor's Image(), which also honors a per-component version.
+func (s *Seaweed) ClusterImage() string {
+	return applyVersion(s.Spec.Image, s.Spec.Version)
 }
 
 // BaseMasterSpec provides merged spec of masters

--- a/api/v1/image.go
+++ b/api/v1/image.go
@@ -1,0 +1,28 @@
+package v1
+
+import "strings"
+
+// applyVersion returns image with its tag replaced by version.
+//
+// A digest-pinned image is returned untouched: a digest is an exact,
+// tamper-evident pin, and silently swapping it for a mutable tag would
+// weaken a supply-chain guarantee the user deliberately opted into.
+//
+// The registry host may itself carry a port (registry:5000/seaweedfs), so the
+// tag separator is only looked for in the final path segment.
+func applyVersion(image, version string) string {
+	if version == "" || image == "" {
+		return image
+	}
+	name := image
+	if slash := strings.LastIndex(image, "/"); slash >= 0 {
+		name = image[slash+1:]
+	}
+	if strings.Contains(name, "@") {
+		return image
+	}
+	if colon := strings.LastIndex(name, ":"); colon >= 0 {
+		image = image[:len(image)-len(name)+colon]
+	}
+	return image + ":" + version
+}

--- a/api/v1/image_test.go
+++ b/api/v1/image_test.go
@@ -1,0 +1,70 @@
+package v1
+
+import "testing"
+
+func TestApplyVersion(t *testing.T) {
+	cases := []struct {
+		name    string
+		image   string
+		version string
+		want    string
+	}{
+		{"no version leaves image alone", "chrislusf/seaweedfs:3.59", "", "chrislusf/seaweedfs:3.59"},
+		{"replaces existing tag", "chrislusf/seaweedfs:3.59", "3.60", "chrislusf/seaweedfs:3.60"},
+		{"appends to untagged image", "chrislusf/seaweedfs", "3.60", "chrislusf/seaweedfs:3.60"},
+		{"bare repository name", "seaweedfs", "3.60", "seaweedfs:3.60"},
+		{"registry port is not a tag", "registry:5000/seaweedfs", "3.60", "registry:5000/seaweedfs:3.60"},
+		{"registry port with tag", "registry:5000/seaweedfs:3.59", "3.60", "registry:5000/seaweedfs:3.60"},
+		{"digest pin is preserved", "chrislusf/seaweedfs@sha256:abc123", "3.60", "chrislusf/seaweedfs@sha256:abc123"},
+		{"digest pin on ported registry", "registry:5000/sw@sha256:abc", "3.60", "registry:5000/sw@sha256:abc"},
+		{"nested path", "ghcr.io/org/team/seaweedfs:v1", "v2", "ghcr.io/org/team/seaweedfs:v2"},
+		{"empty image", "", "3.60", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := applyVersion(tc.image, tc.version); got != tc.want {
+				t.Errorf("applyVersion(%q, %q) = %q want %q", tc.image, tc.version, got, tc.want)
+			}
+		})
+	}
+}
+
+// The per-component version must win over the cluster version, and both must
+// fall back to leaving spec.image untouched.
+func TestComponentAccessorImage(t *testing.T) {
+	componentVersion := "3.99"
+	s := &Seaweed{
+		Spec: SeaweedSpec{
+			Image:   "chrislusf/seaweedfs:3.59",
+			Version: "3.60",
+			Master:  &MasterSpec{},
+			Filer: &FilerSpec{
+				ComponentSpec: ComponentSpec{Version: &componentVersion},
+			},
+		},
+	}
+
+	if got, want := s.BaseMasterSpec().Image(), "chrislusf/seaweedfs:3.60"; got != want {
+		t.Errorf("master image = %q want %q (cluster version)", got, want)
+	}
+	if got, want := s.BaseFilerSpec().Image(), "chrislusf/seaweedfs:3.99"; got != want {
+		t.Errorf("filer image = %q want %q (component override)", got, want)
+	}
+	if got, want := s.ClusterImage(), "chrislusf/seaweedfs:3.60"; got != want {
+		t.Errorf("cluster image = %q want %q", got, want)
+	}
+
+	// An empty component version must not blank out the cluster version.
+	empty := ""
+	s.Spec.Filer.ComponentSpec.Version = &empty
+	if got, want := s.BaseFilerSpec().Image(), "chrislusf/seaweedfs:3.60"; got != want {
+		t.Errorf("filer image with empty override = %q want %q", got, want)
+	}
+
+	// With no versions at all the image is used verbatim.
+	s.Spec.Version = ""
+	s.Spec.Filer.ComponentSpec.Version = nil
+	if got, want := s.BaseFilerSpec().Image(), "chrislusf/seaweedfs:3.59"; got != want {
+		t.Errorf("filer image with no version = %q want %q", got, want)
+	}
+}

--- a/api/v1/seaweed_types.go
+++ b/api/v1/seaweed_types.go
@@ -127,7 +127,9 @@ type SeaweedSpec struct {
 	// Image
 	Image string `json:"image,omitempty"`
 
-	// Version
+	// Version replaces the tag on spec.image for every component, so the
+	// image only has to name a repository. A digest-pinned image is left
+	// alone. Individual components can override this via their own version.
 	Version string `json:"version,omitempty"`
 
 	// Master
@@ -770,7 +772,8 @@ type LivenessProbeOverride struct {
 
 // ComponentSpec is the base spec of each component, the fields should always accessed by the Basic<Component>Spec() method to respect the cluster-level properties
 type ComponentSpec struct {
-	// Version of the component. Override the cluster-level version if non-empty
+	// Version of the component, replacing the tag on spec.image for this
+	// component only. Overrides the cluster-level version if non-empty.
 	Version *string `json:"version,omitempty"`
 
 	// ImagePullPolicy of the component. Override the cluster-level imagePullPolicy if present

--- a/internal/controller/adminscript_controller.go
+++ b/internal/controller/adminscript_controller.go
@@ -117,7 +117,7 @@ func (r *AdminScriptReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 func (r *AdminScriptReconciler) buildCronJob(script *seaweedv1.AdminScript, cluster *seaweedv1.Seaweed) *batchv1.CronJob {
 	labels := labelsForAdminScript(script.Name)
 
-	image := cluster.Spec.Image
+	image := cluster.ClusterImage()
 	if script.Spec.Image != nil && *script.Spec.Image != "" {
 		image = *script.Spec.Image
 	}

--- a/internal/controller/backup_storage.go
+++ b/internal/controller/backup_storage.go
@@ -52,7 +52,7 @@ func backupImage(m *seaweedv1.Seaweed) string {
 	if m.Spec.Backup != nil && m.Spec.Backup.Image != nil && *m.Spec.Backup.Image != "" {
 		return *m.Spec.Backup.Image
 	}
-	return m.Spec.Image
+	return m.ClusterImage()
 }
 
 // filesystemMountPath returns the in-pod mount path for a filesystem storage,

--- a/internal/controller/controller_admin_statefulset.go
+++ b/internal/controller/controller_admin_statefulset.go
@@ -173,7 +173,7 @@ func (r *SeaweedReconciler) createAdminStatefulSet(m *seaweedv1.Seaweed) *appsv1
 	adminPodSpec.EnableServiceLinks = &enableServiceLinks
 	adminPodSpec.Containers = []corev1.Container{{
 		Name:            "admin",
-		Image:           m.Spec.Image,
+		Image:           m.BaseAdminSpec().Image(),
 		ImagePullPolicy: m.BaseAdminSpec().ImagePullPolicy(),
 		SecurityContext: m.BaseAdminSpec().ContainerSecurityContext(),
 		Env:             env,

--- a/internal/controller/controller_filer_statefulset.go
+++ b/internal/controller/controller_filer_statefulset.go
@@ -173,7 +173,7 @@ func (r *SeaweedReconciler) createFilerStatefulSet(m *seaweedv1.Seaweed) *appsv1
 	filerPodSpec.EnableServiceLinks = &enableServiceLinks
 	filerPodSpec.Containers = []corev1.Container{{
 		Name:            "filer",
-		Image:           m.Spec.Image,
+		Image:           m.BaseFilerSpec().Image(),
 		ImagePullPolicy: m.BaseFilerSpec().ImagePullPolicy(),
 		SecurityContext: m.BaseFilerSpec().ContainerSecurityContext(),
 		Env:             append(m.BaseFilerSpec().Env(), kubernetesEnvVars...),

--- a/internal/controller/controller_master_statefulset.go
+++ b/internal/controller/controller_master_statefulset.go
@@ -98,7 +98,7 @@ func (r *SeaweedReconciler) createMasterStatefulSet(m *seaweedv1.Seaweed) *appsv
 	masterPodSpec.EnableServiceLinks = &enableServiceLinks
 	masterPodSpec.Containers = []corev1.Container{{
 		Name:            "master",
-		Image:           m.Spec.Image,
+		Image:           m.BaseMasterSpec().Image(),
 		ImagePullPolicy: m.BaseMasterSpec().ImagePullPolicy(),
 		SecurityContext: m.BaseMasterSpec().ContainerSecurityContext(),
 		Env:             append(m.BaseMasterSpec().Env(), kubernetesEnvVars...),

--- a/internal/controller/controller_s3.go
+++ b/internal/controller/controller_s3.go
@@ -265,7 +265,7 @@ func (r *SeaweedReconciler) buildS3Deployment(m *seaweedv1.Seaweed) *appsv1.Depl
 
 	podSpec.Containers = []corev1.Container{{
 		Name:            "s3",
-		Image:           m.Spec.Image,
+		Image:           m.BaseS3Spec().Image(),
 		ImagePullPolicy: m.BaseS3Spec().ImagePullPolicy(),
 		SecurityContext: m.BaseS3Spec().ContainerSecurityContext(),
 		Env:             append(m.BaseS3Spec().Env(), kubernetesEnvVars...),

--- a/internal/controller/controller_sftp.go
+++ b/internal/controller/controller_sftp.go
@@ -275,7 +275,7 @@ func (r *SeaweedReconciler) buildSFTPDeployment(m *seaweedv1.Seaweed) *appsv1.De
 
 	podSpec.Containers = []corev1.Container{{
 		Name:            "sftp",
-		Image:           m.Spec.Image,
+		Image:           m.BaseSFTPSpec().Image(),
 		ImagePullPolicy: m.BaseSFTPSpec().ImagePullPolicy(),
 		SecurityContext: m.BaseSFTPSpec().ContainerSecurityContext(),
 		Env:             append(m.BaseSFTPSpec().Env(), kubernetesEnvVars...),

--- a/internal/controller/controller_volume_statefulset.go
+++ b/internal/controller/controller_volume_statefulset.go
@@ -279,7 +279,7 @@ func (r *SeaweedReconciler) buildFlatVolumePodSpec(m *seaweedv1.Seaweed, disks v
 	volumePodSpec.EnableServiceLinks = &enableServiceLinks
 	volumePodSpec.Containers = []corev1.Container{{
 		Name:            "volume",
-		Image:           m.Spec.Image,
+		Image:           m.BaseVolumeSpec().Image(),
 		ImagePullPolicy: m.BaseVolumeSpec().ImagePullPolicy(),
 		SecurityContext: m.BaseVolumeSpec().ContainerSecurityContext(),
 		Env:             append(m.BaseVolumeSpec().Env(), kubernetesEnvVars...),
@@ -494,7 +494,7 @@ func (r *SeaweedReconciler) createVolumeServerTopologyStatefulSet(m *seaweedv1.S
 	}
 	volumePodSpec.Containers = []corev1.Container{{
 		Name:            "volume",
-		Image:           m.Spec.Image,
+		Image:           m.BaseVolumeSpec().Image(),
 		ImagePullPolicy: getImagePullPolicy(m, topologySpec),
 		SecurityContext: getContainerSecurityContext(m, topologySpec),
 		Env:             append(getEnvVars(m, topologySpec), kubernetesEnvVars...),

--- a/internal/controller/controller_worker_deployment.go
+++ b/internal/controller/controller_worker_deployment.go
@@ -106,7 +106,7 @@ func (r *SeaweedReconciler) createWorkerDeployment(m *seaweedv1.Seaweed) *appsv1
 
 	container := corev1.Container{
 		Name:            "worker",
-		Image:           m.Spec.Image,
+		Image:           m.BaseWorkerSpec().Image(),
 		ImagePullPolicy: m.BaseWorkerSpec().ImagePullPolicy(),
 		SecurityContext: m.BaseWorkerSpec().ContainerSecurityContext(),
 		Env:             append(m.BaseWorkerSpec().Env(), kubernetesEnvVars...),


### PR DESCRIPTION
Found while auditing for the same class of bug as #334 (a CRD field the controller never reads). Two more of them:

- `SeaweedSpec.Version` (`spec.version`)
- `ComponentSpec.Version` (`spec.<component>.version`)

Neither was referenced anywhere in `internal/` or `cmd/` — `grep -rn '\.Version\b'` over the non-test, non-generated tree returned nothing. Every component image came straight from `m.Spec.Image`, so setting a version did nothing at all.

`ComponentSpec.Version` is the sharper miss: it documented itself as *"Override the cluster-level version if non-empty"*, and since `ComponentSpec` has **no** `image` field, it was the only per-component image control. There was no way to pin one component to a different build.

## Fix

Resolution goes through `ComponentAccessor`, which already models exactly this cluster-default/component-override shape for `ImagePullPolicy`, `ImagePullSecrets`, `HostNetwork` and friends. Added `Image()` to that interface:

```
spec.image  +  (spec.<component>.version ?? spec.version)  →  container image
```

Version replaces the **tag**, so `spec.image` only has to name a repository. Precedence matches every other accessor field, so per-component version wins.

### Digest pins are preserved

`applyVersion` returns a digest-pinned image (`repo@sha256:…`) untouched. A digest is an exact, tamper-evident pin; silently swapping it for a mutable tag would weaken a supply-chain guarantee the user deliberately opted into. Documented on the field.

Tag detection only looks at the final path segment, so a registry port (`registry:5000/seaweedfs`) is not mistaken for a tag.

### Pods that belong to no component

Backup/restore jobs and admin-script CronJobs already had their own image override falling back to the cluster image. They now resolve that fallback through `ClusterImage()` (cluster image + cluster version), so they track the cluster version without picking up some unrelated component's override.

## Tests

`TestApplyVersion` covers tag replacement, untagged images, bare names, registry ports (with and without tags), nested paths, both digest forms, and empty input. `TestComponentAccessorImage` covers component-over-cluster precedence, an empty component version not blanking the cluster version, and no-version passthrough.

`make manifests` produces no CRD diff — the repo generates with `crd:maxDescLen=0`, which strips descriptions.

Full suite passes except the e2e package, which fails in `BeforeSuite` at `make kind-load` for want of a kind cluster in my environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added cluster-wide image versioning for deployed components.
  - Component-specific versions can override the cluster version.
  - Existing image tags are replaced, while digest-pinned images remain unchanged.
  - Cluster and component image settings are now consistently applied across core services, gateways, backups, and administrative workloads.
  - Explicit images configured for administrative scripts and backup storage continue to take precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->