### PR TITLE
Remove pod-template keys that leave the CR and merge metadata on the Deployment path

### DIFF
--- a/internal/controller/controller_admin.go
+++ b/internal/controller/controller_admin.go
@@ -47,7 +47,7 @@ func (r *SeaweedReconciler) ensureAdminStatefulSet(seaweedCR *seaweedv1.Seaweed)
 		desiredStatefulSet := desired.(*appsv1.StatefulSet)
 
 		existingStatefulSet.Spec.Replicas = desiredStatefulSet.Spec.Replicas
-		mergePodTemplateMetadata(&existingStatefulSet.Spec.Template, &desiredStatefulSet.Spec.Template)
+		mergePodTemplateMetadata(existingStatefulSet, &existingStatefulSet.Spec.Template, &desiredStatefulSet.Spec.Template)
 		existingStatefulSet.Spec.Template.Spec = desiredStatefulSet.Spec.Template.Spec
 
 		return nil

--- a/internal/controller/controller_filer.go
+++ b/internal/controller/controller_filer.go
@@ -54,7 +54,7 @@ func (r *SeaweedReconciler) ensureFilerStatefulSet(ctx context.Context, seaweedC
 		desiredStatefulSet := desired.(*appsv1.StatefulSet)
 
 		existingStatefulSet.Spec.Replicas = desiredStatefulSet.Spec.Replicas
-		mergePodTemplateMetadata(&existingStatefulSet.Spec.Template, &desiredStatefulSet.Spec.Template)
+		mergePodTemplateMetadata(existingStatefulSet, &existingStatefulSet.Spec.Template, &desiredStatefulSet.Spec.Template)
 		existingStatefulSet.Spec.Template.Spec = desiredStatefulSet.Spec.Template.Spec
 		existingStatefulSet.Spec.PersistentVolumeClaimRetentionPolicy = desiredStatefulSet.Spec.PersistentVolumeClaimRetentionPolicy
 

--- a/internal/controller/controller_master.go
+++ b/internal/controller/controller_master.go
@@ -99,7 +99,7 @@ func (r *SeaweedReconciler) ensureMasterStatefulSet(seaweedCR *seaweedv1.Seaweed
 		desiredStatefulSet := desired.(*appsv1.StatefulSet)
 
 		existingStatefulSet.Spec.Replicas = desiredStatefulSet.Spec.Replicas
-		mergePodTemplateMetadata(&existingStatefulSet.Spec.Template, &desiredStatefulSet.Spec.Template)
+		mergePodTemplateMetadata(existingStatefulSet, &existingStatefulSet.Spec.Template, &desiredStatefulSet.Spec.Template)
 		existingStatefulSet.Spec.Template.Spec = desiredStatefulSet.Spec.Template.Spec
 		return nil
 	})

--- a/internal/controller/controller_pod_template_metadata_test.go
+++ b/internal/controller/controller_pod_template_metadata_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"reflect"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -36,7 +37,7 @@ func TestMergePodTemplateMetadataKeepsExternalKeys(t *testing.T) {
 		},
 	}
 
-	mergePodTemplateMetadata(existing, desired)
+	mergePodTemplateMetadata(&metav1.ObjectMeta{}, existing, desired)
 
 	for k, want := range map[string]string{
 		"kubectl.kubernetes.io/restartedAt": "2026-09-03T12:23:43Z",
@@ -69,7 +70,7 @@ func TestMergePodTemplateMetadataReplacesTheRestOfObjectMeta(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "seaweed-filer"},
 	}
 
