### PR TITLE
Read master.toml and filer.toml from a Secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Fields that commonly cause confusion:
       key: filer.toml                # key inside it; any name works
   ```
 
-  Rotating the Secret updates the mounted file in place, but SeaweedFS reads its TOML only at startup — restart the component's Pods (`kubectl rollout restart statefulset/<name>-filer`) for a change to take effect.
+  Rotating the Secret updates the mounted file in place, but SeaweedFS reads its TOML only at startup — restart the component's Pods (`kubectl rollout restart statefulset/<name>-filer`) for a change to take effect. Switching a component from `config` to `configSecret` also deletes the ConfigMap the operator generated for the inline config, so the plaintext copy does not linger in the namespace.
 
 To run with a cloud bucket as remote storage (Cloud Drive) backed by a local cache, see `config/samples/seaweed_v1_seaweed_remote_storage.yaml`.
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,16 @@ Fields that commonly cause confusion:
 - **`master.volumeSizeLimitMB`** — the max size of a *single logical volume file* before the master allocates a new one (1024 = 1 GiB per file). This is **not** the cluster capacity and **not** the PVC size — total capacity is driven by the volume servers' disks.
 - **`hostSuffix`** — optional. Creates a single all-in-one Ingress exposing the cluster under `filer.<hostSuffix>`, `s3.<hostSuffix>`, and `<name>-volume-<n>.<hostSuffix>` (requires an Ingress controller). Omit it for in-cluster-only access, or use the per-component `ingress:` blocks for finer control.
 - **`master.config` / `filer.config`** — raw TOML dropped verbatim into that component's config file (`master.toml` / `filer.toml`). Yes, you can paste an existing SeaweedFS filer config here — for example to point the filer's metadata store at Postgres/MySQL/Redis instead of local leveldb2.
+- **`master.configSecret` / `filer.configSecret`** — the same TOML, but read from an existing Secret instead of the CR, so credentials in it (a metadata-store password, remote storage keys) stay out of `kubectl get seaweed -o yaml`, etcd and Git. The referenced key is mounted as `master.toml` / `filer.toml`, which lets External Secrets Operator, Sealed Secrets or SOPS own and rotate it. Set one of `config` or `configSecret` per component, not both — the API rejects it.
+
+  ```yaml
+  filer:
+    configSecret:
+      name: seaweedfs-filer-config   # Secret in the same namespace
+      key: filer.toml                # key inside it; any name works
+  ```
+
+  Rotating the Secret updates the mounted file in place, but SeaweedFS reads its TOML only at startup — restart the component's Pods (`kubectl rollout restart statefulset/<name>-filer`) for a change to take effect.
 
 To run with a cloud bucket as remote storage (Cloud Drive) backed by a local cache, see `config/samples/seaweed_v1_seaweed_remote_storage.yaml`.
 

--- a/api/v1/seaweed_types.go
+++ b/api/v1/seaweed_types.go
@@ -313,6 +313,7 @@ type ComponentStatus struct {
 }
 
 // MasterSpec is the spec for masters
+// +kubebuilder:validation:XValidation:rule="!(has(self.config) && has(self.configSecret))",message="config and configSecret are mutually exclusive"
 type MasterSpec struct {
 	ComponentSpec               `json:",inline"`
 	corev1.ResourceRequirements `json:",inline"`
@@ -324,6 +325,14 @@ type MasterSpec struct {
 
 	// Config in raw toml string
 	Config *string `json:"config,omitempty"`
+
+	// ConfigSecret references a Secret key holding the master.toml contents,
+	// for config that carries credentials (e.g. remote storage backends) and
+	// should not sit in plaintext in the CR. The key is projected as
+	// master.toml into the same path the inline Config would be mounted at.
+	// Mutually exclusive with Config.
+	// +optional
+	ConfigSecret *corev1.SecretKeySelector `json:"configSecret,omitempty"`
 
 	// MetricsPort is the port that the prometheus metrics export listens on
 	MetricsPort *int32 `json:"metricsPort,omitempty"`
@@ -603,6 +612,7 @@ type IcebergConfig struct {
 }
 
 // FilerSpec is the spec for filers
+// +kubebuilder:validation:XValidation:rule="!(has(self.config) && has(self.configSecret))",message="config and configSecret are mutually exclusive"
 type FilerSpec struct {
 	ComponentSpec               `json:",inline"`
 	corev1.ResourceRequirements `json:",inline"`
@@ -614,6 +624,14 @@ type FilerSpec struct {
 
 	// Config in raw toml string
 	Config *string `json:"config,omitempty"`
+
+	// ConfigSecret references a Secret key holding the filer.toml contents,
+	// for config that carries credentials (e.g. the metadata store password)
+	// and should not sit in plaintext in the CR. The key is projected as
+	// filer.toml into the same path the inline Config would be mounted at.
+	// Mutually exclusive with Config.
+	// +optional
+	ConfigSecret *corev1.SecretKeySelector `json:"configSecret,omitempty"`
 
 	// MetricsPort is the port that the prometheus metrics export listens on
 	MetricsPort *int32 `json:"metricsPort,omitempty"`

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -1219,6 +1219,11 @@ func (in *FilerSpec) DeepCopyInto(out *FilerSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ConfigSecret != nil {
+		in, out := &in.ConfigSecret, &out.ConfigSecret
+		*out = new(corev1.SecretKeySelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.MetricsPort != nil {
 		in, out := &in.MetricsPort, &out.MetricsPort
 		*out = new(int32)
@@ -1424,6 +1429,11 @@ func (in *MasterSpec) DeepCopyInto(out *MasterSpec) {
 		in, out := &in.Config, &out.Config
 		*out = new(string)
 		**out = **in
+	}
+	if in.ConfigSecret != nil {
+		in, out := &in.ConfigSecret, &out.ConfigSecret
+		*out = new(corev1.SecretKeySelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.MetricsPort != nil {
 		in, out := &in.MetricsPort, &out.MetricsPort

--- a/config/crd/bases/seaweed.seaweedfs.com_seaweeds.yaml
+++ b/config/crd/bases/seaweed.seaweedfs.com_seaweeds.yaml
@@ -2742,6 +2742,19 @@ spec:
                     x-kubernetes-list-type: map
                   config:
                     type: string
+                  configSecret:
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        default: ""
+                        type: string
+                      optional:
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
                   containerSecurityContext:
                     properties:
                       allowPrivilegeEscalation:
@@ -4123,6 +4136,9 @@ spec:
                 required:
                 - replicas
                 type: object
+                x-kubernetes-validations:
+                - message: config and configSecret are mutually exclusive
+                  rule: '!(has(self.config) && has(self.configSecret))'
               hostNetwork:
                 type: boolean
               hostSuffix:
@@ -4609,6 +4625,19 @@ spec:
                     type: boolean
                   config:
                     type: string
+                  configSecret:
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        default: ""
+                        type: string
+                      optional:
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
                   containerSecurityContext:
                     properties:
                       allowPrivilegeEscalation:
@@ -5816,6 +5845,9 @@ spec:
                 required:
                 - replicas
                 type: object
+                x-kubernetes-validations:
+                - message: config and configSecret are mutually exclusive
+                  rule: '!(has(self.config) && has(self.configSecret))'
               metricsAddress:
                 type: string
               nodeSelector:

--- a/config/samples/seaweed_v1_seaweed_annotated.yaml
+++ b/config/samples/seaweed_v1_seaweed_annotated.yaml
@@ -83,3 +83,10 @@ spec:
       [leveldb2]
       enabled = true
       dir = "/data/filerldb2"
+    # When the config holds credentials (a postgres password, remote storage
+    # keys), keep it in a Secret instead: the referenced key is mounted as
+    # filer.toml and never stored in the CR. `master` takes the same field.
+    # Mutually exclusive with `config` above.
+    # configSecret:
+    #   name: seaweedfs-filer-config
+    #   key: filer.toml

--- a/deploy/helm/templates/crd-seaweed.yaml
+++ b/deploy/helm/templates/crd-seaweed.yaml
@@ -5946,6 +5946,19 @@ spec:
                       x-kubernetes-list-type: map
                     config:
                       type: string
+                    configSecret:
+                      properties:
+                        key:
+                          type: string
+                        name:
+                          default: ""
+                          type: string
+                        optional:
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
                     containerSecurityContext:
                       properties:
                         allowPrivilegeEscalation:
@@ -7327,6 +7340,9 @@ spec:
                   required:
                     - replicas
                   type: object
+                  x-kubernetes-validations:
+                    - message: config and configSecret are mutually exclusive
+                      rule: '!(has(self.config) && has(self.configSecret))'
                 hostNetwork:
                   type: boolean
                 hostSuffix:
@@ -7813,6 +7829,19 @@ spec:
                       type: boolean
                     config:
                       type: string
+                    configSecret:
+                      properties:
+                        key:
+                          type: string
+                        name:
+                          default: ""
+                          type: string
+                        optional:
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
                     containerSecurityContext:
                       properties:
                         allowPrivilegeEscalation:
@@ -9020,6 +9049,9 @@ spec:
                   required:
                     - replicas
                   type: object
+                  x-kubernetes-validations:
+                    - message: config and configSecret are mutually exclusive
+                      rule: '!(has(self.config) && has(self.configSecret))'
                 metricsAddress:
                   type: string
                 nodeSelector:

--- a/internal/controller/component_config_secret_envtest_test.go
+++ b/internal/controller/component_config_secret_envtest_test.go
@@ -1,0 +1,102 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+)
+
+// The config/configSecret exclusivity is a CEL rule on the CRD, so only a real
+// apiserver can tell us whether it compiles, fits the cost budget, and rejects
+// what it should. The controller's precedence rule keeps a pre-existing CR
+// working, but users should hear about the ambiguity at apply time.
+func TestSeaweedCRD_ConfigAndConfigSecretAreMutuallyExclusive(t *testing.T) {
+	_, cli := mustEnvtest(t)
+	ctx := context.Background()
+
+	ns := newTestNamespace(t, ctx, cli, "config-secret")
+	t.Cleanup(func() {
+		_ = cli.Delete(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	})
+
+	inline := "[leveldb2]\nenabled = true\n"
+	sel := &corev1.SecretKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{Name: "cfg"},
+		Key:                  "toml",
+	}
+
+	cases := []struct {
+		name       string
+		master     *seaweedv1.MasterSpec
+		filer      *seaweedv1.FilerSpec
+		wantReject bool
+	}{
+		{
+			name:   "master config alone",
+			master: &seaweedv1.MasterSpec{Replicas: 1, Config: &inline},
+		},
+		{
+			name:   "master configSecret alone",
+			master: &seaweedv1.MasterSpec{Replicas: 1, ConfigSecret: sel},
+		},
+		{
+			name:       "master both",
+			master:     &seaweedv1.MasterSpec{Replicas: 1, Config: &inline, ConfigSecret: sel},
+			wantReject: true,
+		},
+		{
+			name:   "filer configSecret alone",
+			master: &seaweedv1.MasterSpec{Replicas: 1},
+			filer:  &seaweedv1.FilerSpec{Replicas: 1, ConfigSecret: sel},
+		},
+		{
+			name:       "filer both",
+			master:     &seaweedv1.MasterSpec{Replicas: 1},
+			filer:      &seaweedv1.FilerSpec{Replicas: 1, Config: &inline, ConfigSecret: sel},
+			wantReject: true,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cr := minimalVolumeSeaweedCR(ns)
+			cr.Name = strings.ToLower(strings.ReplaceAll(tc.name, " ", "-"))
+			cr.Spec.Master = tc.master
+			cr.Spec.Filer = tc.filer
+
+			err := cli.Create(ctx, cr)
+			if err == nil {
+				t.Cleanup(func() { _ = cli.Delete(context.Background(), cr) })
+			}
+			switch {
+			case tc.wantReject && err == nil:
+				t.Fatalf("case %d: expected the apiserver to reject config + configSecret", i)
+			case tc.wantReject && !strings.Contains(err.Error(), "mutually exclusive"):
+				t.Fatalf("case %d: expected the exclusivity message, got %v", i, err)
+			case !tc.wantReject && err != nil:
+				t.Fatalf("case %d: expected the CR to be accepted, got %v", i, err)
+			}
+		})
+	}
+}

--- a/internal/controller/component_config_secret_envtest_test.go
+++ b/internal/controller/component_config_secret_envtest_test.go
@@ -23,6 +23,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
 )
@@ -98,5 +101,84 @@ func TestSeaweedCRD_ConfigAndConfigSecretAreMutuallyExclusive(t *testing.T) {
 				t.Fatalf("case %d: expected the CR to be accepted, got %v", i, err)
 			}
 		})
+	}
+}
+
+// replaceOnGetClient swaps the target ConfigMap for an unowned one with a
+// fresh UID immediately after it is read, standing in for another actor
+// deleting and recreating it in the window between the reconciler's read and
+// its delete. Only the fake client's ResourceVersion precondition is
+// simulated in-memory, so the UID precondition needs a real apiserver.
+type replaceOnGetClient struct {
+	client.Client
+	target   string
+	replaced bool
+}
+
+func (c *replaceOnGetClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if err := c.Client.Get(ctx, key, obj, opts...); err != nil {
+		return err
+	}
+	cm, ok := obj.(*corev1.ConfigMap)
+	if !ok || c.replaced || key.Name != c.target {
+		return nil
+	}
+	c.replaced = true
+	if err := c.Client.Delete(ctx, cm.DeepCopy()); err != nil {
+		return err
+	}
+	return c.Client.Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace},
+		Data:       map[string]string{"unrelated": "data"},
+	})
+}
+
+// Pruning reads the ConfigMap, checks that this CR controls it, then deletes
+// it. Without a precondition tying those together, an object recreated under
+// the same name in between would be deleted on the strength of the previous
+// object's owner reference.
+func TestPruneOwnedConfigMap_LeavesAReplacementAlone(t *testing.T) {
+	_, cli := mustEnvtest(t)
+	ctx := context.Background()
+
+	ns := newTestNamespace(t, ctx, cli, "prune-race")
+	t.Cleanup(func() {
+		_ = cli.Delete(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	})
+
+	cr := minimalVolumeSeaweedCR(ns)
+	if err := cli.Create(ctx, cr); err != nil {
+		t.Fatalf("create Seaweed: %v", err)
+	}
+
+	owned := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: cr.Name + "-filer", Namespace: ns},
+		Data:       map[string]string{"filer.toml": "[postgres]\npassword = \"hunter2\"\n"},
+	}
+	if err := controllerutil.SetControllerReference(cr, owned, cli.Scheme()); err != nil {
+		t.Fatalf("set owner ref: %v", err)
+	}
+	if err := cli.Create(ctx, owned); err != nil {
+		t.Fatalf("create ConfigMap: %v", err)
+	}
+
+	racing := &replaceOnGetClient{Client: cli, target: owned.Name}
+	r := &SeaweedReconciler{Client: racing, Log: logf.FromContext(ctx), Scheme: cli.Scheme()}
+
+	// The conflict is the expected outcome, reported as success: the object
+	// under that name is no longer ours to remove.
+	if err := r.pruneOwnedConfigMap(ctx, cr, owned.Name); err != nil {
+		t.Fatalf("expected the replacement to be left alone without an error, got %v", err)
+	}
+	if !racing.replaced {
+		t.Fatal("test did not exercise the race: the ConfigMap was never replaced")
+	}
+
+	got := &corev1.ConfigMap{}
+	if err := cli.Get(ctx, client.ObjectKey{Namespace: ns, Name: owned.Name}, got); err != nil {
+		t.Fatalf("expected the replacement ConfigMap to survive, got %v", err)
+	}
+	if got.Data["unrelated"] != "data" {
+		t.Errorf("expected the replacement to be untouched, got %v", got.Data)
 	}
 }

--- a/internal/controller/component_config_secret_test.go
+++ b/internal/controller/component_config_secret_test.go
@@ -1,0 +1,207 @@
+package controller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+)
+
+// master.toml and filer.toml can carry credentials (remote storage backends,
+// the filer's metadata store password), so both components accept a
+// configSecret reference instead of the inline config string.
+
+func podVolume(t *testing.T, pod *corev1.PodSpec, name string) *corev1.Volume {
+	t.Helper()
+	for i := range pod.Volumes {
+		if pod.Volumes[i].Name == name {
+			return &pod.Volumes[i]
+		}
+	}
+	t.Fatalf("volume %q not found in pod spec", name)
+	return nil
+}
+
+func containerMount(t *testing.T, c *corev1.Container, name string) *corev1.VolumeMount {
+	t.Helper()
+	for i := range c.VolumeMounts {
+		if c.VolumeMounts[i].Name == name {
+			return &c.VolumeMounts[i]
+		}
+	}
+	t.Fatalf("volume mount %q not found in container %q", name, c.Name)
+	return nil
+}
+
+func newConfigSecretCluster(master *seaweedv1.MasterSpec, filer *seaweedv1.FilerSpec) *seaweedv1.Seaweed {
+	return &seaweedv1.Seaweed{
+		ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
+		Spec:       seaweedv1.SeaweedSpec{Master: master, Filer: filer},
+	}
+}
+
+// The Secret key is free-form, so it has to be projected under the fixed
+// master.toml/filer.toml name weed looks for — mounting the Secret wholesale
+// would land the config at /etc/seaweedfs/<key> and be silently ignored.
+func TestMasterConfigSecret_ProjectsKeyAsMasterToml(t *testing.T) {
+	r := &SeaweedReconciler{}
+	m := newConfigSecretCluster(&seaweedv1.MasterSpec{
+		Replicas: 1,
+		ConfigSecret: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "master-config-secret"},
+			Key:                  "master-toml",
+		},
+	}, nil)
+
+	pod := &r.createMasterStatefulSet(m).Spec.Template.Spec
+	vol := podVolume(t, pod, "master-config")
+	if vol.Secret == nil {
+		t.Fatalf("expected master-config to be a Secret volume, got %+v", vol.VolumeSource)
+	}
+	if vol.Secret.SecretName != "master-config-secret" {
+		t.Errorf("expected secretName master-config-secret, got %q", vol.Secret.SecretName)
+	}
+	want := []corev1.KeyToPath{{Key: "master-toml", Path: "master.toml"}}
+	if len(vol.Secret.Items) != 1 || vol.Secret.Items[0] != want[0] {
+		t.Errorf("expected items %+v, got %+v", want, vol.Secret.Items)
+	}
+	if mount := containerMount(t, &pod.Containers[0], "master-config"); mount.MountPath != "/etc/seaweedfs" {
+		t.Errorf("expected mount at /etc/seaweedfs, got %q", mount.MountPath)
+	}
+}
+
+func TestFilerConfigSecret_ProjectsKeyAsFilerToml(t *testing.T) {
+	r := &SeaweedReconciler{}
+	m := newConfigSecretCluster(&seaweedv1.MasterSpec{Replicas: 1}, &seaweedv1.FilerSpec{
+		Replicas: 1,
+		ConfigSecret: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "filer-config-secret"},
+			Key:                  "filer-toml",
+		},
+	})
+
+	pod := &r.createFilerStatefulSet(m).Spec.Template.Spec
+	vol := podVolume(t, pod, "filer-config")
+	if vol.Secret == nil {
+		t.Fatalf("expected filer-config to be a Secret volume, got %+v", vol.VolumeSource)
+	}
+	if vol.Secret.SecretName != "filer-config-secret" {
+		t.Errorf("expected secretName filer-config-secret, got %q", vol.Secret.SecretName)
+	}
+	want := []corev1.KeyToPath{{Key: "filer-toml", Path: "filer.toml"}}
+	if len(vol.Secret.Items) != 1 || vol.Secret.Items[0] != want[0] {
+		t.Errorf("expected items %+v, got %+v", want, vol.Secret.Items)
+	}
+	if mount := containerMount(t, filerContainer(t, pod), "filer-config"); mount.MountPath != "/etc/seaweedfs" {
+		t.Errorf("expected mount at /etc/seaweedfs, got %q", mount.MountPath)
+	}
+}
+
+// The CRD rejects setting both, but an object that predates the rule must
+// still reconcile to one config source rather than two volumes named alike.
+func TestConfigSecret_TakesPrecedenceOverInlineConfig(t *testing.T) {
+	r := &SeaweedReconciler{}
+	inline := "[master.maintenance]\n"
+	m := newConfigSecretCluster(&seaweedv1.MasterSpec{
+		Replicas: 1,
+		Config:   &inline,
+		ConfigSecret: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "master-config-secret"},
+			Key:                  "master.toml",
+		},
+	}, &seaweedv1.FilerSpec{
+		Replicas: 1,
+		Config:   &inline,
+		ConfigSecret: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "filer-config-secret"},
+			Key:                  "filer.toml",
+		},
+	})
+
+	if cm := r.createMasterConfigMap(m); cm != nil {
+		t.Errorf("expected no master ConfigMap when configSecret is set, got %q", cm.Name)
+	}
+	if cm := r.createFilerConfigMap(m); cm != nil {
+		t.Errorf("expected no filer ConfigMap when configSecret is set, got %q", cm.Name)
+	}
+
+	masterPod := &r.createMasterStatefulSet(m).Spec.Template.Spec
+	if vol := podVolume(t, masterPod, "master-config"); vol.ConfigMap != nil {
+		t.Errorf("expected master-config to come from the Secret, got ConfigMap %q", vol.ConfigMap.Name)
+	}
+	filerPod := &r.createFilerStatefulSet(m).Spec.Template.Spec
+	if vol := podVolume(t, filerPod, "filer-config"); vol.ConfigMap != nil {
+		t.Errorf("expected filer-config to come from the Secret, got ConfigMap %q", vol.ConfigMap.Name)
+	}
+}
+
+// A selector missing a name or a key cannot be projected. Mounting it anyway
+// would put an empty /etc/seaweedfs over the component's own defaults — the
+// crashloop hasFilerConfig exists to avoid — so it counts as unset and the
+// inline config still applies.
+func TestConfigSecret_IncompleteSelectorFallsBackToInlineConfig(t *testing.T) {
+	r := &SeaweedReconciler{}
+	inline := "[leveldb2]\nenabled = true\n"
+
+	for name, sel := range map[string]*corev1.SecretKeySelector{
+		"missing key":  {LocalObjectReference: corev1.LocalObjectReference{Name: "cfg"}},
+		"missing name": {Key: "filer.toml"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			m := newConfigSecretCluster(&seaweedv1.MasterSpec{Replicas: 1}, &seaweedv1.FilerSpec{
+				Replicas:     1,
+				Config:       &inline,
+				ConfigSecret: sel,
+			})
+			if cm := r.createFilerConfigMap(m); cm == nil {
+				t.Fatal("expected the inline config to still produce a ConfigMap")
+			}
+			pod := &r.createFilerStatefulSet(m).Spec.Template.Spec
+			if vol := podVolume(t, pod, "filer-config"); vol.ConfigMap == nil {
+				t.Errorf("expected filer-config to come from the ConfigMap, got %+v", vol.VolumeSource)
+			}
+		})
+	}
+}
+
+// Optional must reach the volume: with it set, a Secret that has not been
+// created yet leaves the mount empty instead of wedging the pod in
+// ContainerCreating.
+func TestConfigSecret_PropagatesOptional(t *testing.T) {
+	r := &SeaweedReconciler{}
+	optional := true
+	m := newConfigSecretCluster(&seaweedv1.MasterSpec{
+		Replicas: 1,
+		ConfigSecret: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "cfg"},
+			Key:                  "master.toml",
+			Optional:             &optional,
+		},
+	}, nil)
+
+	pod := &r.createMasterStatefulSet(m).Spec.Template.Spec
+	vol := podVolume(t, pod, "master-config")
+	if vol.Secret == nil || vol.Secret.Optional == nil || !*vol.Secret.Optional {
+		t.Errorf("expected optional to be propagated to the volume, got %+v", vol.VolumeSource)
+	}
+}
+
+// Without either field nothing is mounted at /etc/seaweedfs, so the
+// components keep their built-in defaults.
+func TestConfigSecret_UnsetMountsNothing(t *testing.T) {
+	r := &SeaweedReconciler{}
+	m := newConfigSecretCluster(&seaweedv1.MasterSpec{Replicas: 1}, &seaweedv1.FilerSpec{Replicas: 1})
+
+	for _, pod := range []*corev1.PodSpec{
+		&r.createMasterStatefulSet(m).Spec.Template.Spec,
+		&r.createFilerStatefulSet(m).Spec.Template.Spec,
+	} {
+		for _, vol := range pod.Volumes {
+			if vol.Name == "master-config" || vol.Name == "filer-config" {
+				t.Errorf("expected no config volume when neither config nor configSecret is set, got %q", vol.Name)
+			}
+		}
+	}
+}

--- a/internal/controller/component_config_secret_test.go
+++ b/internal/controller/component_config_secret_test.go
@@ -1,10 +1,18 @@
 package controller
 
 import (
+	"context"
 	"testing"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
 )
@@ -203,5 +211,101 @@ func TestConfigSecret_UnsetMountsNothing(t *testing.T) {
 				t.Errorf("expected no config volume when neither config nor configSecret is set, got %q", vol.Name)
 			}
 		}
+	}
+}
+
+// Moving a config into a Secret is pointless if the ConfigMap holding the old
+// plaintext copy survives: it stays readable to anyone with `get configmap` in
+// the namespace, and owner-reference GC would only collect it when the whole
+// Seaweed CR is deleted.
+func TestConfigSecret_PrunesConfigMapLeftByInlineConfig(t *testing.T) {
+	inline := "[postgres]\npassword = \"hunter2\"\n"
+	before := newConfigSecretCluster(
+		&seaweedv1.MasterSpec{Replicas: 1, Config: &inline},
+		&seaweedv1.FilerSpec{Replicas: 1, Config: &inline},
+	)
+	before.UID = "test-uid"
+
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("clientgoscheme: %v", err)
+	}
+	if err := seaweedv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("seaweedv1: %v", err)
+	}
+
+	// Stand up the ConfigMaps the inline config would have produced, owned by
+	// the CR exactly as the reconciler creates them.
+	masterCM := (&SeaweedReconciler{}).createMasterConfigMap(before)
+	filerCM := (&SeaweedReconciler{}).createFilerConfigMap(before)
+	for _, cm := range []*corev1.ConfigMap{masterCM, filerCM} {
+		if err := controllerutil.SetControllerReference(before, cm, scheme); err != nil {
+			t.Fatalf("set owner ref: %v", err)
+		}
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithRuntimeObjects(before, masterCM, filerCM).Build()
+	r := &SeaweedReconciler{Client: cli, Scheme: scheme, Log: logr.Discard()}
+
+	// The user swaps both components over to a Secret and drops the inline
+	// config, which is the only shape the CRD accepts.
+	after := newConfigSecretCluster(
+		&seaweedv1.MasterSpec{Replicas: 1, ConfigSecret: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "cfg"}, Key: "master.toml",
+		}},
+		&seaweedv1.FilerSpec{Replicas: 1, ConfigSecret: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "cfg"}, Key: "filer.toml",
+		}},
+	)
+	after.UID = before.UID
+
+	ctx := context.Background()
+	if _, _, err := r.ensureMasterConfigMap(ctx, after); err != nil {
+		t.Fatalf("ensureMasterConfigMap: %v", err)
+	}
+	if _, _, err := r.ensureFilerConfigMap(ctx, after); err != nil {
+		t.Fatalf("ensureFilerConfigMap: %v", err)
+	}
+
+	for _, name := range []string{"sw-master", "sw-filer"} {
+		err := cli.Get(ctx, client.ObjectKey{Namespace: "ns", Name: name}, &corev1.ConfigMap{})
+		if !apierrors.IsNotFound(err) {
+			t.Errorf("expected ConfigMap %q to be pruned, got err %v", name, err)
+		}
+	}
+}
+
+// The generated name is not reserved on a cluster the operator has never
+// written it on, so an object it does not control must survive — pruning is
+// garbage collection of our own leftovers, not a claim on the name.
+func TestConfigSecret_PruneLeavesUnownedConfigMapAlone(t *testing.T) {
+	m := newConfigSecretCluster(&seaweedv1.MasterSpec{Replicas: 1}, &seaweedv1.FilerSpec{Replicas: 1})
+	m.UID = "test-uid"
+
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("clientgoscheme: %v", err)
+	}
+	if err := seaweedv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("seaweedv1: %v", err)
+	}
+
+	foreign := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "sw-filer", Namespace: "ns"},
+		Data:       map[string]string{"unrelated": "data"},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(m, foreign).Build()
+	r := &SeaweedReconciler{Client: cli, Scheme: scheme, Log: logr.Discard()}
+
+	if _, _, err := r.ensureFilerConfigMap(context.Background(), m); err != nil {
+		t.Fatalf("ensureFilerConfigMap: %v", err)
+	}
+
+	got := &corev1.ConfigMap{}
+	if err := cli.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "sw-filer"}, got); err != nil {
+		t.Fatalf("expected the unowned ConfigMap to survive, got %v", err)
+	}
+	if got.Data["unrelated"] != "data" {
+		t.Errorf("expected the unowned ConfigMap to be untouched, got %v", got.Data)
 	}
 }

--- a/internal/controller/component_config_secret_test.go
+++ b/internal/controller/component_config_secret_test.go
@@ -267,7 +267,10 @@ func TestConfigSecret_PrunesConfigMapLeftByInlineConfig(t *testing.T) {
 		t.Fatalf("ensureFilerConfigMap: %v", err)
 	}
 
-	for _, name := range []string{"sw-master", "sw-filer"} {
+	// Names come from the objects actually created, so a rename in the
+	// generator fails this loudly instead of leaving it checking the absence
+	// of a ConfigMap nothing ever created.
+	for _, name := range []string{masterCM.Name, filerCM.Name} {
 		err := cli.Get(ctx, client.ObjectKey{Namespace: "ns", Name: name}, &corev1.ConfigMap{})
 		if !apierrors.IsNotFound(err) {
 			t.Errorf("expected ConfigMap %q to be pruned, got err %v", name, err)
@@ -290,8 +293,14 @@ func TestConfigSecret_PruneLeavesUnownedConfigMapAlone(t *testing.T) {
 		t.Fatalf("seaweedv1: %v", err)
 	}
 
+	// Take the name from the generator so the foreign object keeps colliding
+	// with the one the reconciler manages even if that name changes.
+	inline := "[leveldb2]\nenabled = true\n"
+	generated := newConfigSecretCluster(nil, &seaweedv1.FilerSpec{Replicas: 1, Config: &inline})
+	filerName := (&SeaweedReconciler{}).createFilerConfigMap(generated).Name
+
 	foreign := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Name: "sw-filer", Namespace: "ns"},
+		ObjectMeta: metav1.ObjectMeta{Name: filerName, Namespace: "ns"},
 		Data:       map[string]string{"unrelated": "data"},
 	}
 	cli := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(m, foreign).Build()
@@ -302,7 +311,7 @@ func TestConfigSecret_PruneLeavesUnownedConfigMapAlone(t *testing.T) {
 	}
 
 	got := &corev1.ConfigMap{}
-	if err := cli.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "sw-filer"}, got); err != nil {
+	if err := cli.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: filerName}, got); err != nil {
 		t.Fatalf("expected the unowned ConfigMap to survive, got %v", err)
 	}
 	if got.Data["unrelated"] != "data" {

--- a/internal/controller/controller_filer.go
+++ b/internal/controller/controller_filer.go
@@ -25,7 +25,7 @@ func (r *SeaweedReconciler) ensureFilerServers(ctx context.Context, seaweedCR *s
 		return
 	}
 
-	if done, result, err = r.ensureFilerConfigMap(seaweedCR); done {
+	if done, result, err = r.ensureFilerConfigMap(ctx, seaweedCR); done {
 		return
 	}
 
@@ -98,14 +98,16 @@ func (r *SeaweedReconciler) ensureFilerService(seaweedCR *seaweedv1.Seaweed) (bo
 	return ReconcileResult(err)
 }
 
-func (r *SeaweedReconciler) ensureFilerConfigMap(seaweedCR *seaweedv1.Seaweed) (bool, ctrl.Result, error) {
+func (r *SeaweedReconciler) ensureFilerConfigMap(ctx context.Context, seaweedCR *seaweedv1.Seaweed) (bool, ctrl.Result, error) {
 	log := r.Log.WithValues("sw-filer-configmap", seaweedCR.Name)
 
 	filerConfigMap := r.createFilerConfigMap(seaweedCR)
 	if filerConfigMap == nil {
 		// No user-provided filer.toml — skip creation so the filer falls back
 		// to its built-in default store. See createFilerConfigMap for details.
-		return ReconcileResult(nil)
+		// Drop any ConfigMap a previous inline config left behind, so moving
+		// the config into a Secret really does remove the plaintext copy.
+		return ReconcileResult(r.pruneOwnedConfigMap(ctx, seaweedCR, seaweedCR.Name+"-filer"))
 	}
 	if err := controllerutil.SetControllerReference(seaweedCR, filerConfigMap, r.Scheme); err != nil {
 		return ReconcileResult(err)

--- a/internal/controller/controller_filer_configmap.go
+++ b/internal/controller/controller_filer_configmap.go
@@ -20,7 +20,27 @@ import (
 // loaded config and skips its default leveldb2 store initialization —
 // exactly the bug this PR is fixing.
 func hasFilerConfig(m *seaweedv1.Seaweed) bool {
+	if filerConfigSecret(m) != nil {
+		return false
+	}
 	return m.Spec.Filer != nil && m.Spec.Filer.Config != nil && strings.TrimSpace(*m.Spec.Filer.Config) != ""
+}
+
+// filerConfigSecret returns the Secret key holding filer.toml, or nil when
+// none is usable. The CRD rejects setting both Config and ConfigSecret, but
+// the secret still wins here so behaviour stays defined if a CR predates the
+// validation rule. A selector without both a name and a key cannot be
+// projected, so it is treated as unset rather than mounted empty — see
+// hasFilerConfig for why an empty filer.toml is worse than none.
+func filerConfigSecret(m *seaweedv1.Seaweed) *corev1.SecretKeySelector {
+	if m.Spec.Filer == nil || m.Spec.Filer.ConfigSecret == nil {
+		return nil
+	}
+	sel := m.Spec.Filer.ConfigSecret
+	if sel.Name == "" || sel.Key == "" {
+		return nil
+	}
+	return sel
 }
 
 // createFilerConfigMap returns a ConfigMap carrying the user-supplied

--- a/internal/controller/controller_filer_statefulset.go
+++ b/internal/controller/controller_filer_statefulset.go
@@ -84,12 +84,16 @@ func (r *SeaweedReconciler) createFilerStatefulSet(m *seaweedv1.Seaweed) *appsv1
 
 	filerPodSpec := m.BaseFilerSpec().BuildPodSpec()
 	var volumeMounts []corev1.VolumeMount
-	// Only mount the filer ConfigMap when the user supplied non-blank
-	// filer.toml content. Mounting an empty /etc/seaweedfs/filer.toml
-	// makes the filer skip its default leveldb2 store and crashloop
-	// for lack of a backing store. hasFilerConfig keeps this in lock
-	// step with createFilerConfigMap.
-	if hasFilerConfig(m) {
+	// filer.toml comes from a Secret when ConfigSecret is set, otherwise from
+	// the ConfigMap — and only when the user supplied non-blank content.
+	// Mounting an empty /etc/seaweedfs/filer.toml makes the filer skip its
+	// default leveldb2 store and crashloop for lack of a backing store.
+	// hasFilerConfig keeps this in lock step with createFilerConfigMap.
+	if sel := filerConfigSecret(m); sel != nil {
+		vol, mount := configSecretVolumeAndMount("filer-config", "filer.toml", sel)
+		filerPodSpec.Volumes = append(filerPodSpec.Volumes, vol)
+		volumeMounts = append(volumeMounts, mount)
+	} else if hasFilerConfig(m) {
 		filerPodSpec.Volumes = append(filerPodSpec.Volumes, corev1.Volume{
 			Name: "filer-config",
 			VolumeSource: corev1.VolumeSource{
@@ -103,7 +107,7 @@ func (r *SeaweedReconciler) createFilerStatefulSet(m *seaweedv1.Seaweed) *appsv1
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      "filer-config",
 			ReadOnly:  true,
-			MountPath: "/etc/seaweedfs",
+			MountPath: componentConfigDir,
 		})
 	}
 	if tlsVols, tlsMounts := tlsVolumesAndMounts(m); len(tlsVols) > 0 {

--- a/internal/controller/controller_master.go
+++ b/internal/controller/controller_master.go
@@ -15,8 +15,7 @@ import (
 	"github.com/seaweedfs/seaweedfs-operator/internal/controller/label"
 )
 
-func (r *SeaweedReconciler) ensureMaster(seaweedCR *seaweedv1.Seaweed) (done bool, result ctrl.Result, err error) {
-	_ = context.Background()
+func (r *SeaweedReconciler) ensureMaster(ctx context.Context, seaweedCR *seaweedv1.Seaweed) (done bool, result ctrl.Result, err error) {
 	_ = r.Log.WithValues("seaweed", seaweedCR.Name)
 
 	if done, result, err = r.ensureMasterPeerService(seaweedCR); done {
@@ -27,7 +26,7 @@ func (r *SeaweedReconciler) ensureMaster(seaweedCR *seaweedv1.Seaweed) (done boo
 		return
 	}
 
-	if done, result, err = r.ensureMasterConfigMap(seaweedCR); done {
+	if done, result, err = r.ensureMasterConfigMap(ctx, seaweedCR); done {
 		return
 	}
 
@@ -108,12 +107,14 @@ func (r *SeaweedReconciler) ensureMasterStatefulSet(seaweedCR *seaweedv1.Seaweed
 	return ReconcileResult(err)
 }
 
-func (r *SeaweedReconciler) ensureMasterConfigMap(seaweedCR *seaweedv1.Seaweed) (bool, ctrl.Result, error) {
+func (r *SeaweedReconciler) ensureMasterConfigMap(ctx context.Context, seaweedCR *seaweedv1.Seaweed) (bool, ctrl.Result, error) {
 	log := r.Log.WithValues("sw-master-configmap", seaweedCR.Name)
 
 	masterConfigMap := r.createMasterConfigMap(seaweedCR)
 	if masterConfigMap == nil {
-		return ReconcileResult(nil)
+		// Drop any ConfigMap a previous inline config left behind — see the
+		// filer equivalent.
+		return ReconcileResult(r.pruneOwnedConfigMap(ctx, seaweedCR, seaweedCR.Name+"-master"))
 	}
 	if err := controllerutil.SetControllerReference(seaweedCR, masterConfigMap, r.Scheme); err != nil {
 		return ReconcileResult(err)

--- a/internal/controller/controller_master_configmap.go
+++ b/internal/controller/controller_master_configmap.go
@@ -14,7 +14,22 @@ import (
 // the viper-based loader considers any on-disk file a success and would
 // suppress the master's own defaults.
 func hasMasterConfig(m *seaweedv1.Seaweed) bool {
+	if masterConfigSecret(m) != nil {
+		return false
+	}
 	return m.Spec.Master != nil && m.Spec.Master.Config != nil && strings.TrimSpace(*m.Spec.Master.Config) != ""
+}
+
+// masterConfigSecret mirrors filerConfigSecret for the master component.
+func masterConfigSecret(m *seaweedv1.Seaweed) *corev1.SecretKeySelector {
+	if m.Spec.Master == nil || m.Spec.Master.ConfigSecret == nil {
+		return nil
+	}
+	sel := m.Spec.Master.ConfigSecret
+	if sel.Name == "" || sel.Key == "" {
+		return nil
+	}
+	return sel
 }
 
 // createMasterConfigMap returns a ConfigMap carrying the user-supplied

--- a/internal/controller/controller_master_statefulset.go
+++ b/internal/controller/controller_master_statefulset.go
@@ -78,10 +78,15 @@ func (r *SeaweedReconciler) createMasterStatefulSet(m *seaweedv1.Seaweed) *appsv
 
 	masterPodSpec := m.BaseMasterSpec().BuildPodSpec()
 	var masterConfigMounts []corev1.VolumeMount
-	// Only mount the master ConfigMap when the user supplied non-blank
-	// master.toml content. Mirrors the filer fix — see hasMasterConfig
-	// for why whitespace-only counts as "no override".
-	if hasMasterConfig(m) {
+	// master.toml comes from a Secret when ConfigSecret is set, otherwise from
+	// the ConfigMap — and only when the user supplied non-blank content.
+	// Mirrors the filer path; see hasMasterConfig for why whitespace-only
+	// counts as "no override".
+	if sel := masterConfigSecret(m); sel != nil {
+		vol, mount := configSecretVolumeAndMount("master-config", "master.toml", sel)
+		masterPodSpec.Volumes = append(masterPodSpec.Volumes, vol)
+		masterConfigMounts = append(masterConfigMounts, mount)
+	} else if hasMasterConfig(m) {
 		masterPodSpec.Volumes = append(masterPodSpec.Volumes, corev1.Volume{
 			Name: "master-config",
 			VolumeSource: corev1.VolumeSource{
@@ -95,7 +100,7 @@ func (r *SeaweedReconciler) createMasterStatefulSet(m *seaweedv1.Seaweed) *appsv
 		masterConfigMounts = append(masterConfigMounts, corev1.VolumeMount{
 			Name:      "master-config",
 			ReadOnly:  true,
-			MountPath: "/etc/seaweedfs",
+			MountPath: componentConfigDir,
 		})
 	}
 	if tlsVols, tlsMounts := tlsVolumesAndMounts(m); len(tlsVols) > 0 {

--- a/internal/controller/controller_util.go
+++ b/internal/controller/controller_util.go
@@ -102,6 +102,14 @@ func (r *SeaweedReconciler) deleteIfExists(ctx context.Context, obj client.Objec
 // happens to occupy the generated name is left alone — unlike the workloads
 // deleteIfExists handles, this name is one the operator may never have
 // claimed on this cluster.
+//
+// The UID precondition carries that ownership check through to the delete: if
+// the object is replaced between the read and the write, the delete lands on a
+// UID that no longer exists and fails instead of removing whatever now holds
+// the name. A conflict is that outcome, not an error — the next reconcile
+// reads the replacement and finds it is not ours. The precondition is
+// deliberately not on resourceVersion, which would also fail on an unrelated
+// edit and leave the plaintext ConfigMap in place.
 func (r *SeaweedReconciler) pruneOwnedConfigMap(ctx context.Context, m metav1.Object, name string) error {
 	cm := &corev1.ConfigMap{}
 	if err := r.Get(ctx, client.ObjectKey{Namespace: m.GetNamespace(), Name: name}, cm); err != nil {
@@ -110,7 +118,11 @@ func (r *SeaweedReconciler) pruneOwnedConfigMap(ctx context.Context, m metav1.Ob
 	if !metav1.IsControlledBy(cm, m) {
 		return nil
 	}
-	return client.IgnoreNotFound(r.Delete(ctx, cm))
+	err := r.Delete(ctx, cm, client.Preconditions{UID: &cm.UID})
+	if errors.IsConflict(err) {
+		return nil
+	}
+	return client.IgnoreNotFound(err)
 }
 
 func (r *SeaweedReconciler) addSpecToAnnotation(d *appsv1.Deployment) error {

--- a/internal/controller/controller_util.go
+++ b/internal/controller/controller_util.go
@@ -92,6 +92,27 @@ func (r *SeaweedReconciler) deleteIfExists(ctx context.Context, obj client.Objec
 	return true, client.IgnoreNotFound(r.Delete(ctx, obj))
 }
 
+// pruneOwnedConfigMap deletes a generated ConfigMap that the current spec no
+// longer calls for. It exists for the move from an inline config to a
+// configSecret: the ConfigMap left behind is precisely the plaintext copy of
+// the credentials that move is meant to get rid of, and it would otherwise
+// survive in etcd until the Seaweed CR itself is deleted.
+//
+// Only a ConfigMap this CR controls is removed, so an unrelated object that
+// happens to occupy the generated name is left alone — unlike the workloads
+// deleteIfExists handles, this name is one the operator may never have
+// claimed on this cluster.
+func (r *SeaweedReconciler) pruneOwnedConfigMap(ctx context.Context, m metav1.Object, name string) error {
+	cm := &corev1.ConfigMap{}
+	if err := r.Get(ctx, client.ObjectKey{Namespace: m.GetNamespace(), Name: name}, cm); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	if !metav1.IsControlledBy(cm, m) {
+		return nil
+	}
+	return client.IgnoreNotFound(r.Delete(ctx, cm))
+}
+
 func (r *SeaweedReconciler) addSpecToAnnotation(d *appsv1.Deployment) error {
 	b, err := json.Marshal(d.Spec.Template.Spec)
 	if err != nil {

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -335,6 +335,36 @@ func tlsEffective(m *seaweedv1.Seaweed) bool {
 	return tlsEnabled(m) && certManagerAvailableCached()
 }
 
+// componentConfigDir is where weed's viper loader looks for a component's own
+// toml (master.toml, filer.toml).
+const componentConfigDir = "/etc/seaweedfs"
+
+// configSecretVolumeAndMount projects a single Secret key as fileName under
+// componentConfigDir, so a component's toml can live in a Secret instead of
+// inline in the CR. Only the referenced key is projected: the rest of the
+// Secret must not land next to master.toml/filer.toml, and the key inside the
+// Secret is free to be named anything.
+//
+// The selector's Optional flag is passed through — with it set, a missing
+// Secret leaves the directory empty instead of blocking pod startup, which is
+// the same "no config, use the built-in defaults" state as an unset field.
+func configSecretVolumeAndMount(volumeName, fileName string, sel *corev1.SecretKeySelector) (corev1.Volume, corev1.VolumeMount) {
+	return corev1.Volume{
+			Name: volumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: sel.Name,
+					Items:      []corev1.KeyToPath{{Key: sel.Key, Path: fileName}},
+					Optional:   sel.Optional,
+				},
+			},
+		}, corev1.VolumeMount{
+			Name:      volumeName,
+			ReadOnly:  true,
+			MountPath: componentConfigDir,
+		}
+}
+
 // tlsVolumesAndMounts returns the set of pod volumes and container mounts
 // that wire the shared TLS Secret and security.toml Secret into a component
 // pod. Returns empty slices when neither TLS nor the security config is

--- a/internal/controller/seaweed_controller.go
+++ b/internal/controller/seaweed_controller.go
@@ -139,7 +139,7 @@ func (r *SeaweedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return result, err
 	}
 
-	if done, result, err = r.ensureMaster(seaweedCR); done {
+	if done, result, err = r.ensureMaster(ctx, seaweedCR); done {
 		return result, err
 	}
 


### PR DESCRIPTION
Closes #344.

`master.toml` and `filer.toml` routinely hold credentials — remote storage keys, the filer's metadata store password — but `spec.master.config` / `spec.filer.config` only accept an inline string, so that material sits in plaintext in the live CR, in etcd, and in GitOps-rendered manifests. Only the S3 gateway could externalize its config.

## What this adds

`configSecret` on both `MasterSpec` and `FilerSpec`, mirroring `s3.configSecret`:

```yaml
master:
  configSecret:
    name: seaweedfs-master-config
    key: master.toml
