### PR TITLE
Honor spec.enablePVReclaim; deprecate spec.pvReclaimPolicy

### DIFF
--- a/api/v1/seaweed_types.go
+++ b/api/v1/seaweed_types.go
@@ -175,7 +175,11 @@ type SeaweedSpec struct {
 	// SchedulerName of pods
 	SchedulerName string `json:"schedulerName,omitempty"`
 
-	// Persistent volume reclaim policy
+	// Deprecated: this field has never had any effect and remains a no-op.
+	// Set reclaimPolicy on the StorageClass backing the cluster's volumes
+	// instead — that is where Kubernetes decides what happens to a released
+	// PersistentVolume, and it applies at provisioning time. The operator
+	// does not patch PersistentVolume objects.
 	PVReclaimPolicy *corev1.PersistentVolumeReclaimPolicy `json:"pvReclaimPolicy,omitempty"`
 
 	// ImagePullPolicy of pods
@@ -184,7 +188,14 @@ type SeaweedSpec struct {
 	// ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images.
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 
-	// Whether enable PVC reclaim for orphan PVC left by statefulset scale-in
+	// EnablePVReclaim deletes the PVCs left behind when a component's
+	// StatefulSet is scaled in, instead of keeping them for a future
+	// scale-out to re-attach. Implemented with the StatefulSet's own
+	// persistentVolumeClaimRetentionPolicy.whenScaled, so Kubernetes does
+	// the deletion at the right point in the scale-down.
+	//
+	// Whether the underlying volume and its data are then destroyed is up to
+	// the StorageClass's reclaimPolicy, not this field. Defaults to false.
 	EnablePVReclaim *bool `json:"enablePVReclaim,omitempty"`
 
 	// Whether Hostnetwork is enabled for pods

--- a/internal/controller/controller_filer.go
+++ b/internal/controller/controller_filer.go
@@ -56,6 +56,7 @@ func (r *SeaweedReconciler) ensureFilerStatefulSet(ctx context.Context, seaweedC
 		existingStatefulSet.Spec.Replicas = desiredStatefulSet.Spec.Replicas
 		existingStatefulSet.Spec.Template.ObjectMeta = desiredStatefulSet.Spec.Template.ObjectMeta
 		existingStatefulSet.Spec.Template.Spec = desiredStatefulSet.Spec.Template.Spec
+		existingStatefulSet.Spec.PersistentVolumeClaimRetentionPolicy = desiredStatefulSet.Spec.PersistentVolumeClaimRetentionPolicy
 
 		return r.reconcileVolumeClaimTemplates(ctx, seaweedCR, existingStatefulSet, desiredStatefulSet)
 	})

--- a/internal/controller/controller_filer_statefulset.go
+++ b/internal/controller/controller_filer_statefulset.go
@@ -243,7 +243,8 @@ func (r *SeaweedReconciler) createFilerStatefulSet(m *seaweedv1.Seaweed) *appsv1
 				},
 				Spec: filerPodSpec,
 			},
-			VolumeClaimTemplates: persistentVolumeClaims,
+			VolumeClaimTemplates:                 persistentVolumeClaims,
+			PersistentVolumeClaimRetentionPolicy: pvcRetentionPolicy(m),
 		},
 	}
 	return dep

--- a/internal/controller/controller_volume.go
+++ b/internal/controller/controller_volume.go
@@ -98,6 +98,7 @@ func (r *SeaweedReconciler) ensureVolumeServerStatefulSet(ctx context.Context, s
 		existingStatefulSet.Spec.Replicas = desiredStatefulSet.Spec.Replicas
 		existingStatefulSet.Spec.Template.ObjectMeta = desiredStatefulSet.Spec.Template.ObjectMeta
 		existingStatefulSet.Spec.Template.Spec = desiredStatefulSet.Spec.Template.Spec
+		existingStatefulSet.Spec.PersistentVolumeClaimRetentionPolicy = desiredStatefulSet.Spec.PersistentVolumeClaimRetentionPolicy
 
 		return r.reconcileVolumeClaimTemplates(ctx, seaweedCR, existingStatefulSet, desiredStatefulSet)
 	})
@@ -265,6 +266,7 @@ func (r *SeaweedReconciler) ensureVolumeServerTopologyStatefulSet(ctx context.Co
 		existingStatefulSet.Spec.Replicas = desiredStatefulSet.Spec.Replicas
 		existingStatefulSet.Spec.Template.ObjectMeta = desiredStatefulSet.Spec.Template.ObjectMeta
 		existingStatefulSet.Spec.Template.Spec = desiredStatefulSet.Spec.Template.Spec
+		existingStatefulSet.Spec.PersistentVolumeClaimRetentionPolicy = desiredStatefulSet.Spec.PersistentVolumeClaimRetentionPolicy
 
 		return r.reconcileVolumeClaimTemplates(ctx, seaweedCR, existingStatefulSet, desiredStatefulSet)
 	})