-	mergePodTemplateMetadata(existing, desired)
+	mergePodTemplateMetadata(&metav1.ObjectMeta{}, existing, desired)
 
 	if existing.Name != "seaweed-filer" {
 		t.Errorf("Name = %q, want the desired value", existing.Name)
@@ -84,12 +85,97 @@ func TestMergePodTemplateMetadataHandlesNilMaps(t *testing.T) {
 	existing := &corev1.PodTemplateSpec{}
 	desired := &corev1.PodTemplateSpec{}
 
-	mergePodTemplateMetadata(existing, desired)
+	mergePodTemplateMetadata(&metav1.ObjectMeta{}, existing, desired)
 
 	if existing.Annotations == nil || len(existing.Annotations) != 0 {
 		t.Errorf("Annotations = %v, want empty and non-nil", existing.Annotations)
 	}
 	if existing.Labels == nil || len(existing.Labels) != 0 {
 		t.Errorf("Labels = %v, want empty and non-nil", existing.Labels)
+	}
+}
+
+// A key the operator rendered last time and no longer does is removed; keys it
+// never managed stay. The record it leaves behind lists the rendered keys in
+// sorted order, so a converged workload is not rewritten every pass.
+func TestMergePodTemplateMetadataRemovesKeysItStoppedRendering(t *testing.T) {
+	owner := &metav1.ObjectMeta{Annotations: map[string]string{
+		LastAppliedPodTemplateKeys: `{"labels":["app","tier"],"annotations":["checksum/config","seaweed.seaweedfs.com/jwt-signing"]}`,
+	}}
+	existing := &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"app":              "seaweedfs",
+				"tier":             "storage",
+				"example.com/team": "storage",
+			},
+			Annotations: map[string]string{
+				"checksum/config":                   "v2",
+				"seaweed.seaweedfs.com/jwt-signing": "volumeWrite",
+				"kubectl.kubernetes.io/restartedAt": "2026-09-03T12:23:43Z",
+			},
+		},
+	}
+	desired := &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"app":       "seaweedfs",
+				"component": "filer",
+			},
+			Annotations: map[string]string{
+				"checksum/config": "v3",
+				"alpha/beta":      "1",
+			},
+		},
+	}
+
+	mergePodTemplateMetadata(owner, existing, desired)
+
+	wantLabels := map[string]string{
+		"app":              "seaweedfs",
+		"component":        "filer",
+		"example.com/team": "storage",
+	}
+	wantAnnotations := map[string]string{
+		"checksum/config":                   "v3",
+		"alpha/beta":                        "1",
+		"kubectl.kubernetes.io/restartedAt": "2026-09-03T12:23:43Z",
+	}
+	if !reflect.DeepEqual(existing.Labels, wantLabels) {
+		t.Errorf("labels = %v, want %v", existing.Labels, wantLabels)
+	}
+	if !reflect.DeepEqual(existing.Annotations, wantAnnotations) {
+		t.Errorf("annotations = %v, want %v", existing.Annotations, wantAnnotations)
+	}
+	wantRecord := `{"labels":["app","component"],"annotations":["alpha/beta","checksum/config"]}`
+	if got := owner.Annotations[LastAppliedPodTemplateKeys]; got != wantRecord {
+		t.Errorf("record = %s, want %s", got, wantRecord)
+	}
+}
+
+// Without a record nothing is removed: on the first pass after an upgrade a
+// stale operator key cannot be told apart from one another controller owns.
+func TestMergePodTemplateMetadataWithoutRecordOnlyOverlays(t *testing.T) {
+	owner := &metav1.ObjectMeta{}
+	existing := &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:      map[string]string{"app": "seaweedfs", "tier": "storage"},
+			Annotations: map[string]string{"kubectl.kubernetes.io/restartedAt": "2026-09-03T12:23:43Z"},
+		},
+	}
+	desired := &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "seaweedfs"}},
+	}
+
+	mergePodTemplateMetadata(owner, existing, desired)
+
+	if got := existing.Labels["tier"]; got != "storage" {
+		t.Errorf("label with no record was removed, got %q", got)
+	}
+	if got := existing.Annotations["kubectl.kubernetes.io/restartedAt"]; got == "" {
+		t.Error("annotation set by another controller was dropped")
+	}
+	if got := owner.Annotations[LastAppliedPodTemplateKeys]; got != `{"labels":["app"]}` {
+		t.Errorf("record = %s, want the rendered keys", got)
 	}
 }

--- a/internal/controller/controller_util.go
+++ b/internal/controller/controller_util.go
@@ -169,10 +169,7 @@ func (r *SeaweedReconciler) CreateOrUpdateDeployment(deploy *appsv1.Deployment) 
 				existingDep.Spec.Strategy.RollingUpdate = desiredDep.Spec.Strategy.RollingUpdate
 			}
 		}
