### PR TITLE
feat: Optionally disable RBAC creation

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -34,7 +34,7 @@ A Helm chart for the seaweedfs-operator
 | podSecurityContext.runAsUser | int | `65532` |  |
 | port.name | string | `"http"` | name of the container port to use for the Kubernete service and ingress |
 | port.number | int | `8080` | container port number to use for the Kubernete service and ingress |
-| rbac.create | bool | `true` | Create the Roles, ClusterRoles and bindings the chart would otherwise install. Set to false when RBAC is provisioned out-of-band (e.g., a restricted cluster where a platform team owns it); the operator still needs the same permissions bound to its service account. |
+| rbac.create | bool | `true` | Create the Roles, ClusterRoles and bindings the chart would otherwise install. Set to false when RBAC is provisioned out-of-band (e.g., a restricted cluster where a platform team owns it). Two service accounts then need the equivalent permissions bound before install: the operator's, and the pre-install webhook certificate hook's, which blocks the release if it cannot reach its secret and the webhook configurations. Setting webhook.certManager.enabled removes that hook. |
 | rbac.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | rbac.serviceAccount.automount | bool | `true` | Automount service account token for the server service account |
 | rbac.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -34,6 +34,7 @@ A Helm chart for the seaweedfs-operator
 | podSecurityContext.runAsUser | int | `65532` |  |
 | port.name | string | `"http"` | name of the container port to use for the Kubernete service and ingress |
 | port.number | int | `8080` | container port number to use for the Kubernete service and ingress |
+| rbac.create | bool | `true` | Enable or disable RBAC creation |
 | rbac.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | rbac.serviceAccount.automount | bool | `true` | Automount service account token for the server service account |
 | rbac.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -34,7 +34,7 @@ A Helm chart for the seaweedfs-operator
 | podSecurityContext.runAsUser | int | `65532` |  |
 | port.name | string | `"http"` | name of the container port to use for the Kubernete service and ingress |
 | port.number | int | `8080` | container port number to use for the Kubernete service and ingress |
-| rbac.create | bool | `true` | Enable or disable RBAC creation |
+| rbac.create | bool | `true` | Create the Roles, ClusterRoles and bindings the chart would otherwise install. Set to false when RBAC is provisioned out-of-band (e.g., a restricted cluster where a platform team owns it); the operator still needs the same permissions bound to its service account. |
 | rbac.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | rbac.serviceAccount.automount | bool | `true` | Automount service account token for the server service account |
 | rbac.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |

--- a/deploy/helm/templates/rbac/leader_election_role.yaml
+++ b/deploy/helm/templates/rbac/leader_election_role.yaml
@@ -1,5 +1,5 @@
+{{- if .Values.rbac.create }}
 # permissions to do leader election.
-{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -42,4 +42,4 @@ rules:
   - get
   - list
   - update
-{{- end -}}
+{{- end }}

--- a/deploy/helm/templates/rbac/leader_election_role.yaml
+++ b/deploy/helm/templates/rbac/leader_election_role.yaml
@@ -1,4 +1,5 @@
 # permissions to do leader election.
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -41,3 +42,4 @@ rules:
   - get
   - list
   - update
+{{- end -}}

--- a/deploy/helm/templates/rbac/leader_election_role_binding.yaml
+++ b/deploy/helm/templates/rbac/leader_election_role_binding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -12,4 +12,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "seaweedfs-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
-{{- end -}}
+{{- end }}

--- a/deploy/helm/templates/rbac/leader_election_role_binding.yaml
+++ b/deploy/helm/templates/rbac/leader_election_role_binding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -11,3 +12,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "seaweedfs-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/deploy/helm/templates/rbac/role.yaml
+++ b/deploy/helm/templates/rbac/role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if .Values.rbac.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -227,4 +227,4 @@ rules:
   - patch
   - update
   - watch
-{{- end -}}
+{{- end }}

--- a/deploy/helm/templates/rbac/role.yaml
+++ b/deploy/helm/templates/rbac/role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create -}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -226,3 +227,4 @@ rules:
   - patch
   - update
   - watch
+{{- end -}}

--- a/deploy/helm/templates/rbac/role_binding.yaml
+++ b/deploy/helm/templates/rbac/role_binding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -11,4 +11,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "seaweedfs-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
-{{- end -}}
+{{- end }}

--- a/deploy/helm/templates/rbac/role_binding.yaml
+++ b/deploy/helm/templates/rbac/role_binding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -10,3 +11,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "seaweedfs-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/deploy/helm/templates/rbac/seaweed_editor_role.yaml
+++ b/deploy/helm/templates/rbac/seaweed_editor_role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create }}
 # permissions for end users to edit seaweeds.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -22,3 +23,4 @@ rules:
   - seaweeds/status
   verbs:
   - get
