### PR TITLE
test: pin evacuation e2e volume growth to each server

### DIFF
--- a/test/e2e/volume_evacuation_test.go
+++ b/test/e2e/volume_evacuation_test.go
@@ -208,28 +208,48 @@ var _ = Describe("Volume server evacuation on scale-down", Ordered, Label("integ
 			masterPod = pods.Items[0].Name
 		}, time.Minute, time.Second*5).Should(Succeed())
 
-		By("growing volumes so both servers host data")
-		// replication=000 keeps every volume to a single copy, so the doomed
-		// server's volumes can always move onto the one remaining server. Grow
-		// once (retrying only a transient HTTP error), then wait separately for
-		// the new volumes to register so a slow heartbeat does not re-grow.
+		By("waiting for both volume servers to register with the master")
+		// A pod that passes its readiness probe has not necessarily heartbeated
+		// to the master yet, and a grow only places volumes on servers the
+		// topology already knows about.
+		var doomedNode, survivorNode string
 		Eventually(func(g Gomega) {
-			_, err := masterGet("/vol/grow?count=6&replication=000")
+			ds, err := fetchTopology()
 			g.Expect(err).NotTo(HaveOccurred())
-		}, time.Minute, time.Second*5).Should(Succeed())
+			byNode := ds.volumesByNode()
+			g.Expect(byNode).To(HaveLen(2), "expected two registered volume servers, got %v", byNode)
+			doomedNode, survivorNode = "", ""
+			for nodeURL := range byNode {
+				if strings.HasPrefix(nodeURL, doomedNodePrefix) {
+					doomedNode = nodeURL
+				} else {
+					survivorNode = nodeURL
+				}
+			}
+			g.Expect(doomedNode).NotTo(BeEmpty(), "doomed volume server is not registered: %v", byNode)
+			g.Expect(survivorNode).NotTo(BeEmpty(), "surviving volume server is not registered: %v", byNode)
+		}, time.Minute*2, time.Second*5).Should(Succeed())
+
+		By("growing volumes on both servers so the doomed one has data to evacuate")
+		// replication=000 keeps every volume to a single copy, so the doomed
+		// server's volumes can always move onto the one remaining server. An
+		// unpinned grow picks a server at random per volume and can leave the
+		// doomed one empty, so pin a grow to each node by its master node id.
+		// The counts stay well under the per-server max so the survivor has
+		// slots to spare for the evacuated volumes.
+		for _, node := range []string{doomedNode, survivorNode} {
+			Eventually(func(g Gomega) {
+				_, err := masterGet(fmt.Sprintf("/vol/grow?count=3&replication=000&dataNode=%s", node))
+				g.Expect(err).NotTo(HaveOccurred())
+			}, time.Minute, time.Second*5).Should(Succeed())
+		}
 
 		Eventually(func(g Gomega) {
 			ds, err := fetchTopology()
 			g.Expect(err).NotTo(HaveOccurred())
 			byNode := ds.volumesByNode()
-			g.Expect(byNode).To(HaveLen(2), "expected two registered volume servers")
-			var doomed int64 = -1
-			for url, n := range byNode {
-				if strings.HasPrefix(url, doomedNodePrefix) {
-					doomed = n
-				}
-			}
-			g.Expect(doomed).To(BeNumerically(">", 0), "doomed server holds no volumes to evacuate")
+			g.Expect(byNode).To(HaveLen(2), "expected two registered volume servers, got %v", byNode)
+			g.Expect(byNode[doomedNode]).To(BeNumerically(">", 0), "doomed server holds no volumes to evacuate: %v", byNode)
 		}, time.Minute*2, time.Second*5).Should(Succeed())
 
 		ds, err := fetchTopology()
