### PR TITLE
Pass spec.filer.maxMB to the filer

### DIFF
--- a/api/v1/seaweed_types.go
+++ b/api/v1/seaweed_types.go
@@ -606,6 +606,9 @@ type FilerSpec struct {
 
 	// Filer-specific settings
 
+	// MaxMB is the chunk size in MiB the filer splits larger files into.
+	// Omit to leave the filer at its own default (4).
+	// +kubebuilder:validation:Minimum=1
 	MaxMB *int32 `json:"maxMB,omitempty"`
 	// S3 configuration for the filer
 	S3 *S3Config `json:"s3,omitempty"`

--- a/config/crd/bases/seaweed.seaweedfs.com_seaweeds.yaml
+++ b/config/crd/bases/seaweed.seaweedfs.com_seaweeds.yaml
@@ -3015,6 +3015,7 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                   maxMB:
+                    minimum: 1
                     type: integer
                   metricsPort:
                     type: integer

--- a/deploy/helm/templates/crd-seaweed.yaml
+++ b/deploy/helm/templates/crd-seaweed.yaml
@@ -6219,6 +6219,7 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     maxMB:
+                      minimum: 1
                       type: integer
                     metricsPort:
                       type: integer

--- a/internal/controller/controller_filer_statefulset.go
+++ b/internal/controller/controller_filer_statefulset.go
@@ -33,6 +33,9 @@ func buildFilerStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string {
 	if m.Spec.Filer.MetricsPort != nil {
 		commands = append(commands, fmt.Sprintf("-metricsPort=%d", *m.Spec.Filer.MetricsPort))
 	}
+	if m.Spec.Filer.MaxMB != nil {
+		commands = append(commands, fmt.Sprintf("-maxMB=%d", *m.Spec.Filer.MaxMB))
+	}
 	if m.Spec.Filer.Iceberg != nil && m.Spec.Filer.Iceberg.Enabled {
 		commands = append(commands, fmt.Sprintf("-icebergPort=%d", m.Spec.Filer.Iceberg.IcebergEffectivePort()))
 	}

--- a/internal/controller/controller_filer_statefulset_test.go
+++ b/internal/controller/controller_filer_statefulset_test.go
@@ -23,6 +23,35 @@ func filerContainer(t *testing.T, sts *corev1.PodSpec) *corev1.Container {
 	return nil
 }
 
+// spec.filer.maxMB was served by the CRD but never reached the filer, so the
+// chunk size stayed at weed's built-in default no matter what was set.
+func TestBuildFilerStartupScript_MaxMB(t *testing.T) {
+	newFiler := func(maxMB *int32) *seaweedv1.Seaweed {
+		return &seaweedv1.Seaweed{
+			ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
+			Spec: seaweedv1.SeaweedSpec{
+				Master: &seaweedv1.MasterSpec{Replicas: 1},
+				Filer:  &seaweedv1.FilerSpec{Replicas: 1, MaxMB: maxMB},
+			},
+		}
+	}
+
+	t.Run("set value is passed through", func(t *testing.T) {
+		maxMB := int32(32)
+		if got := buildFilerStartupScript(newFiler(&maxMB)); !strings.Contains(got, "-maxMB=32") {
+			t.Errorf("expected -maxMB=32 in startup script, got %q", got)
+		}
+	})
+
+	// Unset must stay absent rather than emit -maxMB=0, which would tell the
+	// filer never to chunk instead of leaving it at its own default.
+	t.Run("unset omits the flag", func(t *testing.T) {
+		if got := buildFilerStartupScript(newFiler(nil)); strings.Contains(got, "-maxMB") {
+			t.Errorf("expected no -maxMB flag when unset, got %q", got)
+		}
+	})
+}
+
 // On a fresh, no-TLS install the operator used to mount a security.toml that
 // enabled [jwt.filer_signing.read], which made the filer demand a signed JWT
 // on every GET. The readiness/liveness probe is an unauthenticated GET / on


### PR DESCRIPTION
Another dead CRD field found in the same audit as #334 and #336: `FilerSpec.MaxMB` (`spec.filer.maxMB`).

It appeared exactly once in the whole repo — its own declaration in `api/v1/seaweed_types.go`. Nothing built it into the filer's argv, so the filer always ran at weed's built-in 4 MiB chunk size and setting the field did nothing.

## Fix

Emit `-maxMB` from `buildFilerStartupScript`, alongside the `-metricsPort` flag that was already handled the same way. Upstream defines it as `filer.go: cmdFiler.Flag.Int("maxMB", 4, "split files larger than the limit")`.

The flag is only emitted when the field is set. That matters: `MaxMB` is a `*int32`, and unconditionally emitting it would send `-maxMB=0` for an unset field, telling the filer never to chunk — a silent behavior change for every existing cluster. Added `Minimum=1` so `0` cannot be set explicitly either.

## Tests

`TestBuildFilerStartupScript_MaxMB` covers both directions: a set value reaches the argv, and an unset field emits no flag at all.

This one does change the generated CRD (`minimum: 1`), unlike the doc-only edits in #336 — `crd:maxDescLen=0` strips descriptions but keeps validation.

Full suite passes except e2e, which fails in `BeforeSuite` at `make kind-load` for want of a kind cluster in my environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the filer chunk size for splitting larger files.
  * The setting is passed to the filer when configured.

* **Bug Fixes**
  * Prevented an unintended zero-value chunk-size option when the setting is omitted.
  * Added validation requiring the chunk size to be at least 1 MiB.

* **Documentation**
  * Clarified the setting’s behavior and default value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->