### PR TITLE
Grant seaweeds/finalizers to the manager role

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -163,6 +163,7 @@ rules:
   - seaweedbackups/finalizers
   - seaweedcsidrivers/finalizers
   - seaweedrestores/finalizers
+  - seaweeds/finalizers
   verbs:
   - update
 - apiGroups:

--- a/deploy/helm/templates/rbac/role.yaml
+++ b/deploy/helm/templates/rbac/role.yaml
@@ -164,6 +164,7 @@ rules:
   - seaweedbackups/finalizers
   - seaweedcsidrivers/finalizers
   - seaweedrestores/finalizers
+  - seaweeds/finalizers
   verbs:
   - update
 - apiGroups:

--- a/internal/controller/rbac_ownerref_envtest_test.go
+++ b/internal/controller/rbac_ownerref_envtest_test.go
@@ -1,0 +1,174 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+)
+
+// TestReconcile_SucceedsWithOnlyManagerRolePermissions drives a full Seaweed
+// reconcile with a client that holds exactly the permissions
+// config/rbac/role.yaml grants — no more — against an apiserver running the
+// OwnerReferencesPermissionEnforcement admission plugin.
+//
+// Every owned object the reconciler writes carries a controller reference with
+// blockOwnerDeletion: true (controllerutil.SetControllerReference always sets
+// it), and that plugin rejects such a write unless the writer can update the
+// owner's finalizers subresource. So a missing `<kind>/finalizers` grant turns
+// every reconcile into an immediate hard failure:
+//
+//	secrets "x-security-config" is forbidden: cannot set blockOwnerDeletion if
+//	an ownerReference refers to a resource you can't set finalizers on: , <nil>
+//
+// Clusters that leave the plugin disabled (kind, k3s, upstream defaults) never
+// see it, so the gap only surfaces on OpenShift and other strict-RBAC installs.
+// Enforcing the real ClusterRole here is what makes that environment-specific
+// failure reproducible in CI.
+func TestReconcile_SucceedsWithOnlyManagerRolePermissions(t *testing.T) {
+	cfg, admin := mustEnvtest(t)
+	ctx := context.Background()
+
+	ns := newTestNamespace(t, ctx, admin, "managerrbac")
+	t.Cleanup(func() {
+		_ = admin.Delete(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	})
+
+	limited := managerRoleClient(t, ctx, cfg, admin, ns)
+
+	// ConcurrentStart skips the master pod-readiness wait — envtest runs no
+	// kubelets, so no pod would ever report Running.
+	concurrentStart := true
+	diskCount := int32(1)
+	cr := &seaweedv1.Seaweed{
+		ObjectMeta: metav1.ObjectMeta{Name: "rbac", Namespace: ns},
+		Spec: seaweedv1.SeaweedSpec{
+			Image:                 "chrislusf/seaweedfs:latest",
+			VolumeServerDiskCount: &diskCount,
+			Master: &seaweedv1.MasterSpec{
+				Replicas:        1,
+				ConcurrentStart: &concurrentStart,
+			},
+			Volume: &seaweedv1.VolumeSpec{
+				Replicas: 1,
+				VolumeServerConfig: seaweedv1.VolumeServerConfig{
+					ResourceRequirements: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("1Gi"),
+						},
+					},
+				},
+			},
+			Filer: &seaweedv1.FilerSpec{Replicas: 1},
+		},
+	}
+	if err := admin.Create(ctx, cr); err != nil {
+		t.Fatalf("create Seaweed CR: %v", err)
+	}
+
+	r := &SeaweedReconciler{
+		Client: limited,
+		Log:    logf.FromContext(ctx),
+		Scheme: limited.Scheme(),
+	}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: cr.Name, Namespace: ns}}
+
+	// Convergence takes several passes, each returning early after the
+	// component it just created, so run enough of them to reach the tail of the
+	// loop and exercise every owned-object write.
+	for i := 0; i < 5; i++ {
+		if _, err := r.Reconcile(ctx, req); err != nil {
+			t.Fatalf("reconcile pass %d failed with only the permissions config/rbac/role.yaml grants: %v\n"+
+				"If this is a blockOwnerDeletion error, the manager ClusterRole is missing an "+
+				"`update` grant on the owner kind's /finalizers subresource — add the "+
+				"kubebuilder:rbac marker to the owning controller and re-run `make manifests`.", i+1, err)
+		}
+	}
+
+	// The security Secret is the first owned object every reconcile writes, and
+	// the one the bug report tripped over, so assert it actually landed instead
+	// of trusting a nil error alone.
+	var secret corev1.Secret
+	if err := admin.Get(ctx, types.NamespacedName{Name: cr.Name + "-security-config", Namespace: ns}, &secret); err != nil {
+		t.Fatalf("owned security Secret was not created: %v", err)
+	}
+	if len(secret.OwnerReferences) != 1 || secret.OwnerReferences[0].BlockOwnerDeletion == nil || !*secret.OwnerReferences[0].BlockOwnerDeletion {
+		t.Fatalf("security Secret should carry a blockOwnerDeletion controller reference, got %+v", secret.OwnerReferences)
+	}
+}
+
+// managerRoleClient returns a client authenticated as the operator's
+// ServiceAccount, authorized by a ClusterRole built from the live
+// config/rbac/role.yaml. Reading the rules off disk rather than restating them
+// keeps the test honest: it always asserts against the permissions the
+// kustomize overlay and the Helm chart actually ship.
+func managerRoleClient(t *testing.T, ctx context.Context, cfg *rest.Config, admin client.Client, ns string) client.Client {
+	t.Helper()
+
+	role := loadManagerClusterRole(t)
+	role.Name = "manager-role-" + ns
+
+	const saName = "seaweedfs-operator-controller-manager"
+	sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: ns}}
+	binding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "manager-rolebinding-" + ns},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     role.Name,
+		},
+		Subjects: []rbacv1.Subject{{Kind: rbacv1.ServiceAccountKind, Name: saName, Namespace: ns}},
+	}
+	for _, obj := range []client.Object{role, sa, binding} {
+		if err := admin.Create(ctx, obj); err != nil {
+			t.Fatalf("create %T %s: %v", obj, obj.GetName(), err)
+		}
+	}
+	// The namespace cleanup takes the ServiceAccount with it; the ClusterRole
+	// and its binding are cluster-scoped and have to go explicitly.
+	t.Cleanup(func() {
+		bg := context.Background()
+		_ = admin.Delete(bg, binding)
+		_ = admin.Delete(bg, role)
+	})
+
+	// Impersonation, rather than a minted ServiceAccount token, so the test
+	// does not depend on the TokenRequest API or on the ServiceAccount
+	// admission plugin (envtest disables the latter).
+	limitedCfg := rest.CopyConfig(cfg)
+	limitedCfg.Impersonate = rest.ImpersonationConfig{
+		UserName: fmt.Sprintf("system:serviceaccount:%s:%s", ns, saName),
+	}
+	cli, err := client.New(limitedCfg, client.Options{Scheme: admin.Scheme()})
+	if err != nil {
+		t.Fatalf("build impersonating client: %v", err)
+	}
+	return cli
+}

