### PR TITLE
Add conditional RBAC configuration

### DIFF
--- a/deploy/helm/templates/rbac/leader_election_role.yaml
+++ b/deploy/helm/templates/rbac/leader_election_role.yaml
@@ -1,4 +1,5 @@
 # permissions to do leader election.
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -41,3 +42,4 @@ rules:
   - get
   - list
   - update
+{{- end -}}

--- a/deploy/helm/templates/rbac/leader_election_role_binding.yaml
+++ b/deploy/helm/templates/rbac/leader_election_role_binding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -11,3 +12,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "seaweedfs-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/deploy/helm/templates/rbac/role.yaml
+++ b/deploy/helm/templates/rbac/role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create -}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -226,3 +227,4 @@ rules:
   - patch
   - update
   - watch
+{{- end -}}

--- a/deploy/helm/templates/rbac/role_binding.yaml
+++ b/deploy/helm/templates/rbac/role_binding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -10,3 +11,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "seaweedfs-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/deploy/helm/templates/rbac/seaweed_editor_role.yaml
+++ b/deploy/helm/templates/rbac/seaweed_editor_role.yaml
@@ -1,4 +1,5 @@
 # permissions for end users to edit seaweeds.
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -22,3 +23,4 @@ rules:
   - seaweeds/status
   verbs:
   - get
+{{- end -}}

--- a/deploy/helm/templates/rbac/seaweed_viewer_role.yaml
+++ b/deploy/helm/templates/rbac/seaweed_viewer_role.yaml
@@ -1,4 +1,5 @@
 # permissions for end users to view seaweeds.
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -18,3 +19,4 @@ rules:
   - seaweeds/status
   verbs:
   - get
+{{- end -}}

--- a/deploy/helm/templates/webhook/job-update-webhook-certificates.yaml
+++ b/deploy/helm/templates/webhook/job-update-webhook-certificates.yaml
@@ -1,5 +1,5 @@
 {{- $certManager := default dict .Values.webhook.certManager -}}
-{{- if and .Values.webhook.enabled (not $certManager.enabled) -}}
+{{- if and .Values.rbac.create .Values.webhook.enabled (not $certManager.enabled) -}}
 ---
 apiVersion: batch/v1
 kind: Job

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -24,6 +24,7 @@ crds:
 
 ## Configure Kubernetes Rbac parameters
 rbac:
+  create: true
   serviceAccount:
     # -- Specifies whether a service account should be created
     create: true


### PR DESCRIPTION
## 🛠️ Description <!-- What are you changing? -->

Added Values.rbac.create. This allows for the configuration of seaweedfs-operator helm RBAC to be conditional.

## 🎯 Motivation <!--- Why is this change required? What problem does it solve? -->

This allows us to provide custom RBAC configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable RBAC resource creation for Helm deployments.
  * Enabled RBAC resources by default.
  * Prevented RBAC and webhook certificate resources from being deployed when RBAC creation is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->