+{{- end }}

--- a/deploy/helm/templates/rbac/seaweed_editor_role.yaml
+++ b/deploy/helm/templates/rbac/seaweed_editor_role.yaml
@@ -1,5 +1,4 @@
 # permissions for end users to edit seaweeds.
-{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -23,4 +22,3 @@ rules:
   - seaweeds/status
   verbs:
   - get
-{{- end -}}

--- a/deploy/helm/templates/rbac/seaweed_editor_role.yaml
+++ b/deploy/helm/templates/rbac/seaweed_editor_role.yaml
@@ -1,4 +1,5 @@
 # permissions for end users to edit seaweeds.
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -22,3 +23,4 @@ rules:
   - seaweeds/status
   verbs:
   - get
+{{- end -}}

--- a/deploy/helm/templates/rbac/seaweed_viewer_role.yaml
+++ b/deploy/helm/templates/rbac/seaweed_viewer_role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create }}
 # permissions for end users to view seaweeds.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -18,3 +19,4 @@ rules:
   - seaweeds/status
   verbs:
   - get
+{{- end }}

--- a/deploy/helm/templates/rbac/seaweed_viewer_role.yaml
+++ b/deploy/helm/templates/rbac/seaweed_viewer_role.yaml
@@ -1,4 +1,5 @@
 # permissions for end users to view seaweeds.
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -18,3 +19,4 @@ rules:
   - seaweeds/status
   verbs:
   - get
+{{- end -}}

--- a/deploy/helm/templates/rbac/seaweed_viewer_role.yaml
+++ b/deploy/helm/templates/rbac/seaweed_viewer_role.yaml
@@ -1,5 +1,4 @@
 # permissions for end users to view seaweeds.
-{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -19,4 +18,3 @@ rules:
   - seaweeds/status
   verbs:
   - get
-{{- end -}}

--- a/deploy/helm/templates/webhook/job-update-webhook-certificates.yaml
+++ b/deploy/helm/templates/webhook/job-update-webhook-certificates.yaml
@@ -1,5 +1,5 @@
 {{- $certManager := default dict .Values.webhook.certManager -}}
-{{- if and .Values.webhook.enabled (not $certManager.enabled) -}}
+{{- if and .Values.rbac.create .Values.webhook.enabled (not $certManager.enabled) -}}
 ---
 apiVersion: batch/v1
 kind: Job

--- a/deploy/helm/templates/webhook/job-update-webhook-certificates.yaml
+++ b/deploy/helm/templates/webhook/job-update-webhook-certificates.yaml
@@ -123,6 +123,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-10"
+{{- if .Values.rbac.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -191,4 +192,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "seaweedfs-operator.fullname" . }}-update-webhook-certificates
     namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end -}}

--- a/deploy/helm/templates/webhook/job-update-webhook-certificates.yaml
+++ b/deploy/helm/templates/webhook/job-update-webhook-certificates.yaml
@@ -1,5 +1,5 @@
 {{- $certManager := default dict .Values.webhook.certManager -}}
-{{- if and .Values.rbac.create .Values.webhook.enabled (not $certManager.enabled) -}}
+{{- if and .Values.webhook.enabled (not $certManager.enabled) -}}
 ---
 apiVersion: batch/v1
 kind: Job

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -24,6 +24,7 @@ crds:
 
 ## Configure Kubernetes Rbac parameters
 rbac:
+  create: true
   serviceAccount:
     # -- Specifies whether a service account should be created
     create: true

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -24,6 +24,10 @@ crds:
 
 ## Configure Kubernetes Rbac parameters
 rbac:
+  # -- Create the Roles, ClusterRoles and bindings the chart would otherwise
+  # install. Set to false when RBAC is provisioned out-of-band (e.g., a
+  # restricted cluster where a platform team owns it); the operator still
+  # needs the same permissions bound to its service account.
   create: true
   serviceAccount:
     # -- Specifies whether a service account should be created

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -26,8 +26,11 @@ crds:
 rbac:
   # -- Create the Roles, ClusterRoles and bindings the chart would otherwise
   # install. Set to false when RBAC is provisioned out-of-band (e.g., a
-  # restricted cluster where a platform team owns it); the operator still
-  # needs the same permissions bound to its service account.
+  # restricted cluster where a platform team owns it). Two service accounts
+  # then need the equivalent permissions bound before install: the operator's,
+  # and the pre-install webhook certificate hook's, which blocks the release if
+  # it cannot reach its secret and the webhook configurations. Setting
+  # webhook.certManager.enabled removes that hook.
   create: true
   serviceAccount:
     # -- Specifies whether a service account should be created