@@ -271,8 +291,8 @@ var _ = Describe("Volume server evacuation on scale-down", Ordered, Label("integ
 			g.Expect(err).NotTo(HaveOccurred())
 			byNode := ds.volumesByNode()
 			// The doomed server is gone from the topology...
-			for url := range byNode {
-				g.Expect(url).NotTo(HavePrefix(doomedNodePrefix), "doomed server still registered")
+			for nodeURL := range byNode {
+				g.Expect(nodeURL).NotTo(HavePrefix(doomedNodePrefix), "doomed server still registered")
 			}
 			// ...and every volume it held now lives on the surviving server.
 			g.Expect(ds.totalVolumes()).To(Equal(totalBefore), "volumes were lost during scale-down")

--- a/test/e2e/volume_evacuation_test.go
+++ b/test/e2e/volume_evacuation_test.go
@@ -237,20 +237,25 @@ var _ = Describe("Volume server evacuation on scale-down", Ordered, Label("integ
 		// doomed one empty, so pin a grow to each node by its master node id.
 		// The counts stay well under the per-server max so the survivor has
 		// slots to spare for the evacuated volumes.
+		const volumesPerServer = 3
 		for _, node := range []string{doomedNode, survivorNode} {
 			Eventually(func(g Gomega) {
-				_, err := masterGet(fmt.Sprintf("/vol/grow?count=3&replication=000&dataNode=%s", node))
+				ds, err := fetchTopology()
 				g.Expect(err).NotTo(HaveOccurred())
+				// Grow only the shortfall: the master registers new volumes
+				// before it answers, so retrying a lost response tops up what
+				// is missing instead of growing a second batch.
+				if missing := volumesPerServer - ds.volumesByNode()[node]; missing > 0 {
+					_, err = masterGet(fmt.Sprintf("/vol/grow?count=%d&replication=000&dataNode=%s", missing, node))
+					g.Expect(err).NotTo(HaveOccurred())
+					ds, err = fetchTopology()
+					g.Expect(err).NotTo(HaveOccurred())
+				}
+				byNode := ds.volumesByNode()
+				g.Expect(byNode[node]).To(BeNumerically(">=", volumesPerServer),
+					"volume server %s did not receive its volumes: %v", node, byNode)
 			}, time.Minute, time.Second*5).Should(Succeed())
 		}
-
-		Eventually(func(g Gomega) {
-			ds, err := fetchTopology()
-			g.Expect(err).NotTo(HaveOccurred())
-			byNode := ds.volumesByNode()
-			g.Expect(byNode).To(HaveLen(2), "expected two registered volume servers, got %v", byNode)
-			g.Expect(byNode[doomedNode]).To(BeNumerically(">", 0), "doomed server holds no volumes to evacuate: %v", byNode)
-		}, time.Minute*2, time.Second*5).Should(Succeed())
 
 		ds, err := fetchTopology()
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Problem

The `Volume server evacuation on scale-down` integration spec flaked in CI:

```
[FAILED] Timed out after 120.003s.
The function passed to Eventually failed at test/e2e/volume_evacuation_test.go:232 with:
doomed server holds no volumes to evacuate
Expected <int64>: 0 to be > <int>: 0
```

The spec grew six volumes with `/vol/grow?count=6&replication=000` and then waited for the
ordinal-1 (doomed) server to hold at least one of them. The master picks a data node at
random per volume (`PickNodesByWeight`, weighted by free slots), so an all-on-one-server
draw leaves the doomed server permanently empty and the poll can only time out. The grow
also fired ~15ms after the pods reported ready, so a volume server that was pod-ready but
had not yet heartbeated into the topology would miss the grow the same way.

This is the spec's precondition, not the operator's evacuation gate — re-running the same
commit passed.

## Fix

- Wait for both volume servers to register in `/dir/status` before growing, capturing each
  one's master node id.
- Grow three volumes pinned to each node with `dataNode=<node id>` — the same
  `<host>:<port>` identifier the operator's evacuation gate keys on — so the doomed server
  always holds data to evacuate.
- Include the per-node volume map in the failure messages so a future failure shows the
  actual topology.

Same six volumes as before, still well under the per-server max of 20 so the survivor can
absorb the evacuated volumes.

## Verification

Checked the pinning against `chrislusf/seaweedfs:latest` (master + 2 volume servers in
Docker):

- `dataNode=<node>` grows returned `{"count":3}` each and `/dir/status` showed exactly
  `vol0=3, vol1=3` immediately, with no heartbeat lag.
- A non-matching `dataNode` returns HTTP 406 `No matching data node found!`, so if node
  identity ever changes the spec fails loudly rather than silently falling back to random
  placement.

`go vet`, `gofmt` and `go test -c` pass on `./test/e2e/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved volume evacuation coverage for multi-node volume growth.
  * Verified each server reaches its configured volume target after growth.
  * Added topology validation after each volume expansion and following server scale-down.
  * Strengthened checks for the identified server being evacuated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->