--- a/internal/controller/controller_volume_statefulset.go
+++ b/internal/controller/controller_volume_statefulset.go
@@ -363,7 +363,8 @@ func (r *SeaweedReconciler) createVolumeServerStatefulSet(m *seaweedv1.Seaweed) 
 				},
 				Spec: volumePodSpec,
 			},
-			VolumeClaimTemplates: disks.pvcs,
+			VolumeClaimTemplates:                 disks.pvcs,
+			PersistentVolumeClaimRetentionPolicy: pvcRetentionPolicy(m),
 		},
 	}
 	return dep
@@ -565,7 +566,8 @@ func (r *SeaweedReconciler) createVolumeServerTopologyStatefulSet(m *seaweedv1.S
 				},
 				Spec: volumePodSpec,
 			},
-			VolumeClaimTemplates: persistentVolumeClaims,
+			VolumeClaimTemplates:                 persistentVolumeClaims,
+			PersistentVolumeClaimRetentionPolicy: pvcRetentionPolicy(m),
 		},
 	}
 	return dep

--- a/internal/controller/pv_reclaim.go
+++ b/internal/controller/pv_reclaim.go
@@ -1,0 +1,30 @@
+package controller
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+)
+
+// pvcRetentionPolicy renders spec.enablePVReclaim as a StatefulSet
+// persistentVolumeClaimRetentionPolicy.
+//
+// whenScaled is the knob the field describes: it decides the fate of the PVCs
+// a scale-in orphans. whenDeleted is pinned to Retain so tearing down the CR
+// never takes the data with it — that path is not what the field promises, and
+// silently deleting on cluster delete would be an unpleasant surprise.
+//
+// The policy is always returned, rather than left nil when disabled, so that
+// flipping the field back off actually restores Retain on a StatefulSet that
+// already carries Delete. Retain/Retain is also the Kubernetes default, so
+// emitting it explicitly changes nothing for clusters that never set the field.
+func pvcRetentionPolicy(m *seaweedv1.Seaweed) *appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy {
+	whenScaled := appsv1.RetainPersistentVolumeClaimRetentionPolicyType
+	if m.Spec.EnablePVReclaim != nil && *m.Spec.EnablePVReclaim {
+		whenScaled = appsv1.DeletePersistentVolumeClaimRetentionPolicyType
+	}
+	return &appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
+		WhenDeleted: appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
+		WhenScaled:  whenScaled,
+	}
+}

--- a/internal/controller/pv_reclaim_test.go
+++ b/internal/controller/pv_reclaim_test.go
@@ -1,0 +1,86 @@
+package controller
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+)
+
+func newReclaimCluster(enable *bool) *seaweedv1.Seaweed {
+	mountPath, subPath := "/data", ""
+	return &seaweedv1.Seaweed{
+		ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
+		Spec: seaweedv1.SeaweedSpec{
+			Image:           "chrislusf/seaweedfs:3.96",
+			EnablePVReclaim: enable,
+			Master:          &seaweedv1.MasterSpec{Replicas: 1},
+			Volume:          &seaweedv1.VolumeSpec{Replicas: 1},
+			Filer: &seaweedv1.FilerSpec{
+				Replicas: 1,
+				Persistence: &seaweedv1.PersistenceSpec{
+					Enabled:   true,
+					MountPath: &mountPath,
+					SubPath:   &subPath,
+				},
+			},
+		},
+	}
+}
+
+// spec.enablePVReclaim was served by the CRD but never read, so PVCs orphaned
+// by a scale-in were kept regardless of what it was set to.
+func TestPVCRetentionPolicy(t *testing.T) {
+	enabled, disabled := true, false
+
+	cases := []struct {
+		name           string
+		enable         *bool
+		wantWhenScaled appsv1.PersistentVolumeClaimRetentionPolicyType
+	}{
+		{"enabled deletes orphans", &enabled, appsv1.DeletePersistentVolumeClaimRetentionPolicyType},
+		{"disabled retains", &disabled, appsv1.RetainPersistentVolumeClaimRetentionPolicyType},
+		{"unset retains", nil, appsv1.RetainPersistentVolumeClaimRetentionPolicyType},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := pvcRetentionPolicy(newReclaimCluster(tc.enable))
+			if got.WhenScaled != tc.wantWhenScaled {
+				t.Errorf("whenScaled = %q want %q", got.WhenScaled, tc.wantWhenScaled)
+			}
+			// Deleting the cluster must never take the data with it, whatever
+			// the scale-in setting is.
+			if got.WhenDeleted != appsv1.RetainPersistentVolumeClaimRetentionPolicyType {
+				t.Errorf("whenDeleted = %q want Retain", got.WhenDeleted)
+			}
+		})
+	}
+}
+
+// The policy has to reach the StatefulSets that actually own PVCs, or the
+// setting is inert no matter how it resolves.
+func TestStatefulSetsCarryRetentionPolicy(t *testing.T) {
+	enabled := true
+	m := newReclaimCluster(&enabled)
+	r := &SeaweedReconciler{}
+
+	sets := map[string]*appsv1.StatefulSet{
+		"filer":  r.createFilerStatefulSet(m),
+		"volume": r.createVolumeServerStatefulSet(m),
+	}
+	for name, sts := range sets {
+		if len(sts.Spec.VolumeClaimTemplates) == 0 {
+			t.Fatalf("precondition: %s StatefulSet has no VolumeClaimTemplates", name)
+		}
+		policy := sts.Spec.PersistentVolumeClaimRetentionPolicy
+		if policy == nil {
+			t.Errorf("%s StatefulSet has no PersistentVolumeClaimRetentionPolicy", name)
+			continue
+		}
+		if policy.WhenScaled != appsv1.DeletePersistentVolumeClaimRetentionPolicyType {
+			t.Errorf("%s whenScaled = %q want Delete", name, policy.WhenScaled)
+		}
+	}
+}