--- a/internal/controller/rbac_ownerref_test.go
+++ b/internal/controller/rbac_ownerref_test.go
@@ -1,0 +1,102 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+// TestManagerRoleGrantsFinalizersForEveryWritableCRD is the apiserver-free
+// counterpart to TestReconcile_SucceedsWithOnlyManagerRolePermissions, so the
+// invariant is still guarded on machines where the envtest binaries are absent
+// and envtest-backed tests Skip.
+//
+// Any seaweed.seaweedfs.com kind the operator can create is a kind it may also
+// use as an owner, and owning an object on a cluster running the
+// OwnerReferencesPermissionEnforcement admission plugin requires `update` on
+// that kind's finalizers subresource.
+func TestManagerRoleGrantsFinalizersForEveryWritableCRD(t *testing.T) {
+	role := loadManagerClusterRole(t)
+
+	const group = "seaweed.seaweedfs.com"
+	writable := map[string]bool{}
+	finalizers := map[string]bool{}
+	for _, rule := range role.Rules {
+		if !slices.Contains(rule.APIGroups, group) {
+			continue
+		}
+		for _, res := range rule.Resources {
+			switch {
+			case strings.HasSuffix(res, "/finalizers"):
+				if slices.Contains(rule.Verbs, "update") || slices.Contains(rule.Verbs, "*") {
+					finalizers[strings.TrimSuffix(res, "/finalizers")] = true
+				}
+			case !strings.Contains(res, "/"):
+				if slices.Contains(rule.Verbs, "create") || slices.Contains(rule.Verbs, "*") {
+					writable[res] = true
+				}
+			}
+		}
+	}
+	if len(writable) == 0 {
+		t.Fatalf("no writable %s resources found in config/rbac/role.yaml; did the group name change?", group)
+	}
+
+	var missing []string
+	for res := range writable {
+		if !finalizers[res] {
+			missing = append(missing, res)
+		}
+	}
+	sort.Strings(missing)
+	for _, res := range missing {
+		t.Errorf("config/rbac/role.yaml grants create on %s.%s but no update on %s/finalizers: "+
+			"objects owned by that kind cannot be created on clusters running the "+
+			"OwnerReferencesPermissionEnforcement admission plugin (OpenShift enables it by default). "+
+			"Add `// +kubebuilder:rbac:groups=%s,resources=%s/finalizers,verbs=update` to the owning "+
+			"controller and re-run `make manifests`.", res, group, res, group, res)
+	}
+}
+
+// loadManagerClusterRole decodes config/rbac/role.yaml, the controller-gen
+// output that both the kustomize overlay and the Helm chart's manager
+// ClusterRole are derived from.
+func loadManagerClusterRole(t *testing.T) *rbacv1.ClusterRole {
+	t.Helper()
+
+	path := filepath.Join(projectRoot(), "config", "rbac", "role.yaml")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	role := &rbacv1.ClusterRole{}
+	if err := yaml.Unmarshal(raw, role); err != nil {
+		t.Fatalf("decode %s: %v", path, err)
+	}
+	if len(role.Rules) == 0 {
+		t.Fatalf("%s declares no rules; did controller-gen output move?", path)
+	}
+	return role
+}