-		// pod selector of deployment is immutable, so we don't mutate the labels of pod
-		for k, v := range desiredDep.Spec.Template.Annotations {
-			existingDep.Spec.Template.Annotations[k] = v
-		}
+		mergePodTemplateMetadata(&existingDep.Spec.Template, &desiredDep.Spec.Template)
 		// podSpec of deployment is hard to merge, use an annotation to assist
 		if DeploymentPodSpecChanged(desiredDep, existingDep) {
 			// Record last applied spec in favor of future equality check

--- a/internal/controller/controller_util.go
+++ b/internal/controller/controller_util.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
+	"slices"
 	"sync"
 
 	monitorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -28,6 +30,10 @@ const (
 
 	// LastAppliedConfigAnnotation is annotation key of last applied configuration
 	LastAppliedConfigAnnotation = "seaweedfs.com/last-applied-configuration"
+
+	// LastAppliedPodTemplateKeys is annotation key of the pod template labels
+	// and annotations the operator rendered on its last write
+	LastAppliedPodTemplateKeys = "seaweedfs.com/last-applied-podtemplate-keys"
 )
 
 // MergeFn is to resolve conflicts
@@ -169,7 +175,7 @@ func (r *SeaweedReconciler) CreateOrUpdateDeployment(deploy *appsv1.Deployment) 
 				existingDep.Spec.Strategy.RollingUpdate = desiredDep.Spec.Strategy.RollingUpdate
 			}
 		}
