### PR TITLE
Pass spec.metricsAddress to the master

### DIFF
--- a/api/v1/seaweed_types.go
+++ b/api/v1/seaweed_types.go
@@ -121,7 +121,11 @@ type SeaweedSpec struct {
 	// +optional
 	TLS *TLSSpec `json:"tls,omitempty"`
 
-	// MetricsAddress is Prometheus gateway address
+	// MetricsAddress is the Prometheus Pushgateway to push metrics to, as
+	// <host>:<port>. Set on the master, which passes it to the rest of the
+	// cluster in its heartbeat response, so one value covers every component.
+	// This is push-based and independent of the per-component metricsPort,
+	// which exposes a scrape endpoint instead.
 	MetricsAddress string `json:"metricsAddress,omitempty"`
 
 	// Image

--- a/internal/controller/controller_master_statefulset.go
+++ b/internal/controller/controller_master_statefulset.go
@@ -39,6 +39,13 @@ func buildMasterStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string 
 		command = append(command, fmt.Sprintf("-metricsPort=%d", *m.Spec.Master.MetricsPort))
 	}
 
+	// Only the master takes -metrics.address; it hands the value to volume
+	// servers, filers and gateways in its heartbeat response, so setting it
+	// here turns on push metrics for the whole cluster.
+	if m.Spec.MetricsAddress != "" {
+		command = append(command, fmt.Sprintf("-metrics.address=%s", m.Spec.MetricsAddress))
+	}
+
 	command = append(command, fmt.Sprintf("-ip=$(POD_NAME).%s-master-peer.%s", m.Name, m.Namespace))
 	command = append(command, fmt.Sprintf("-peers=%s", getMasterPeersString(m)))
 	command = append(command, extraArgs...)

--- a/internal/controller/controller_master_statefulset_test.go
+++ b/internal/controller/controller_master_statefulset_test.go
@@ -1,0 +1,40 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+)
+
+// spec.metricsAddress was served by the CRD but never read, so no component
+// ever pushed to the configured Pushgateway.
+func TestBuildMasterStartupScript_MetricsAddress(t *testing.T) {
+	newMaster := func(addr string) *seaweedv1.Seaweed {
+		return &seaweedv1.Seaweed{
+			ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
+			Spec: seaweedv1.SeaweedSpec{
+				MetricsAddress: addr,
+				Master:         &seaweedv1.MasterSpec{Replicas: 1},
+			},
+		}
+	}
+
+	t.Run("set value is passed through", func(t *testing.T) {
+		got := buildMasterStartupScript(newMaster("pushgateway.monitoring:9091"))
+		if !strings.Contains(got, "-metrics.address=pushgateway.monitoring:9091") {
+			t.Errorf("expected -metrics.address in startup script, got %q", got)
+		}
+	})
+
+	// Empty must emit nothing: weed's own default is "" (push disabled), and
+	// passing an empty value would be an unnecessary argv change on every
+	// existing cluster.
+	t.Run("unset omits the flag", func(t *testing.T) {
+		if got := buildMasterStartupScript(newMaster("")); strings.Contains(got, "-metrics.address") {
+			t.Errorf("expected no -metrics.address flag when unset, got %q", got)
+		}
+	})
+}


### PR DESCRIPTION
Another dead CRD field from the same audit as #334, #336 and #337: `SeaweedSpec.MetricsAddress` (`spec.metricsAddress`).

Like the others it appeared exactly once in the repo — its own declaration. Nothing put it into any component's argv, so a configured Prometheus Pushgateway never received anything.

## Fix

Emit `-metrics.address` from `buildMasterStartupScript`.

**Only on the master, deliberately.** Upstream defines the flag on `weed master` alone (`master.go:99`) — no other command exposes it. The master then hands the value to the rest of the cluster in its heartbeat response (`HeartbeatResponse.metrics_address`, consumed in `s3.go:290` and friends), so a single flag on the master turns on push metrics cluster-wide. Adding it to each component's argv would not work — the flag does not exist there.

Empty emits nothing, matching weed's own default of push disabled, so no existing cluster's argv changes.

Also clarified the field doc: this is push-based and orthogonal to the per-component `metricsPort`, which exposes a scrape endpoint instead. The two were easy to confuse when neither did anything.

## Tests

`TestBuildMasterStartupScript_MetricsAddress` covers both directions — set reaches the argv, empty emits no flag. New file; the master statefulset had no test file previously.

No CRD diff (doc-only change; `crd:maxDescLen=0` strips descriptions).

Full suite passes except e2e, which fails in `BeforeSuite` at `make kind-load` for want of a kind cluster in my environment.