--- a/test/helm/rbac_create_test.go
+++ b/test/helm/rbac_create_test.go
@@ -53,7 +53,16 @@ func TestHelmRBACCreate(t *testing.T) {
 	t.Run("disabled renders no RBAC", func(t *testing.T) {
 		// Default webhook config, i.e. the certgen hook job path, which
 		// carries RBAC of its own outside templates/rbac.
-		assertNoRBAC(t, renderDocs(t, chartDir, "--set", "rbac.create=false"))
+		docs := renderDocs(t, chartDir, "--set", "rbac.create=false")
+		assertNoRBAC(t, docs)
+
+		// The hook Job names this ServiceAccount, so it stays ungated on
+		// purpose: the Job cannot start without it, and an out-of-band
+		// RoleBinding needs a subject that already exists.
+		const hookSA = "ServiceAccount/rbac-test-seaweedfs-operator-update-webhook-certificates"
+		if !renderedKeys(docs)[hookSA] {
+			t.Errorf("rbac.create=false must still render %s; the pre-install hook Job references it and external bindings need it as a subject", hookSA)
+		}
 	})
 
 	t.Run("disabled renders no RBAC with cert-manager", func(t *testing.T) {
@@ -79,10 +88,7 @@ func TestHelmRBACCreate(t *testing.T) {
 			{"ClusterRole", "rbac-test-seaweedfs-operator-update-webhook-certificates"},
 			{"ClusterRoleBinding", "rbac-test-seaweedfs-operator-update-webhook-certificates"},
 		}
-		rendered := map[string]bool{}
-		for _, doc := range docs {
-			rendered[docKey(doc)] = true
-		}
+		rendered := renderedKeys(docs)
 		for _, w := range want {
 			if key := w.kind + "/" + w.name; !rendered[key] {
 				t.Errorf("default values no longer render %s; rbac.create defaults to true and must stay backward compatible", key)
@@ -110,6 +116,15 @@ func assertNoRBAC(t *testing.T, docs []map[string]any) {
 			t.Errorf("rbac.create=false still renders %s; it must be gated on .Values.rbac.create", docKey(doc))
 		}
 	}
+}
+
+// renderedKeys indexes rendered documents by docKey for presence checks.
+func renderedKeys(docs []map[string]any) map[string]bool {
+	keys := map[string]bool{}
+	for _, doc := range docs {
+		keys[docKey(doc)] = true
+	}
+	return keys
 }
 
 // docKey identifies a rendered document for test failure messages.

--- a/test/helm/rbac_create_test.go
+++ b/test/helm/rbac_create_test.go
@@ -1,0 +1,165 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helm
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+// rbacKinds are every kind rbac.create is expected to gate. A chart that
+// renders any of these while rbac.create is false breaks the restricted
+// installs the flag exists for: the cluster admin provisions RBAC
+// out-of-band and the release must not fight them for ownership.
+var rbacKinds = map[string]bool{
+	"Role":               true,
+	"RoleBinding":        true,
+	"ClusterRole":        true,
+	"ClusterRoleBinding": true,
+}
+
+// TestHelmRBACCreate covers both sides of the rbac.create switch. The
+// disabled cases are the regression guard: RBAC lives in several
+// templates (the manager role, leader election, the end-user
+// editor/viewer roles, and the webhook certificate hook job), so a new
+// RBAC resource added later without the conditional silently reintroduces
+// the resources this flag promises to suppress.
+func TestHelmRBACCreate(t *testing.T) {
+	chartDir := filepath.Join(projectRoot(t), "deploy", "helm")
+
+	t.Run("disabled renders no RBAC", func(t *testing.T) {
+		// Default webhook config, i.e. the certgen hook job path, which
+		// carries RBAC of its own outside templates/rbac.
+		assertNoRBAC(t, renderDocs(t, chartDir, "--set", "rbac.create=false"))
+	})
+
+	t.Run("disabled renders no RBAC with cert-manager", func(t *testing.T) {
+		// The cert-manager path skips the hook job; assert the other
+		// templates stay gated regardless of which webhook mode is on.
+		assertNoRBAC(t, renderDocs(t, chartDir,
+			"--set", "rbac.create=false",
+			"--set", "webhook.certManager.enabled=true"))
+	})
+
+	t.Run("enabled by default renders every RBAC resource", func(t *testing.T) {
+		docs := renderDocs(t, chartDir)
+
+		want := []struct{ kind, name string }{
+			{"ClusterRole", "rbac-test-seaweedfs-operator-manager-role"},
+			{"ClusterRoleBinding", "rbac-test-seaweedfs-operator-manager-rolebinding"},
+			{"Role", "rbac-test-seaweedfs-operator-leader-election-role"},
+			{"RoleBinding", "rbac-test-seaweedfs-operator-leader-election-rolebinding"},
+			{"ClusterRole", "seaweed-editor-role"},
+			{"ClusterRole", "seaweed-viewer-role"},
+			{"Role", "rbac-test-seaweedfs-operator-update-webhook-certificates"},
+			{"RoleBinding", "rbac-test-seaweedfs-operator-update-webhook-certificates"},
+			{"ClusterRole", "rbac-test-seaweedfs-operator-update-webhook-certificates"},
+			{"ClusterRoleBinding", "rbac-test-seaweedfs-operator-update-webhook-certificates"},
+		}
+		rendered := map[string]bool{}
+		for _, doc := range docs {
+			rendered[docKey(doc)] = true
+		}
+		for _, w := range want {
+			if key := w.kind + "/" + w.name; !rendered[key] {
+				t.Errorf("default values no longer render %s; rbac.create defaults to true and must stay backward compatible", key)
+			}
+		}
+	})
+
+	t.Run("enabled renders complete manifests", func(t *testing.T) {
+		// A guard on `{{- if ... -}}`: the trailing trim marker eats the
+		// newline after the conditional and glues the following line onto
+		// the preceding one, which silently comments out apiVersion when
+		// the template opens with a YAML comment.
+		for _, doc := range renderDocs(t, chartDir) {
+			if apiVersion, _ := doc["apiVersion"].(string); apiVersion == "" {
+				t.Errorf("rendered document %q has no apiVersion; check the whitespace trim markers on its template conditional", docKey(doc))
+			}
+		}
+	})
+}
+
+func assertNoRBAC(t *testing.T, docs []map[string]any) {
+	t.Helper()
+	for _, doc := range docs {
+		if kind, _ := doc["kind"].(string); rbacKinds[kind] {
+			t.Errorf("rbac.create=false still renders %s; it must be gated on .Values.rbac.create", docKey(doc))
+		}
+	}
+}
+
+// docKey identifies a rendered document for test failure messages.
+func docKey(doc map[string]any) string {
+	kind, _ := doc["kind"].(string)
+	metadata, _ := doc["metadata"].(map[string]any)
+	name, _ := metadata["name"].(string)
+	return fmt.Sprintf("%s/%s", kind, name)
+}
+
+// renderDocs runs `helm template` and returns every non-empty rendered
+// document as a generic map, so assertions can inspect fields (like a
+// missing apiVersion) that typed decoding would quietly drop.
+func renderDocs(t *testing.T, chartDir string, extraArgs ...string) []map[string]any {
+	t.Helper()
+	args := append([]string{"template", "rbac-test", chartDir}, extraArgs...)
+	// Timeout so a stalled render can't hang CI.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "helm", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			t.Fatalf("helm template timed out after 30s\nstderr: %s", stderr.String())
+		}
+		// Missing helm binary: skip on a dev machine. Render error: fail.
+		if errors.Is(err, exec.ErrNotFound) {
+			t.Skipf("helm not found in PATH; skipping RBAC toggle test: %v", err)
+		}
+		t.Fatalf("helm template %v failed: %v\nstderr: %s", extraArgs, err, stderr.String())
+	}
+
+	var docs []map[string]any
+	dec := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(stdout.Bytes()), 4096)
+	for {
+		var doc map[string]any
+		if err := dec.Decode(&doc); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			t.Fatalf("helm template %v produced undecodable YAML: %v", extraArgs, err)
+		}
+		if len(doc) > 0 {
+			docs = append(docs, doc)
+		}
+	}
+	if len(docs) == 0 {
+		t.Fatalf("helm template %v rendered no documents", extraArgs)
+	}
+	return docs
+}


### PR DESCRIPTION
Make it possible to disable the creation of RBAC resources so they can be created externally in restricted environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Helm chart option to enable or disable creation of RBAC resources.
  - RBAC creation remains enabled by default for existing deployments.
  - Supports deployments where RBAC resources are managed externally.
  - Documents release-blocking certificate setup behavior and cert-manager compatibility.
- **Documentation**
  - Documented required permissions for externally managed RBAC.
- **Tests**
  - Added coverage confirming RBAC resources are correctly created or omitted across supported configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->