-		mergePodTemplateMetadata(&existingDep.Spec.Template, &desiredDep.Spec.Template)
+		mergePodTemplateMetadata(existingDep, &existingDep.Spec.Template, &desiredDep.Spec.Template)
 		// podSpec of deployment is hard to merge, use an annotation to assist
 		if DeploymentPodSpecChanged(desiredDep, existingDep) {
 			// Record last applied spec in favor of future equality check
@@ -499,30 +505,48 @@ func (r *SeaweedReconciler) probeServiceMonitorCRD() bool {
 	return true
 }
 
-// mergePodTemplateMetadata applies the desired pod template metadata to an
-// existing workload while preserving annotations and labels the operator does
-// not manage.
-//
-// Assigning ObjectMeta wholesale discards every key written by anything else,
-// which breaks the standard "annotate the pod template to trigger a restart"
-// mechanism that `kubectl rollout restart`, Reloader and the Vault Secrets
-// Operator's rolloutRestartTargets all rely on.
-//
-// It also does not cancel such a restart cleanly. The StatefulSet controller
-// rolls the highest ordinal first, so by the time the operator reverts the
-// template, that replica has already been recreated. Ordinal 0 still matches
-// the operator's canonical template and is never rolled at all, leaving a
-// StatefulSet permanently half rolled with no indication that it happened.
-//
-// The operator's own keys stay authoritative: anything it sets overwrites the
-// existing value. A key the operator previously set and no longer sets is kept
-// rather than removed, since there is nothing here to distinguish it from a key
-// another controller owns.
-func mergePodTemplateMetadata(existing, desired *corev1.PodTemplateSpec) {
+// podTemplateKeys is the LastAppliedPodTemplateKeys record.
+type podTemplateKeys struct {
+	Labels      []string `json:"labels,omitempty"`
+	Annotations []string `json:"annotations,omitempty"`
+}
+
+// mergePodTemplateMetadata applies the desired pod template labels and
+// annotations to an existing workload the way kubectl apply does: keys the
+// operator renders are overwritten, keys it rendered last time and no longer
+// does are removed, and keys it never managed are left alone. That keeps the
+// restart annotation kubectl rollout restart, Reloader and the Vault Secrets
+// Operator stamp on the template from being reverted mid-roll. The rendered
+// key set is recorded on the owning workload; without a record, nothing is
+// removed.
+func mergePodTemplateMetadata(owner metav1.Object, existing, desired *corev1.PodTemplateSpec) {
+	var last podTemplateKeys
+	if raw, ok := owner.GetAnnotations()[LastAppliedPodTemplateKeys]; ok {
+		_ = json.Unmarshal([]byte(raw), &last)
+	}
+
 	annotations := mergeStringMaps(existing.Annotations, desired.Annotations)
 	labels := mergeStringMaps(existing.Labels, desired.Labels)
+	for _, k := range last.Annotations {
+		if _, ok := desired.Annotations[k]; !ok {
+			delete(annotations, k)
+		}
+	}
+	for _, k := range last.Labels {
+		if _, ok := desired.Labels[k]; !ok {
+			delete(labels, k)
+		}
+	}
 
 	existing.ObjectMeta = desired.ObjectMeta
 	existing.Annotations = annotations
 	existing.Labels = labels
+
+	rendered, _ := json.Marshal(podTemplateKeys{
+		Labels:      slices.Sorted(maps.Keys(desired.Labels)),
+		Annotations: slices.Sorted(maps.Keys(desired.Annotations)),
+	})
+	owner.SetAnnotations(mergeStringMaps(owner.GetAnnotations(), map[string]string{
+		LastAppliedPodTemplateKeys: string(rendered),
+	}))
 }

--- a/internal/controller/controller_volume.go
+++ b/internal/controller/controller_volume.go
@@ -96,7 +96,7 @@ func (r *SeaweedReconciler) ensureVolumeServerStatefulSet(ctx context.Context, s
 		desiredStatefulSet := desired.(*appsv1.StatefulSet)
 
 		existingStatefulSet.Spec.Replicas = desiredStatefulSet.Spec.Replicas
-		mergePodTemplateMetadata(&existingStatefulSet.Spec.Template, &desiredStatefulSet.Spec.Template)
+		mergePodTemplateMetadata(existingStatefulSet, &existingStatefulSet.Spec.Template, &desiredStatefulSet.Spec.Template)
 		existingStatefulSet.Spec.Template.Spec = desiredStatefulSet.Spec.Template.Spec
 		existingStatefulSet.Spec.PersistentVolumeClaimRetentionPolicy = desiredStatefulSet.Spec.PersistentVolumeClaimRetentionPolicy
 
@@ -132,7 +132,7 @@ func (r *SeaweedReconciler) ensureVolumeServerDaemonSet(ctx context.Context, sea
 		existingDaemonSet := existing.(*appsv1.DaemonSet)
 		desiredDaemonSet := desired.(*appsv1.DaemonSet)
 
-		mergePodTemplateMetadata(&existingDaemonSet.Spec.Template, &desiredDaemonSet.Spec.Template)
+		mergePodTemplateMetadata(existingDaemonSet, &existingDaemonSet.Spec.Template, &desiredDaemonSet.Spec.Template)
 		existingDaemonSet.Spec.Template.Spec = desiredDaemonSet.Spec.Template.Spec
 		existingDaemonSet.Spec.UpdateStrategy = desiredDaemonSet.Spec.UpdateStrategy
 
@@ -264,7 +264,7 @@ func (r *SeaweedReconciler) ensureVolumeServerTopologyStatefulSet(ctx context.Co
 		desiredStatefulSet := desired.(*appsv1.StatefulSet)
 
 		existingStatefulSet.Spec.Replicas = desiredStatefulSet.Spec.Replicas
-		mergePodTemplateMetadata(&existingStatefulSet.Spec.Template, &desiredStatefulSet.Spec.Template)
+		mergePodTemplateMetadata(existingStatefulSet, &existingStatefulSet.Spec.Template, &desiredStatefulSet.Spec.Template)
 		existingStatefulSet.Spec.Template.Spec = desiredStatefulSet.Spec.Template.Spec
 		existingStatefulSet.Spec.PersistentVolumeClaimRetentionPolicy = desiredStatefulSet.Spec.PersistentVolumeClaimRetentionPolicy
 

--- a/internal/controller/pod_template_metadata_envtest_test.go
+++ b/internal/controller/pod_template_metadata_envtest_test.go
@@ -64,7 +64,8 @@ func podTemplateOf(t *testing.T, obj client.Object) corev1.PodTemplateSpec {
 
 // assertTemplateAnnotations re-reads obj and checks that the restart
 // annotation stamped by another controller survived the reconcile while the
-// operator's own annotation was brought up to date.
+// operator's own annotation was brought up to date, or removed when checksum
+// is empty.
 func assertTemplateAnnotations(t *testing.T, ctx context.Context, cli client.Client, obj client.Object, checksum string) {
 	t.Helper()
 	if err := cli.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
@@ -157,6 +158,40 @@ func TestReconcile_PreservesPodTemplateAnnotationsFromOtherControllers(t *testin
 	for _, w := range workloads {
 		assertTemplateAnnotations(t, ctx, cli, w, "v2")
 	}
+
+	// Dropping the key from the CR drops it from every template; the foreign
+	// key still survives.
+	if err := cli.Get(ctx, req.NamespacedName, cr); err != nil {
+		t.Fatalf("re-read CR: %v", err)
+	}
+	delete(cr.Spec.Annotations, "checksum/config")
+	if err := cli.Update(ctx, cr); err != nil {
+		t.Fatalf("update CR: %v", err)
+	}
+	if _, err := r.Reconcile(ctx, req); err != nil {
+		t.Fatalf("reconcile after removal: %v", err)
+	}
+	for _, w := range workloads {
+		assertTemplateAnnotations(t, ctx, cli, w, "")
+	}
+
+	// A converged workload is not rewritten: the rendered-key record must
+	// come out byte-identical on every pass.
+	versions := map[string]string{}
+	for _, w := range workloads {
+		versions[w.GetName()] = w.GetResourceVersion()
+	}
+	if _, err := r.Reconcile(ctx, req); err != nil {
+		t.Fatalf("steady-state reconcile: %v", err)
+	}
+	for _, w := range workloads {
+		if err := cli.Get(ctx, client.ObjectKeyFromObject(w), w); err != nil {
+			t.Fatalf("get %s: %v", w.GetName(), err)
+		}
+		if w.GetResourceVersion() != versions[w.GetName()] {
+			t.Errorf("%s was rewritten by a steady-state reconcile", w.GetName())
+		}
+	}
 }
 
 // TestEnsureVolumeServerDaemonSet_PreservesPodTemplateAnnotationsFromOtherControllers
@@ -200,6 +235,12 @@ func TestEnsureVolumeServerDaemonSet_PreservesPodTemplateAnnotationsFromOtherCon
 		t.Fatalf("ensure DaemonSet after restart: %v", err)
 	}
 	assertTemplateAnnotations(t, ctx, cli, ds, "v2")
+
+	delete(cr.Spec.Annotations, "checksum/config")
+	if _, _, err := r.ensureVolumeServerDaemonSet(ctx, cr); err != nil {
+		t.Fatalf("ensure DaemonSet after removal: %v", err)
+	}
+	assertTemplateAnnotations(t, ctx, cli, ds, "")
 }
 
 // TestCreateOrUpdateDeployment_AddsAnnotationsToBareTemplate pins the
@@ -246,5 +287,15 @@ func TestCreateOrUpdateDeployment_AddsAnnotationsToBareTemplate(t *testing.T) {
 	}
 	if got.Spec.Template.Annotations["checksum/config"] != "v1" {
 		t.Errorf("template annotation checksum/config = %q, want v1", got.Spec.Template.Annotations["checksum/config"])
+	}
+
+	if _, err := r.CreateOrUpdateDeployment(deploy(nil)); err != nil {
+		t.Fatalf("update back to bare: %v", err)
+	}
+	if err := cli.Get(ctx, types.NamespacedName{Name: "bare", Namespace: ns}, &got); err != nil {
+		t.Fatalf("readback: %v", err)
+	}
+	if v, ok := got.Spec.Template.Annotations["checksum/config"]; ok {
+		t.Errorf("template annotation checksum/config = %q, want it removed", v)
 	}
 }

--- a/internal/controller/pod_template_metadata_envtest_test.go
+++ b/internal/controller/pod_template_metadata_envtest_test.go
@@ -1,0 +1,250 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+)
+
+const (
+	restartedAtAnnotation = "kubectl.kubernetes.io/restartedAt"
+	restartedAt           = "2026-09-03T12:23:43Z"
+)
+
+// rolloutRestart stamps a workload's pod template the way kubectl rollout
+// restart does: a strategic merge patch adding the restartedAt annotation.
+func rolloutRestart(t *testing.T, ctx context.Context, cli client.Client, obj client.Object) {
+	t.Helper()
+	patch := fmt.Sprintf(`{"spec":{"template":{"metadata":{"annotations":{%q:%q}}}}}`, restartedAtAnnotation, restartedAt)
+	if err := cli.Patch(ctx, obj, client.RawPatch(types.StrategicMergePatchType, []byte(patch))); err != nil {
+		t.Fatalf("rollout restart %s: %v", obj.GetName(), err)
+	}
+}
+
+func podTemplateOf(t *testing.T, obj client.Object) corev1.PodTemplateSpec {
+	t.Helper()
+	switch o := obj.(type) {
+	case *appsv1.StatefulSet:
+		return o.Spec.Template
+	case *appsv1.Deployment:
+		return o.Spec.Template
+	case *appsv1.DaemonSet:
+		return o.Spec.Template
+	}
+	t.Fatalf("unexpected workload type %T", obj)
+	return corev1.PodTemplateSpec{}
+}
+
+// assertTemplateAnnotations re-reads obj and checks that the restart
+// annotation stamped by another controller survived the reconcile while the
+// operator's own annotation was brought up to date.
+func assertTemplateAnnotations(t *testing.T, ctx context.Context, cli client.Client, obj client.Object, checksum string) {
+	t.Helper()
+	if err := cli.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+		t.Fatalf("get %s: %v", obj.GetName(), err)
+	}
+	got := podTemplateOf(t, obj).Annotations
+	if got[restartedAtAnnotation] != restartedAt {
+		t.Errorf("%s: template annotation %s = %q, want %q", obj.GetName(), restartedAtAnnotation, got[restartedAtAnnotation], restartedAt)
+	}
+	if got["checksum/config"] != checksum {
+		t.Errorf("%s: template annotation checksum/config = %q, want %q", obj.GetName(), got["checksum/config"], checksum)
+	}
+}
+
+// TestReconcile_PreservesPodTemplateAnnotationsFromOtherControllers converges
+// a cluster against a real apiserver, stamps every managed workload's pod
+// template the way kubectl rollout restart (and Reloader, and the Vault
+// Secrets Operator) does, and bumps an operator-owned annotation on the CR.
+// The next reconcile must keep the foreign key and apply its own. Reverting
+// the template mid-roll left StatefulSets half rolled, with ordinal 0 never
+// restarted.
+func TestReconcile_PreservesPodTemplateAnnotationsFromOtherControllers(t *testing.T) {
+	_, cli := mustEnvtest(t)
+	ctx := context.Background()
+
+	ns := newTestNamespace(t, ctx, cli, "restart")
+	t.Cleanup(func() {
+		_ = cli.Delete(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	})
+
+	concurrentStart := true
+	diskCount := int32(1)
+	cr := &seaweedv1.Seaweed{
+		ObjectMeta: metav1.ObjectMeta{Name: "restart", Namespace: ns},
+		Spec: seaweedv1.SeaweedSpec{
+			Image:                 "chrislusf/seaweedfs:latest",
+			Annotations:           map[string]string{"checksum/config": "v1"},
+			VolumeServerDiskCount: &diskCount,
+			Master: &seaweedv1.MasterSpec{
+				Replicas:        1,
+				ConcurrentStart: &concurrentStart,
+			},
+			Volume: &seaweedv1.VolumeSpec{
+				Replicas: 1,
+				VolumeServerConfig: seaweedv1.VolumeServerConfig{
+					ResourceRequirements: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("1Gi"),
+						},
+					},
+				},
+			},
+			Filer: &seaweedv1.FilerSpec{Replicas: 1},
+			S3:    &seaweedv1.S3GatewaySpec{Replicas: 1},
+		},
+	}
+	if err := cli.Create(ctx, cr); err != nil {
+		t.Fatalf("create Seaweed CR: %v", err)
+	}
+
+	r := &SeaweedReconciler{Client: cli, Log: logf.FromContext(ctx), Scheme: cli.Scheme()}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: cr.Name, Namespace: ns}}
+	for i := 0; i < 3; i++ {
+		if _, err := r.Reconcile(ctx, req); err != nil {
+			t.Fatalf("convergence reconcile %d: %v", i+1, err)
+		}
+	}
+
+	workloads := []client.Object{
+		&appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "restart-master", Namespace: ns}},
+		&appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "restart-volume", Namespace: ns}},
+		&appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "restart-filer", Namespace: ns}},
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "restart-s3", Namespace: ns}},
+	}
+	for _, w := range workloads {
+		rolloutRestart(t, ctx, cli, w)
+	}
+
+	if err := cli.Get(ctx, req.NamespacedName, cr); err != nil {
+		t.Fatalf("re-read CR: %v", err)
+	}
+	cr.Spec.Annotations["checksum/config"] = "v2"
+	if err := cli.Update(ctx, cr); err != nil {
+		t.Fatalf("update CR: %v", err)
+	}
+	if _, err := r.Reconcile(ctx, req); err != nil {
+		t.Fatalf("reconcile after restart: %v", err)
+	}
+
+	for _, w := range workloads {
+		assertTemplateAnnotations(t, ctx, cli, w, "v2")
+	}
+}
+
+// TestEnsureVolumeServerDaemonSet_PreservesPodTemplateAnnotationsFromOtherControllers
+// covers the hostPath DaemonSet, which is reconciled outside the StatefulSet path.
+func TestEnsureVolumeServerDaemonSet_PreservesPodTemplateAnnotationsFromOtherControllers(t *testing.T) {
+	_, cli := mustEnvtest(t)
+	ctx := context.Background()
+
+	ns := newTestNamespace(t, ctx, cli, "restart-ds")
+	t.Cleanup(func() {
+		_ = cli.Delete(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	})
+
+	cr := &seaweedv1.Seaweed{
+		ObjectMeta: metav1.ObjectMeta{Name: "restart", Namespace: ns},
+		Spec: seaweedv1.SeaweedSpec{
+			Image:       "chrislusf/seaweedfs:latest",
+			Annotations: map[string]string{"checksum/config": "v1"},
+			Master:      &seaweedv1.MasterSpec{Replicas: 1},
+			Volume: &seaweedv1.VolumeSpec{
+				Replicas: 1,
+				Kind:     seaweedv1.VolumeServerDaemonSet,
+				HostPath: []seaweedv1.VolumeServerHostPath{{Path: "/mnt/disk0"}},
+			},
+		},
+	}
+	if err := cli.Create(ctx, cr); err != nil {
+		t.Fatalf("create Seaweed CR: %v", err)
+	}
+
+	r := &SeaweedReconciler{Client: cli, Log: logf.FromContext(ctx), Scheme: cli.Scheme()}
+	if _, _, err := r.ensureVolumeServerDaemonSet(ctx, cr); err != nil {
+		t.Fatalf("ensure DaemonSet: %v", err)
+	}
+
+	ds := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "restart-volume", Namespace: ns}}
+	rolloutRestart(t, ctx, cli, ds)
+
+	cr.Spec.Annotations["checksum/config"] = "v2"
+	if _, _, err := r.ensureVolumeServerDaemonSet(ctx, cr); err != nil {
+		t.Fatalf("ensure DaemonSet after restart: %v", err)
+	}
+	assertTemplateAnnotations(t, ctx, cli, ds, "v2")
+}
+
+// TestCreateOrUpdateDeployment_AddsAnnotationsToBareTemplate pins the
+// Deployment path for a template that was created without annotations: the
+// apiserver hands it back with a nil map, and the merge must allocate rather
+// than panic when the CR later gains an annotation.
+func TestCreateOrUpdateDeployment_AddsAnnotationsToBareTemplate(t *testing.T) {
+	_, cli := mustEnvtest(t)
+	ctx := context.Background()
+
+	ns := newTestNamespace(t, ctx, cli, "bare-template")
+	t.Cleanup(func() {
+		_ = cli.Delete(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	})
+
+	r := &SeaweedReconciler{Client: cli, Log: logf.FromContext(ctx), Scheme: cli.Scheme()}
+	deploy := func(annotations map[string]string) *appsv1.Deployment {
+		labels := map[string]string{"app": "bare"}
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "bare", Namespace: ns},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: labels},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: labels, Annotations: annotations},
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{
+						Name:  "app",
+						Image: "busybox",
+					}}},
+				},
+			},
+		}
+	}
+
+	if _, err := r.CreateOrUpdateDeployment(deploy(nil)); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := r.CreateOrUpdateDeployment(deploy(map[string]string{"checksum/config": "v1"})); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	var got appsv1.Deployment
+	if err := cli.Get(ctx, types.NamespacedName{Name: "bare", Namespace: ns}, &got); err != nil {
+		t.Fatalf("readback: %v", err)
+	}
+	if got.Spec.Template.Annotations["checksum/config"] != "v1" {
+		t.Errorf("template annotation checksum/config = %q, want v1", got.Spec.Template.Annotations["checksum/config"])
+	}
+}