--- a/internal/controller/seaweed_controller.go
+++ b/internal/controller/seaweed_controller.go
@@ -101,6 +101,7 @@ type SeaweedReconciler struct {
 
 // +kubebuilder:rbac:groups=seaweed.seaweedfs.com,resources=seaweeds,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=seaweed.seaweedfs.com,resources=seaweeds/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=seaweed.seaweedfs.com,resources=seaweeds/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -73,6 +73,16 @@ func startEnvtest() error {
 		CRDDirectoryPaths:     []string{filepath.Join(projectRoot(), "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
 	}
+	// OpenShift and other strict-RBAC distributions enable
+	// OwnerReferencesPermissionEnforcement, which rejects writes that set
+	// blockOwnerDeletion unless the writer can update the owner's finalizers
+	// subresource. Upstream leaves the plugin off, so without this flag the
+	// RBAC gaps it catches stay invisible until a user installs on OpenShift.
+	// Costs nothing for the admin-credentialed tests: system:masters passes
+	// every authorization check the plugin makes.
+	envtestEnv.ControlPlane.GetAPIServer().Configure().
+		Append("enable-admission-plugins", "OwnerReferencesPermissionEnforcement")
+
 	cfg, err := envtestEnv.Start()
 	if err != nil {
 		envtestEnv = nil


### PR DESCRIPTION
Fixes #342

## The bug

The manager `ClusterRole` granted `update` on the `finalizers` subresource of every seaweed CRD **except `seaweeds`** — the marker was simply never added to `seaweed_controller.go`.

Every object the Seaweed reconciler owns gets its controller reference from `controllerutil.SetControllerReference`, which always sets `blockOwnerDeletion: true`. Clusters running the `OwnerReferencesPermissionEnforcement` admission plugin reject such a write unless the writer can update the *owner's* `finalizers` subresource, so the first owned write of every reconcile failed:

```
secrets "seaweedfs-security-config" is forbidden: cannot set blockOwnerDeletion if
an ownerReference refers to a resource you can't set finalizers on: , <nil>
```

The reconcile aborted before `ensureMaster`, so no StatefulSets and no pods were ever created. Upstream Kubernetes leaves that plugin disabled — which is why kind and k3s masked the gap and OpenShift, which enables it by default, did not.

## The fix

Add the marker to the Seaweed controller, regenerate `config/rbac/role.yaml` via `make manifests`, and mirror the rule into the hand-maintained chart role (`deploy/helm/templates/rbac/role.yaml`). One line of RBAC in each:

```yaml
  - seaweeds/finalizers
```

## Reproduction / regression guards

`internal/controller/suite_test.go` now starts the shared envtest apiserver with `--enable-admission-plugins=OwnerReferencesPermissionEnforcement`. That costs the existing tests nothing — they use admin credentials, and `system:masters` passes every authorization check the plugin makes — but it makes the strict-RBAC behavior reachable in CI.

Two tests then pin the invariant:

- **`TestReconcile_SucceedsWithOnlyManagerRolePermissions`** (envtest) reconciles a real Seaweed CR through a client impersonating `system:serviceaccount:<ns>:seaweedfs-operator-controller-manager`, bound to a `ClusterRole` loaded from the on-disk `config/rbac/role.yaml`. Reading the rules off disk rather than restating them means the test always asserts against the permissions actually shipped. Reverting the one-line fix reproduces the reported error verbatim:

  ```
  reconcile pass 1 failed with only the permissions config/rbac/role.yaml grants:
  secrets "rbac-security-config" is forbidden: cannot set blockOwnerDeletion if an
  ownerReference refers to a resource you can't set finalizers on: , <nil>
  ```

- **`TestManagerRoleGrantsFinalizersForEveryWritableCRD`** needs no apiserver, so the invariant is still guarded where the envtest binaries are absent and envtest tests `Skip`. It fails for any `seaweed.seaweedfs.com` resource that the role can `create` but lacks a matching `/finalizers` `update` grant, and the failure message names the marker to add.

Chart `version` is left alone — release automation bumps it.

## Test

`make test`-equivalent run is green on both k8s 1.28.0 and 1.30.0 assets, including the existing `test/helm` chart-parity suite. Both new tests fail as intended when the `seaweeds/finalizers` line is removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved controller permissions for managing Seaweed resource finalizers.
  * Reconciliation now works correctly in environments enforcing owner-reference permissions.
  * Ensured created security resources receive the correct controller ownership metadata.

* **Tests**
  * Added coverage verifying finalizer permissions for writable Seaweed resources.
  * Added regression tests for reconciliation under stricter permission enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->