### PR TITLE
Bump kind to v0.33.0 so k8s 1.37 clusters can be created

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,7 @@ CONTROLLER_TOOLS_VERSION ?= v0.19.0
 ENVTEST_VERSION ?= latest
 
 # renovate: datasource=github-tags depName=kubernetes-sigs/kind
-KIND_VERSION ?= v0.23.0
+KIND_VERSION ?= v0.33.0
 # renovate: datasource=github-tags depName=helm/helm
 HELM_VERSION ?= v3.15.2
 # renovate: datasource=github-tags depName=losisin/helm-values-schema-json


### PR DESCRIPTION
## Problem

`Integration Tests on k8s v1.37.0` fails on master and on every PR during `make kind-create`:

```
error: your configuration file uses an old API spec: "kubeadm.k8s.io/v1beta3" (kind: "ClusterConfiguration").
ERROR: failed to create cluster: failed to init node with kubeadm
make: *** [Makefile:211: kind-create] Error 1
```

The pinned kind v0.23.0 (May 2024) writes a `kubeadm.k8s.io/v1beta3` cluster config. Kubernetes 1.37 dropped support for that config version, so the cluster never comes up.

The integration matrix is generated from the three newest upstream Kubernetes minors, so the kind pin has to keep pace with them. This broke as soon as 1.37 was tagged, and it will keep breaking on each new minor if kind is left behind.

## Fix

Bump `KIND_VERSION` to v0.33.0. kind v0.32.0 switched to the `v1beta4` config format for Kubernetes 1.36+, while keeping `v1beta3` for 1.23 through 1.35 and `v1beta2` for older releases. The repo creates single-node clusters with no `kubeadmConfigPatches` and no kind config file, so nothing else needs to change.

## Verification

Created clusters locally with the bumped pin and waited for the node to go `Ready` in each case:

| k8s version | kubeadm config | Result |
| --- | --- | --- |
| v1.37.0 | `v1beta4` | Ready |
| v1.35.8 | `v1beta3` | Ready |
| v1.28.0 | `v1beta3` | Ready |

v1.37.0 is the version that fails today. v1.35.8 is the oldest entry in the integration matrix. v1.28.0 is the oldest version used by the e2e and Helm smoke workflows, included to confirm the newer kind does not drop the older node images those jobs rely on.

https://claude.ai/code/session_018r9JTPC7zk2NmAmaR2oN4u

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Kind tool version used for local Kubernetes cluster workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->