### PR DESCRIPTION
Follow-up to #373, which fixed the StatefulSet and DaemonSet sites from #371.

## Keys that leave the CR are removed

The merge in #373 overlays desired keys, so an annotation or label dropped from `spec.annotations` / `spec.<component>.annotations` stayed on the pod template until the workload was recreated. Both #373 and the first cut of this PR named that as a limitation, and CodeRabbit flagged it.

`mergePodTemplateMetadata` now does what `kubectl apply` does for a map: it records the set of keys it rendered as an annotation on the owning workload (`seaweedfs.com/last-applied-podtemplate-keys`), and on the next pass removes keys that are in the record but no longer rendered. Keys outside the record are never touched, so the `restartedAt` annotation another controller stamps survives, and the first pass after an operator upgrade removes nothing. The record lists keys only, sorted, so a converged workload is not rewritten.

## Deployment path

`CreateOrUpdateDeployment` (S3, SFTP, worker) merged template annotations by hand and left labels alone. Two gaps:

- It wrote into the annotation map the apiserver returned. That map is nil for a template created without annotations, so a CR that later gained one panicked every reconcile with `assignment to entry in nil map`.
- A label change on the CR never reached an existing Deployment. Labels were applied at creation only.

The path now calls the shared helper, so every workload converges template metadata the same way.