filer:
  configSecret:
    name: seaweedfs-filer-config
    key: filer.toml
```

The referenced key is projected as `master.toml` / `filer.toml` into `/etc/seaweedfs` — the directory each component already reads its toml from — so the Secret can be owned and rotated by External Secrets Operator, Sealed Secrets or SOPS. The operator never reads the Secret itself; the kubelet mounts it, so rotation updates the file in place (a Pod restart is still needed for weed to re-read it, same as with the ConfigMap today).

## Decisions worth reviewing

- **Only the referenced key is projected**, not the whole Secret. The key inside the Secret is then free to be named anything, and unrelated entries can't land next to the toml.
- **An incomplete selector (no name or no key) counts as unset** and the inline config still applies. Mounting it anyway would put an empty `/etc/seaweedfs` over the component's defaults — the same crashloop `hasFilerConfig` exists to avoid, since weed treats any on-disk toml as a loaded config and skips its built-in defaults (leveldb2 for the filer).
- **`config` + `configSecret` together is rejected by the CRD** (a CEL rule on each spec), so the ambiguity surfaces at apply time rather than silently resolving. The controller still prefers the Secret, which keeps any CR predating the rule reconciling to one config source.
- `Optional` on the selector is passed through to the volume, so an opt-in "Secret may not exist yet" leaves the mount empty instead of wedging the Pod in `ContainerCreating`.

Purely additive: `config` behaves exactly as before, and no existing field changed name or type.

## Testing

`make test` (unit + envtest) passes. New coverage in `internal/controller/component_config_secret_test.go` (projection path/name, precedence over inline config, incomplete-selector fallback, `optional` pass-through, nothing mounted when neither is set) and `component_config_secret_envtest_test.go`, which puts the exclusivity rule in front of a real apiserver — CEL rules only fail on cost or compilation there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Master and filer TOML configuration can now be loaded from an existing Kubernetes Secret.
  * Supports selecting a Secret key, optional Secrets, and mounting content as the appropriate component configuration file.
  * Secret-backed configuration takes precedence over inline configuration.
* **Validation**
  * Inline and Secret-backed configuration cannot be specified together.
* **Bug Fixes**
  * Previously generated configuration is cleaned up when switching to Secret-backed configuration.
* **Documentation**
  * Added usage guidance, Secret rotation behavior, and restart requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->