### PR TITLE
Apply a rotated S3 credentials secret key to the identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,7 +643,10 @@ underlying IAM object. Set `reclaimPolicy: Retain` to opt out.
   absent or empty the operator **generates** a key pair and writes it
   (the operator-created `Secret` is annotated as managed and removed with
   the CR under `reclaimPolicy: Delete`); if the `Secret` already holds
-  both keys they are **adopted** and registered on the identity. A
+  both keys they are **adopted** and registered on the identity. A later
+  change to the `Secret` is **rotated onto the identity**: a new access
+  key is registered and the superseded pair revoked, and a rotation that
+  changes only the secret key is rewritten onto the same access key. A
   user-managed `Secret` is never deleted by the controller. The secret
   key is written only to the `Secret`, never to status.
 

--- a/internal/controller/iam_admin.go
+++ b/internal/controller/iam_admin.go
@@ -50,6 +50,10 @@ type IAMAdmin interface {
 
 	// CreateAccessKey registers an explicit credential pair on an identity.
 	CreateAccessKey(ctx context.Context, user, accessKey, secretKey string) error
+	// UpdateAccessKey replaces the secret key of an access key already
+	// registered on an identity, keeping the access key id. Returns
+	// ErrIAMNotFound if the identity does not hold the access key.
+	UpdateAccessKey(ctx context.Context, user, accessKey, secretKey string) error
 	// DeleteAccessKey removes a credential pair. Idempotent.
 	DeleteAccessKey(ctx context.Context, user, accessKey string) error
 
@@ -138,6 +142,10 @@ func (a *swadminIAMAdmin) DeleteUser(ctx context.Context, name string) error {
 
 func (a *swadminIAMAdmin) CreateAccessKey(ctx context.Context, user, accessKey, secretKey string) error {
 	return mapIAMError(a.c.CreateAccessKey(ctx, user, accessKey, secretKey))
+}
+
+func (a *swadminIAMAdmin) UpdateAccessKey(ctx context.Context, user, accessKey, secretKey string) error {
+	return mapIAMError(a.c.UpdateAccessKey(ctx, user, accessKey, secretKey))
 }
 
 func (a *swadminIAMAdmin) DeleteAccessKey(ctx context.Context, user, accessKey string) error {

--- a/internal/controller/iam_admin_test.go
+++ b/internal/controller/iam_admin_test.go
@@ -66,12 +66,11 @@ func TestMapIAMError_PassesThroughOther(t *testing.T) {
 // ErrIAMNotFound when absent; DeleteUser/DeleteAccessKey/DeletePolicy are
 // idempotent; AttachPolicy/DetachPolicy require the user to exist.
 type fakeIAMAdmin struct {
-	mu         sync.Mutex
-	users      map[string]*swadmin.IAMUser
-	policies   map[string]string
-	secretKeys map[string]string // accessKey -> secretKey, to assert generation/adoption
-	providers  map[string]string // issuerURL -> arn
-	calls      []string
+	mu        sync.Mutex
+	users     map[string]*swadmin.IAMUser
+	policies  map[string]string
+	providers map[string]string // issuerURL -> arn
+	calls     []string
 
 	createUserErr   error
 	createAKErr     error
@@ -82,10 +81,9 @@ type fakeIAMAdmin struct {
 
 func newFakeIAMAdmin() *fakeIAMAdmin {
 	return &fakeIAMAdmin{
-		users:      map[string]*swadmin.IAMUser{},
-		policies:   map[string]string{},
-		secretKeys: map[string]string{},
-		providers:  map[string]string{},
+		users:     map[string]*swadmin.IAMUser{},
+		policies:  map[string]string{},
+		providers: map[string]string{},
 	}
 }
 
@@ -105,7 +103,7 @@ func (f *fakeIAMAdmin) GetUser(_ context.Context, name string) (*swadmin.IAMUser
 		return nil, ErrIAMNotFound
 	}
 	cp := *u
-	cp.AccessKeys = append([]string(nil), u.AccessKeys...)
+	cp.Credentials = append([]swadmin.IAMCredential(nil), u.Credentials...)
 	cp.PolicyNames = append([]string(nil), u.PolicyNames...)
 	return &cp, nil
 }
@@ -157,15 +155,29 @@ func (f *fakeIAMAdmin) CreateAccessKey(_ context.Context, user, accessKey, secre
 	if !ok {
 		return ErrIAMNotFound
 	}
-	for _, existing := range u.AccessKeys {
-		if existing == accessKey {
-			// Mirror the IAM service, which rejects a duplicate access key.
-			return errors.New("access key already exists")
+	if _, exists := u.Credential(accessKey); exists {
+		// Mirror the IAM service, which rejects a duplicate access key.
+		return errors.New("access key already exists")
+	}
+	u.Credentials = append(u.Credentials, swadmin.IAMCredential{AccessKey: accessKey, SecretKey: secretKey})
+	return nil
+}
+
+func (f *fakeIAMAdmin) UpdateAccessKey(_ context.Context, user, accessKey, secretKey string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.record("UpdateAccessKey:" + user + ":" + accessKey)
+	u, ok := f.users[user]
+	if !ok {
+		return ErrIAMNotFound
+	}
+	for i := range u.Credentials {
+		if u.Credentials[i].AccessKey == accessKey {
+			u.Credentials[i].SecretKey = secretKey
+			return nil
 		}
 	}
-	u.AccessKeys = append(u.AccessKeys, accessKey)
-	f.secretKeys[accessKey] = secretKey
-	return nil
+	return ErrIAMNotFound
 }
 
 func (f *fakeIAMAdmin) DeleteAccessKey(_ context.Context, user, accessKey string) error {
@@ -176,14 +188,13 @@ func (f *fakeIAMAdmin) DeleteAccessKey(_ context.Context, user, accessKey string
 	if !ok {
 		return nil
 	}
-	kept := u.AccessKeys[:0]
-	for _, ak := range u.AccessKeys {
-		if ak != accessKey {
-			kept = append(kept, ak)
+	kept := u.Credentials[:0]
+	for _, c := range u.Credentials {
+		if c.AccessKey != accessKey {
+			kept = append(kept, c)
 		}
 	}
-	u.AccessKeys = kept
-	delete(f.secretKeys, accessKey)
+	u.Credentials = kept
 	return nil
 }
 
@@ -289,7 +300,20 @@ func (f *fakeIAMAdmin) userKeys(name string) []string {
 	if !ok {
 		return nil
 	}
-	return append([]string(nil), u.AccessKeys...)
+	return u.AccessKeys()
+}
+
+// secretKeyFor returns the secret key the identity holds for accessKey, or ""
+// when the key is not registered.
+func (f *fakeIAMAdmin) secretKeyFor(user, accessKey string) string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	u, ok := f.users[user]
+	if !ok {
+		return ""
+	}
+	c, _ := u.Credential(accessKey)
+	return c.SecretKey
 }
 
 func (f *fakeIAMAdmin) PutOIDCProvider(_ context.Context, provider swadmin.OIDCProvider) (string, error) {

--- a/internal/controller/iam_controller_test.go
+++ b/internal/controller/iam_controller_test.go
@@ -373,8 +373,8 @@ func TestS3Credentials_AdoptsExistingSecret(t *testing.T) {
 	if keys := fa.userKeys("alice"); len(keys) != 1 || keys[0] != "AKIAADOPTED" {
 		t.Fatalf("expected adopted key AKIAADOPTED, got %v", keys)
 	}
-	if fa.secretKeys["AKIAADOPTED"] != "supersecret" {
-		t.Errorf("adopted secret key mismatch: %q", fa.secretKeys["AKIAADOPTED"])
+	if sk := fa.secretKeyFor("alice", "AKIAADOPTED"); sk != "supersecret" {
+		t.Errorf("adopted secret key mismatch: %q", sk)
 	}
 	var secret corev1.Secret
 	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "media", Name: "alice-secret"}, &secret); err != nil {
@@ -382,6 +382,86 @@ func TestS3Credentials_AdoptsExistingSecret(t *testing.T) {
 	}
 	if secret.Annotations[s3CredentialsManagedAnnotation] == "true" {
 		t.Error("pre-existing secret must not be marked managed")
+	}
+}
+
+// Rotating only the secretKey in the referenced Secret — the access key id
+// stays put, as External Secrets does when it refreshes one field — must be
+// applied to the identity, so the pair the Secret holds is the pair that
+// authenticates and the superseded secret stops working.
+func TestS3Credentials_AppliesRotatedSecretKey(t *testing.T) {
+	scheme := iamTestScheme(t)
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "alice-secret", Namespace: "media"},
+		Data: map[string][]byte{
+			defaultAccessKeyField: []byte("AKIAROTATE"),
+			defaultSecretKeyField: []byte("oldsecret"),
+		},
+	}
+	cred := &seaweedv1.S3Credentials{
+		ObjectMeta: metav1.ObjectMeta{Name: "alice-creds", Namespace: "media"},
+		Spec: seaweedv1.S3CredentialsSpec{
+			SeaweedRef:  iamSeaweedRef(),
+			IdentityRef: seaweedv1.S3IdentityRef{Name: "alice"},
+			SecretRef:   seaweedv1.S3SecretRef{Name: "alice-secret"},
+		},
+	}
+	cli := iamTestClient(t, scheme, newTestSeaweed(), existing, cred)
+	fa := newFakeIAMAdmin()
+	fa.seedUser("alice")
+	r := &S3CredentialsReconciler{Client: cli, Log: logf.FromContext(context.Background()), Scheme: scheme}
+	r.AdminFactory = fakeIAMFactory(fa)
+
+	key := types.NamespacedName{Namespace: "media", Name: "alice-creds"}
+	secretKey := types.NamespacedName{Namespace: "media", Name: "alice-secret"}
+	reconcileStable(t, r, key, 5)
+	if sk := fa.secretKeyFor("alice", "AKIAROTATE"); sk != "oldsecret" {
+		t.Fatalf("precondition: adopted secret key = %q, want %q", sk, "oldsecret")
+	}
+
+	// Rotate just the secret key in the Secret.
+	var secret corev1.Secret
+	if err := cli.Get(context.Background(), secretKey, &secret); err != nil {
+		t.Fatalf("get secret: %v", err)
+	}
+	secret.Data[defaultSecretKeyField] = []byte("newsecret")
+	if err := cli.Update(context.Background(), &secret); err != nil {
+		t.Fatalf("update secret: %v", err)
+	}
+
+	reconcileStable(t, r, key, 5)
+
+	if keys := fa.userKeys("alice"); len(keys) != 1 || keys[0] != "AKIAROTATE" {
+		t.Fatalf("access keys on alice = %v, want the same single key AKIAROTATE", keys)
+	}
+	if sk := fa.secretKeyFor("alice", "AKIAROTATE"); sk != "newsecret" {
+		t.Errorf("IAM secret key = %q, want the rotated %q", sk, "newsecret")
+	}
+
+	// The Secret is the source of truth here; it must not be rewritten.
+	if err := cli.Get(context.Background(), secretKey, &secret); err != nil {
+		t.Fatalf("get secret: %v", err)
+	}
+	if got := string(secret.Data[defaultSecretKeyField]); got != "newsecret" {
+		t.Errorf("secret secretKey = %q, want the rotated %q", got, "newsecret")
+	}
+	if got := string(secret.Data[defaultAccessKeyField]); got != "AKIAROTATE" {
+		t.Errorf("secret accessKey = %q, want stable %q", got, "AKIAROTATE")
+	}
+
+	var got seaweedv1.S3Credentials
+	if err := cli.Get(context.Background(), key, &got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status.AccessKey != "AKIAROTATE" || got.Status.Phase != seaweedv1.S3PhaseReady {
+		t.Errorf("status = %+v", got.Status)
+	}
+
+	// Converged: further resyncs must not keep rewriting the credential.
+	updates := countCalls(fa.calls, "UpdateAccessKey:alice:AKIAROTATE")
+	reconcileStable(t, r, key, 5)
+	if n := countCalls(fa.calls, "UpdateAccessKey:alice:AKIAROTATE"); n != updates {
+		t.Errorf("UpdateAccessKey calls = %d, want no further rewrite after %d", n, updates)
 	}
 }
 

--- a/internal/controller/iam_name_claim_test.go
+++ b/internal/controller/iam_name_claim_test.go
@@ -292,8 +292,8 @@ func TestS3Credentials_IdentityRefResolvesResourceName(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get user: %v", err)
 	}
-	if len(user.AccessKeys) != 1 || user.AccessKeys[0] != got.Status.AccessKey {
-		t.Errorf("access keys on myapp-media = %v, want [%s]", user.AccessKeys, got.Status.AccessKey)
+	if keys := user.AccessKeys(); len(keys) != 1 || keys[0] != got.Status.AccessKey {
+		t.Errorf("access keys on myapp-media = %v, want [%s]", user.AccessKeys(), got.Status.AccessKey)
 	}
 }
 
@@ -319,8 +319,8 @@ func TestS3Credentials_IdentityRefFallsBackToIAMName(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get user: %v", err)
 	}
-	if len(user.AccessKeys) != 1 {
-		t.Errorf("access keys on external = %v, want one key", user.AccessKeys)
+	if len(user.AccessKeys()) != 1 {
+		t.Errorf("access keys on external = %v, want one key", user.AccessKeys())
 	}
 }
 
@@ -358,8 +358,8 @@ func TestS3Credentials_Delete_CleansUpResolvedIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get user: %v", err)
 	}
-	if len(user.AccessKeys) != 0 {
-		t.Errorf("access keys = %v, want the provisioned key removed", user.AccessKeys)
+	if len(user.AccessKeys()) != 0 {
+		t.Errorf("access keys = %v, want the provisioned key removed", user.AccessKeys())
 	}
 }
 
@@ -409,8 +409,8 @@ func TestS3Credentials_PinnedIdentitySurvivesShadowingResource(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get user: %v", err)
 	}
-	if len(shadowUser.AccessKeys) != 0 {
-		t.Errorf("keys on external-media = %v, want none (key must not move)", shadowUser.AccessKeys)
+	if len(shadowUser.AccessKeys()) != 0 {
+		t.Errorf("keys on external-media = %v, want none (key must not move)", shadowUser.AccessKeys())
 	}
 }
 

--- a/internal/controller/iam_resync_test.go
+++ b/internal/controller/iam_resync_test.go
@@ -37,7 +37,6 @@ func (f *fakeIAMAdmin) simulateFilerRestart() {
 	f.users = map[string]*swadmin.IAMUser{}
 	f.policies = map[string]string{}
 	f.providers = map[string]string{}
-	f.secretKeys = map[string]string{}
 }
 
 // Success schedules a periodic resync, and re-running it re-creates a user the

--- a/internal/controller/s3credentials_controller.go
+++ b/internal/controller/s3credentials_controller.go
@@ -151,10 +151,11 @@ func (r *S3CredentialsReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	return r.reconcileKey(ctx, &cred, user, secretName, secretNamespace, iamUser, admin)
 }
 
-// reconcileKey ensures the identity owns exactly the access key recorded in
-// the Secret. It adopts a user-populated Secret, generates and stores a fresh
-// key pair when the Secret is missing/incomplete, and removes a previously
-// generated key it is replacing.
+// reconcileKey ensures the identity owns exactly the key pair recorded in the
+// Secret. It adopts a user-populated Secret, generates and stores a fresh key
+// pair when the Secret is missing/incomplete, applies a rotated secret key
+// onto the registered access key, and removes a previously generated key it
+// is replacing.
 func (r *S3CredentialsReconciler) reconcileKey(ctx context.Context, cred *seaweedv1.S3Credentials, user, secretName, secretNamespace string, iamUser *swadmin.IAMUser, admin IAMAdmin) (ctrl.Result, error) {
 	akField, skField := credentialFields(cred)
 
@@ -198,10 +199,17 @@ func (r *S3CredentialsReconciler) reconcileKey(ctx context.Context, cred *seawee
 		}
 	}
 
-	// Register the key on the identity if it is not already present.
-	if !containsString(iamUser.AccessKeys, desiredAK) {
+	// Reconcile the identity against the pair the Secret holds: register the
+	// key when absent, rewrite its secret key when only that field rotated —
+	// the access key id stays, so there is no superseded pair to revoke below.
+	switch existing, present := iamUser.Credential(desiredAK); {
+	case !present:
 		if err := admin.CreateAccessKey(ctx, user, desiredAK, desiredSK); err != nil {
 			return r.fail(ctx, cred, "CreateAccessKeyFailed", err.Error())
+		}
+	case existing.SecretKey != desiredSK:
+		if err := admin.UpdateAccessKey(ctx, user, desiredAK, desiredSK); err != nil {
+			return r.fail(ctx, cred, "UpdateAccessKeyFailed", err.Error())
 		}
 	}
 
@@ -405,15 +413,6 @@ func credentialFields(cred *seaweedv1.S3Credentials) (akField, skField string) {
 		skField = defaultSecretKeyField
 	}
 	return akField, skField
-}
-
-func containsString(list []string, want string) bool {
-	for _, s := range list {
-		if s == want {
-			return true
-		}
-	}
-	return false
 }
 
 // SetupWithManager wires the reconciler into the manager.

--- a/internal/controller/swadmin/iam_client.go
+++ b/internal/controller/swadmin/iam_client.go
@@ -135,6 +135,12 @@ func (c *IAMClient) lockUser(name string) func() {
 	return iamUserLocks.lock(c.filerGrpcAddress + "\x00" + name)
 }
 
+// IAMCredential is one access key / secret key pair registered on an identity.
+type IAMCredential struct {
+	AccessKey string
+	SecretKey string
+}
+
 // IAMUser is the subset of an IAM identity the operator reconciles. It is a
 // plain domain struct so the iam_pb types stay confined to this package.
 type IAMUser struct {
@@ -143,7 +149,27 @@ type IAMUser struct {
 	DisplayName string
 	Email       string
 	PolicyNames []string
-	AccessKeys  []string
+	Credentials []IAMCredential
+}
+
+// Credential returns the credential registered under accessKey, so a caller
+// can tell an unregistered key from one whose secret key has drifted.
+func (u *IAMUser) Credential(accessKey string) (IAMCredential, bool) {
+	for _, c := range u.Credentials {
+		if c.AccessKey == accessKey {
+			return c, true
+		}
+	}
+	return IAMCredential{}, false
+}
+
+// AccessKeys returns the identity's access key ids.
+func (u *IAMUser) AccessKeys() []string {
+	keys := make([]string, 0, len(u.Credentials))
+	for _, c := range u.Credentials {
+		keys = append(keys, c.AccessKey)
+	}
+	return keys
 }
 
 // GetUser fetches an identity. The raw gRPC error (codes.NotFound when the
@@ -222,6 +248,38 @@ func (c *IAMClient) CreateAccessKey(ctx context.Context, user, accessKey, secret
 				Status:    iam.AccessKeyStatusActive,
 			},
 		})
+		return err
+	})
+}
+
+// UpdateAccessKey replaces the secret key of an access key already registered
+// on an identity, leaving its other credentials and policies untouched. The
+// IAM service has no update-credential RPC and rejects re-creating an existing
+// access key, so the pair is rewritten through UpdateUser. Returns a
+// codes.NotFound error when the identity does not hold accessKey.
+func (c *IAMClient) UpdateAccessKey(ctx context.Context, user, accessKey, secretKey string) error {
+	defer c.lockUser(user)()
+	return c.withClient(ctx, func(ctx context.Context, client iam_pb.SeaweedIdentityAccessManagementClient) error {
+		resp, err := client.GetUser(ctx, &iam_pb.GetUserRequest{Username: user})
+		if err != nil {
+			return err
+		}
+		id := resp.GetIdentity()
+		if id == nil {
+			return fmt.Errorf("user %q returned empty identity", user)
+		}
+		found := false
+		for _, cred := range id.Credentials {
+			if cred.AccessKey == accessKey {
+				cred.SecretKey = secretKey
+				found = true
+				break
+			}
+		}
+		if !found {
+			return status.Errorf(codes.NotFound, "access key %s not found on user %s", accessKey, user)
+		}
+		_, err = client.UpdateUser(ctx, &iam_pb.UpdateUserRequest{Username: user, Identity: id})
 		return err
 	})
 }
@@ -411,7 +469,7 @@ func identityToUser(id *iam_pb.Identity) *IAMUser {
 		u.Email = id.Account.EmailAddress
 	}
 	for _, cred := range id.Credentials {
-		u.AccessKeys = append(u.AccessKeys, cred.AccessKey)
+		u.Credentials = append(u.Credentials, IAMCredential{AccessKey: cred.AccessKey, SecretKey: cred.SecretKey})
 	}
 	return u
 }

--- a/internal/controller/swadmin/iam_client.go
+++ b/internal/controller/swadmin/iam_client.go
@@ -45,11 +45,14 @@ func (k *keyedMutex) lock(key string) func() {
 	return m.Unlock
 }
 
-// iamUserLocks serializes the GetUser→mutate→UpdateUser sequences in
-// SetUserState / AttachPolicy / DetachPolicy. The SeaweedFS IAM service has no
+// iamUserLocks serializes every mutation of a single identity: the
+// GetUser→mutate→UpdateUser sequences in SetUserState / UpdateAccessKey /
+// AttachPolicy / DetachPolicy, and the Create/DeleteAccessKey RPCs those
+// sequences would otherwise overwrite. The SeaweedFS IAM service has no
 // ETag/versioning on identities, so without this lock two concurrent
 // reconciles touching the same user (e.g. an S3Identity disabling it while an
-// S3PolicyBinding attaches a policy) could clobber each other's write. The map
+// S3PolicyBinding attaches a policy, or a revoked key being restored by a
+// whole-identity write that read it) could clobber each other. The map
 // is package-global because each reconciler holds its own IAMClient, so the
 // lock has to live above any single client instance. Keyed by
 // filer-address + user, it does not guard against changes made outside the
@@ -239,6 +242,7 @@ func (c *IAMClient) DeleteUser(ctx context.Context, name string) error {
 // identity. The caller is responsible for not creating a duplicate access key
 // (the IAM service reports that as a generic error, not AlreadyExists).
 func (c *IAMClient) CreateAccessKey(ctx context.Context, user, accessKey, secretKey string) error {
+	defer c.lockUser(user)()
 	return c.withClient(ctx, func(ctx context.Context, client iam_pb.SeaweedIdentityAccessManagementClient) error {
 		_, err := client.CreateAccessKey(ctx, &iam_pb.CreateAccessKeyRequest{
 			Username: user,
@@ -286,6 +290,7 @@ func (c *IAMClient) UpdateAccessKey(ctx context.Context, user, accessKey, secret
 
 // DeleteAccessKey removes a credential pair from an identity.
 func (c *IAMClient) DeleteAccessKey(ctx context.Context, user, accessKey string) error {
+	defer c.lockUser(user)()
 	return c.withClient(ctx, func(ctx context.Context, client iam_pb.SeaweedIdentityAccessManagementClient) error {
 		_, err := client.DeleteAccessKey(ctx, &iam_pb.DeleteAccessKeyRequest{
 			Username:  user,

--- a/internal/controller/swadmin/iam_client_test.go
+++ b/internal/controller/swadmin/iam_client_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/seaweedfs/seaweedfs/weed/iam"
 	"github.com/seaweedfs/seaweedfs/weed/pb/iam_pb"
 	"github.com/seaweedfs/seaweedfs/weed/security"
 	"google.golang.org/grpc"
@@ -191,4 +192,111 @@ func (s *authRecordingIAM) GetUser(ctx context.Context, req *iam_pb.GetUserReque
 		return nil, s.authErr
 	}
 	return &iam_pb.GetUserResponse{Identity: &iam_pb.Identity{Name: req.Username}}, nil
+}
+
+// identityStoreIAM is a minimal in-memory IAM gRPC server that serves and
+// stores one identity, enough to exercise the read-modify-write path
+// UpdateAccessKey relies on. Messages cross the wire, so the served and
+// stored identities are never aliased with the client's copy.
+type identityStoreIAM struct {
+	iam_pb.UnimplementedSeaweedIdentityAccessManagementServer
+	identity *iam_pb.Identity
+	updates  int
+}
+
+func (s *identityStoreIAM) GetUser(_ context.Context, req *iam_pb.GetUserRequest) (*iam_pb.GetUserResponse, error) {
+	if s.identity == nil || s.identity.Name != req.Username {
+		return nil, status.Errorf(codes.NotFound, "user %s not found", req.Username)
+	}
+	return &iam_pb.GetUserResponse{Identity: s.identity}, nil
+}
+
+func (s *identityStoreIAM) UpdateUser(_ context.Context, req *iam_pb.UpdateUserRequest) (*iam_pb.UpdateUserResponse, error) {
+	if s.identity == nil || s.identity.Name != req.Username {
+		return nil, status.Errorf(codes.NotFound, "user %s not found", req.Username)
+	}
+	s.updates++
+	s.identity = req.Identity
+	return &iam_pb.UpdateUserResponse{}, nil
+}
+
+// startIAMServer serves impl on an ephemeral port and returns a client dialing it.
+func startIAMServer(t *testing.T, impl iam_pb.SeaweedIdentityAccessManagementServer) *IAMClient {
+	t.Helper()
+	srv := grpc.NewServer()
+	t.Cleanup(srv.Stop)
+	iam_pb.RegisterSeaweedIdentityAccessManagementServer(srv, impl)
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() { _ = srv.Serve(lis) }()
+
+	// pb.ServerAddress derives the gRPC port as HTTPPort+10000, so hand the
+	// client the listening port minus 10000.
+	grpcPort := lis.Addr().(*net.TCPAddr).Port
+	if grpcPort < 10001 {
+		t.Skipf("ephemeral gRPC port %d too low to map to a valid HTTP port", grpcPort)
+	}
+	return NewIAMClient(net.JoinHostPort("127.0.0.1", strconv.Itoa(grpcPort-10000)), nil, nil)
+}
+
+// UpdateAccessKey must rewrite only the secret key of the named access key,
+// leaving the identity's other credentials and its policies intact — the IAM
+// service has no update-credential RPC, so this goes through UpdateUser.
+func TestIAMClient_UpdateAccessKey_RewritesSecretKeyInPlace(t *testing.T) {
+	store := &identityStoreIAM{identity: &iam_pb.Identity{
+		Name: "alice",
+		Credentials: []*iam_pb.Credential{
+			{AccessKey: "AKIAONE", SecretKey: "sk-one", Status: iam.AccessKeyStatusActive},
+			{AccessKey: "AKIATWO", SecretKey: "sk-two", Status: iam.AccessKeyStatusActive},
+		},
+		PolicyNames: []string{"rw"},
+	}}
+	c := startIAMServer(t, store)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := c.UpdateAccessKey(ctx, "alice", "AKIAONE", "sk-rotated"); err != nil {
+		t.Fatalf("UpdateAccessKey: %v", err)
+	}
+
+	user, err := c.GetUser(ctx, "alice")
+	if err != nil {
+		t.Fatalf("GetUser: %v", err)
+	}
+	if got, _ := user.Credential("AKIAONE"); got.SecretKey != "sk-rotated" {
+		t.Errorf("AKIAONE secret key = %q, want %q", got.SecretKey, "sk-rotated")
+	}
+	if got, _ := user.Credential("AKIATWO"); got.SecretKey != "sk-two" {
+		t.Errorf("AKIATWO secret key = %q, want it untouched", got.SecretKey)
+	}
+	if len(user.PolicyNames) != 1 || user.PolicyNames[0] != "rw" {
+		t.Errorf("policy names = %v, want [rw] preserved", user.PolicyNames)
+	}
+	// Fields the domain struct drops must survive the rewrite too.
+	if got := store.identity.Credentials[0].Status; got != iam.AccessKeyStatusActive {
+		t.Errorf("AKIAONE status = %q, want %q preserved", got, iam.AccessKeyStatusActive)
+	}
+}
+
+// An access key the identity does not hold is reported as NotFound, so the
+// caller can tell a drifted secret key from a key that was never registered.
+func TestIAMClient_UpdateAccessKey_UnknownKeyIsNotFound(t *testing.T) {
+	store := &identityStoreIAM{identity: &iam_pb.Identity{
+		Name:        "alice",
+		Credentials: []*iam_pb.Credential{{AccessKey: "AKIAONE", SecretKey: "sk-one"}},
+	}}
+	c := startIAMServer(t, store)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := c.UpdateAccessKey(ctx, "alice", "AKIAGONE", "sk-rotated")
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("UpdateAccessKey error = %v, want codes.NotFound", err)
+	}
+	if store.updates != 0 {
+		t.Errorf("UpdateUser calls = %d, want none", store.updates)
+	}
 }

--- a/internal/controller/swadmin/iam_client_test.go
+++ b/internal/controller/swadmin/iam_client_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -200,24 +201,84 @@ func (s *authRecordingIAM) GetUser(ctx context.Context, req *iam_pb.GetUserReque
 // stored identities are never aliased with the client's copy.
 type identityStoreIAM struct {
 	iam_pb.UnimplementedSeaweedIdentityAccessManagementServer
+	mu       sync.Mutex
 	identity *iam_pb.Identity
 	updates  int
+
+	// When gate is non-nil every GetUser blocks on it, and the first call
+	// closes entered — enough to pin a read-modify-write open while another
+	// call races it.
+	gate    chan struct{}
+	entered chan struct{}
+	once    sync.Once
 }
 
 func (s *identityStoreIAM) GetUser(_ context.Context, req *iam_pb.GetUserRequest) (*iam_pb.GetUserResponse, error) {
+	if s.gate != nil {
+		s.once.Do(func() { close(s.entered) })
+		<-s.gate
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.identity == nil || s.identity.Name != req.Username {
 		return nil, status.Errorf(codes.NotFound, "user %s not found", req.Username)
 	}
-	return &iam_pb.GetUserResponse{Identity: s.identity}, nil
+	// Copy: the response is marshalled after this handler returns the lock.
+	return &iam_pb.GetUserResponse{Identity: cloneIdentity(s.identity)}, nil
 }
 
 func (s *identityStoreIAM) UpdateUser(_ context.Context, req *iam_pb.UpdateUserRequest) (*iam_pb.UpdateUserResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.identity == nil || s.identity.Name != req.Username {
 		return nil, status.Errorf(codes.NotFound, "user %s not found", req.Username)
 	}
 	s.updates++
 	s.identity = req.Identity
 	return &iam_pb.UpdateUserResponse{}, nil
+}
+
+func (s *identityStoreIAM) DeleteAccessKey(_ context.Context, req *iam_pb.DeleteAccessKeyRequest) (*iam_pb.DeleteAccessKeyResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.identity == nil || s.identity.Name != req.Username {
+		return nil, status.Errorf(codes.NotFound, "user %s not found", req.Username)
+	}
+	kept := s.identity.Credentials[:0]
+	for _, cred := range s.identity.Credentials {
+		if cred.AccessKey != req.AccessKey {
+			kept = append(kept, cred)
+		}
+	}
+	s.identity.Credentials = kept
+	return &iam_pb.DeleteAccessKeyResponse{}, nil
+}
+
+func (s *identityStoreIAM) accessKeys() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	keys := make([]string, 0, len(s.identity.Credentials))
+	for _, cred := range s.identity.Credentials {
+		keys = append(keys, cred.AccessKey)
+	}
+	return keys
+}
+
+func cloneIdentity(id *iam_pb.Identity) *iam_pb.Identity {
+	out := &iam_pb.Identity{
+		Name:        id.Name,
+		Disabled:    id.Disabled,
+		Account:     id.Account,
+		PolicyNames: append([]string(nil), id.PolicyNames...),
+	}
+	for _, cred := range id.Credentials {
+		out.Credentials = append(out.Credentials, &iam_pb.Credential{
+			AccessKey: cred.AccessKey,
+			SecretKey: cred.SecretKey,
+			Status:    cred.Status,
+		})
+	}
+	return out
 }
 
 // startIAMServer serves impl on an ephemeral port and returns a client dialing it.
@@ -298,5 +359,55 @@ func TestIAMClient_UpdateAccessKey_UnknownKeyIsNotFound(t *testing.T) {
 	}
 	if store.updates != 0 {
 		t.Errorf("UpdateUser calls = %d, want none", store.updates)
+	}
+}
+
+// A credential delete that lands mid-rewrite must not be undone: UpdateAccessKey
+// writes the whole identity it read, so DeleteAccessKey has to wait for it
+// rather than be resurrected by the stale copy.
+func TestIAMClient_UpdateAccessKey_SerializesWithDelete(t *testing.T) {
+	store := &identityStoreIAM{
+		identity: &iam_pb.Identity{
+			Name: "alice",
+			Credentials: []*iam_pb.Credential{
+				{AccessKey: "AKIAONE", SecretKey: "sk-one"},
+				{AccessKey: "AKIATWO", SecretKey: "sk-two"},
+			},
+		},
+		gate:    make(chan struct{}),
+		entered: make(chan struct{}),
+	}
+	c := startIAMServer(t, store)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	updateDone := make(chan error, 1)
+	go func() { updateDone <- c.UpdateAccessKey(ctx, "alice", "AKIAONE", "sk-rotated") }()
+	select {
+	case <-store.entered:
+	case <-ctx.Done():
+		t.Fatal("UpdateAccessKey never reached GetUser")
+	}
+
+	// The delete now races the rewrite; it must block on the per-user lock.
+	deleteDone := make(chan error, 1)
+	go func() { deleteDone <- c.DeleteAccessKey(ctx, "alice", "AKIATWO") }()
+	select {
+	case err := <-deleteDone:
+		t.Fatalf("DeleteAccessKey ran during the rewrite (err=%v); it must wait for the lock", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	close(store.gate)
+	if err := <-updateDone; err != nil {
+		t.Fatalf("UpdateAccessKey: %v", err)
+	}
+	if err := <-deleteDone; err != nil {
+		t.Fatalf("DeleteAccessKey: %v", err)
+	}
+
+	if keys := store.accessKeys(); len(keys) != 1 || keys[0] != "AKIAONE" {
+		t.Fatalf("access keys = %v, want only AKIAONE — the revoked key must stay revoked", keys)
 	}
 }


### PR DESCRIPTION
Fixes #353.

## Problem

When only the `secretKey` changed in the Secret an `S3Credentials` references — an access key kept, its secret rotated, as External Secrets does when it refreshes one field — the controller read the new value but never applied it.

`reconcileKey` registered the pair only when the access key id was absent from the identity:

```go
if !containsString(iamUser.AccessKeys, desiredAK) {
    admin.CreateAccessKey(ctx, user, desiredAK, desiredSK)
}
```

The id was still there, so nothing happened. The Secret and the IAM store diverged permanently: the pair in the Secret was rejected with `SignatureDoesNotMatch`, the superseded secret kept authenticating, and the CR stayed `Ready`. Rotating both fields at once worked, because the new access key id was missing and took the create-and-revoke path.

## Fix

Compare the secret key the identity actually holds against the one in the Secret, and rewrite it in place when they differ:

```go
switch existing, present := iamUser.Credential(desiredAK); {
case !present:
    admin.CreateAccessKey(...)
case existing.SecretKey != desiredSK:
    admin.UpdateAccessKey(...)
}
```

- `swadmin.IAMUser` now carries `Credentials []IAMCredential` (access key + secret key) instead of access key ids alone — `GetUser` already returned the secret keys, `identityToUser` was dropping them.
- `IAMClient.UpdateAccessKey` rewrites the pair through `UpdateUser` (the IAM service has no update-credential RPC and rejects re-creating an existing access key), preserving the identity's other credentials, its policies, and per-credential fields the domain struct drops such as `Status`. It is serialized by the existing per-user lock and returns `NotFound` when the identity does not hold the key.
- The access key id is unchanged in this path, so there is no separate old pair to revoke — the superseded secret is gone once it is overwritten. The existing revoke-on-access-key-change path is untouched.
- A failure surfaces as `phase: Failed` with reason `UpdateAccessKeyFailed`, so a rotation the operator cannot apply is no longer reported as success.

## Tests

- `TestS3Credentials_AppliesRotatedSecretKey` reproduces the report: adopt a pre-populated Secret, patch only `secretKey`, resync. It fails on master (IAM keeps `oldsecret`) and passes with the fix, and also asserts the access key id stays put, the Secret is not rewritten, and further resyncs issue no repeat `UpdateAccessKey` calls.
- `TestIAMClient_UpdateAccessKey_RewritesSecretKeyInPlace` / `..._UnknownKeyIsNotFound` exercise the real gRPC path against an in-process IAM server.
- `go build ./...`, `go vet ./...`, `make nilaway-lint`, and the unit suites pass; `test/e2e` needs a live cluster and was not run.

README's `S3Credentials` description now states the rotation behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Secret key rotation now updates the existing IAM access key while preserving its identifier and status.
  - Credential reconciliation detects and corrects secret key changes without creating duplicate access keys.
  - Full credential pairs are tracked to improve consistency during provisioning and recovery.

- **Documentation**
  - Updated `S3Credentials` documentation to explain access key registration and secret-only rotation behavior.

- **Bug Fixes**
  - Prevented repeated IAM updates after rotated credentials have converged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->