## Tests

Unit tests on the helper, on top of the ones #373 added: a key in the record but not rendered is removed while foreign keys stay, the record comes out sorted, and with no record nothing is removed.

envtest coverage through the real reconcile loop:

- `TestReconcile_PreservesPodTemplateAnnotationsFromOtherControllers` converges a master/volume/filer/S3 cluster, patches every workload's template the way `kubectl rollout restart` does, bumps a CR-level annotation, then removes it. Each reconcile must keep the foreign key and apply, then remove, its own. A final steady-state pass must leave every workload's resourceVersion unchanged.
- `TestEnsureVolumeServerDaemonSet_PreservesPodTemplateAnnotationsFromOtherControllers` covers the hostPath DaemonSet, including removal.
- `TestCreateOrUpdateDeployment_AddsAnnotationsToBareTemplate` pins the nil-map case and removal. It panics without the Deployment change.

`go test ./internal/controller/...` with envtest passes, including the steady-state no-spurious-writes test. `make vet` and `make nilaway-lint` are clean.

https://claude.ai/code/session_015Wm1B5dsVVazYFcDLyyCao


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pod template annotations and labels managed by the operator are now removed when no longer configured.
  * Metadata added by other controllers, including restart and secret-management tools, is preserved.
  * Workload reconciliation now safely handles pod templates without existing annotations.
  * Stable workloads are no longer unnecessarily rewritten during reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->