### PR DESCRIPTION
The last two dead CRD fields from the audit that started with #334 (see also #336, #337, #338):

- `SeaweedSpec.EnablePVReclaim` (`spec.enablePVReclaim`)
- `SeaweedSpec.PVReclaimPolicy` (`spec.pvReclaimPolicy`)

Both appeared exactly once in the repo — their own declarations. They get different treatment because only one of them describes something the operator should be doing.

## enablePVReclaim — implemented

*"Whether enable PVC reclaim for orphan PVC left by statefulset scale-in."* When a StatefulSet scales in, Kubernetes keeps the departing ordinals' PVCs so a later scale-out re-attaches the same volumes. This field was supposed to opt out of that; it did nothing.

Implemented with the StatefulSet's own `persistentVolumeClaimRetentionPolicy.whenScaled` (GA since 1.27) rather than an operator loop that hunts orphaned PVCs and deletes them. The StatefulSet controller already does this at exactly the right point in the scale-down, so the native field is both less code and better sequenced than anything the operator could do from outside.

Applied to the three StatefulSets that actually own PVCs — filer and both volume-server variants.

Two details worth review:

- **The policy is emitted in both states**, not left `nil` when disabled. Otherwise flipping the field back off would leave `Delete` in place on a StatefulSet that already had it. `Retain`/`Retain` is the Kubernetes default, so clusters that never set the field see no semantic change.
- **It is copied on update.** The reconcilers only propagate `Replicas` and the pod template onto an existing StatefulSet, so without an explicit copy the field would only ever apply to freshly created ones. Unlike `volumeClaimTemplates` this field is mutable, so no StatefulSet recreation is involved.

`whenDeleted` is pinned to `Retain`: deleting the CR should not take the data with it, and that is not what this field promises.

## pvReclaimPolicy — deprecated as a no-op

Typed `corev1.PersistentVolumeReclaimPolicy`, so the literal implementation is patching `spec.persistentVolumeReclaimPolicy` on the PVs bound to the cluster's PVCs.

Not doing that. `StorageClass.reclaimPolicy` is the ecosystem-standard lever for this and applies at provisioning time, whereas an operator patching cluster-scoped objects that outlive the CR is a meaningful blast radius for something the platform already handles. The field is now documented as a deprecated no-op pointing at the StorageClass, so at least it stops silently implying it does something.

Whether a released volume's data is destroyed is therefore a StorageClass question — noted on `enablePVReclaim` too, since the two are easy to conflate.

## Tests

`TestPVCRetentionPolicy` covers enabled/disabled/unset and pins `whenDeleted: Retain` in all three. `TestStatefulSetsCarryRetentionPolicy` asserts the policy actually reaches the filer and volume StatefulSets, with a precondition that those sets do own `volumeClaimTemplates` — so the test fails rather than silently passing if the fixture stops creating PVCs.

No CRD diff (doc-only API changes; `crd:maxDescLen=0` strips descriptions).

Full suite passes except e2e, which fails in `BeforeSuite` at `make kind-load` for want of a kind cluster in my environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable PVC retention behavior for filer and volume StatefulSets.
  * When enabled, PVCs are automatically deleted after StatefulSet scale-in; PVCs are retained otherwise and when StatefulSets are deleted.
  * Underlying volume and data retention remains governed by the associated StorageClass.

* **Documentation**
  * Clarified that the legacy PV reclaim setting is deprecated and has no effect.
  * Documented the new retention behavior and its default setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->