### PR TITLE
Preserve pod template annotations and labels set by other controllers

### DIFF
--- a/internal/controller/controller_admin.go
+++ b/internal/controller/controller_admin.go
@@ -47,7 +47,7 @@ func (r *SeaweedReconciler) ensureAdminStatefulSet(seaweedCR *seaweedv1.Seaweed)
 		desiredStatefulSet := desired.(*appsv1.StatefulSet)
 
 		existingStatefulSet.Spec.Replicas = desiredStatefulSet.Spec.Replicas
-		existingStatefulSet.Spec.Template.ObjectMeta = desiredStatefulSet.Spec.Template.ObjectMeta
+		mergePodTemplateMetadata(&existingStatefulSet.Spec.Template, &desiredStatefulSet.Spec.Template)
 		existingStatefulSet.Spec.Template.Spec = desiredStatefulSet.Spec.Template.Spec
 
 		return nil

--- a/internal/controller/controller_filer.go
+++ b/internal/controller/controller_filer.go
@@ -54,7 +54,7 @@ func (r *SeaweedReconciler) ensureFilerStatefulSet(ctx context.Context, seaweedC
 		desiredStatefulSet := desired.(*appsv1.StatefulSet)
 
 		existingStatefulSet.Spec.Replicas = desiredStatefulSet.Spec.Replicas
-		existingStatefulSet.Spec.Template.ObjectMeta = desiredStatefulSet.Spec.Template.ObjectMeta
+		mergePodTemplateMetadata(&existingStatefulSet.Spec.Template, &desiredStatefulSet.Spec.Template)
 		existingStatefulSet.Spec.Template.Spec = desiredStatefulSet.Spec.Template.Spec
 		existingStatefulSet.Spec.PersistentVolumeClaimRetentionPolicy = desiredStatefulSet.Spec.PersistentVolumeClaimRetentionPolicy
 

--- a/internal/controller/controller_master.go
+++ b/internal/controller/controller_master.go
@@ -99,7 +99,7 @@ func (r *SeaweedReconciler) ensureMasterStatefulSet(seaweedCR *seaweedv1.Seaweed
 		desiredStatefulSet := desired.(*appsv1.StatefulSet)
 
 		existingStatefulSet.Spec.Replicas = desiredStatefulSet.Spec.Replicas
-		existingStatefulSet.Spec.Template.ObjectMeta = desiredStatefulSet.Spec.Template.ObjectMeta
+		mergePodTemplateMetadata(&existingStatefulSet.Spec.Template, &desiredStatefulSet.Spec.Template)
 		existingStatefulSet.Spec.Template.Spec = desiredStatefulSet.Spec.Template.Spec
 		return nil
 	})

--- a/internal/controller/controller_pod_template_metadata_test.go
+++ b/internal/controller/controller_pod_template_metadata_test.go
@@ -1,0 +1,95 @@
+package controller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestMergePodTemplateMetadataKeepsExternalKeys covers the restart signal that
+// kubectl rollout restart, Reloader and the Vault Secrets Operator all write to
+// the pod template. Replacing ObjectMeta wholesale discarded it mid-roll, which
+// left the StatefulSet half rolled: the highest ordinal had already been
+// recreated, and ordinal 0 matched the reverted template and was never rolled.
+func TestMergePodTemplateMetadataKeepsExternalKeys(t *testing.T) {
+	existing := &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"kubectl.kubernetes.io/restartedAt": "2026-09-03T12:23:43Z",
+				"vso.hashicorp.com/restartedAt":     "rotation-7",
+			},
+			Labels: map[string]string{
+				"app":                     "seaweedfs",
+				"example.com/team":        "storage",
+				"pod-template-generation": "stale",
+			},
+		},
+	}
+	desired := &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{"seaweed.seaweedfs.com/checksum": "abc123"},
+			Labels: map[string]string{
+				"app":                     "seaweedfs",
+				"pod-template-generation": "fresh",
+			},
+		},
+	}
+
+	mergePodTemplateMetadata(existing, desired)
+
+	for k, want := range map[string]string{
+		"kubectl.kubernetes.io/restartedAt": "2026-09-03T12:23:43Z",
+		"vso.hashicorp.com/restartedAt":     "rotation-7",
+		"seaweed.seaweedfs.com/checksum":    "abc123",
+	} {
+		if got := existing.Annotations[k]; got != want {
+			t.Errorf("annotation %q = %q, want %q", k, got, want)
+		}
+	}
+	if got := existing.Labels["example.com/team"]; got != "storage" {
+		t.Errorf("label set by another controller was dropped, got %q", got)
+	}
+	// The operator stays authoritative over the keys it does set.
+	if got := existing.Labels["pod-template-generation"]; got != "fresh" {
+		t.Errorf("operator-managed label = %q, want the desired value", got)
+	}
+}
+
+// The rest of the pod template must still be replaced outright, so a spec
+// change the operator makes is not silently merged away.
+func TestMergePodTemplateMetadataReplacesTheRestOfObjectMeta(t *testing.T) {
+	existing := &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "left-over",
+			Annotations: map[string]string{"external": "keep"},
+		},
+	}
+	desired := &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{Name: "seaweed-filer"},
+	}
+
+	mergePodTemplateMetadata(existing, desired)
+
+	if existing.Name != "seaweed-filer" {
+		t.Errorf("Name = %q, want the desired value", existing.Name)
+	}
+	if got := existing.Annotations["external"]; got != "keep" {
+		t.Errorf("external annotation = %q, want it preserved", got)
+	}
+}
+
+// Both sides start empty on a freshly created workload.
+func TestMergePodTemplateMetadataHandlesNilMaps(t *testing.T) {
+	existing := &corev1.PodTemplateSpec{}
+	desired := &corev1.PodTemplateSpec{}
+
+	mergePodTemplateMetadata(existing, desired)
+
+	if existing.Annotations == nil || len(existing.Annotations) != 0 {
+		t.Errorf("Annotations = %v, want empty and non-nil", existing.Annotations)
+	}
+	if existing.Labels == nil || len(existing.Labels) != 0 {
+		t.Errorf("Labels = %v, want empty and non-nil", existing.Labels)
+	}
+}

--- a/internal/controller/controller_util.go
+++ b/internal/controller/controller_util.go
@@ -501,3 +501,31 @@ func (r *SeaweedReconciler) probeServiceMonitorCRD() bool {
 	klog.Warningf("ServiceMonitor CRD probe returned unexpected error (assuming available): %v", err)
 	return true
 }
+
+// mergePodTemplateMetadata applies the desired pod template metadata to an
+// existing workload while preserving annotations and labels the operator does
+// not manage.
+//
+// Assigning ObjectMeta wholesale discards every key written by anything else,
+// which breaks the standard "annotate the pod template to trigger a restart"
+// mechanism that `kubectl rollout restart`, Reloader and the Vault Secrets
+// Operator's rolloutRestartTargets all rely on.
+//
+// It also does not cancel such a restart cleanly. The StatefulSet controller
+// rolls the highest ordinal first, so by the time the operator reverts the
+// template, that replica has already been recreated. Ordinal 0 still matches
+// the operator's canonical template and is never rolled at all, leaving a
+// StatefulSet permanently half rolled with no indication that it happened.
+//
+// The operator's own keys stay authoritative: anything it sets overwrites the
+// existing value. A key the operator previously set and no longer sets is kept
+// rather than removed, since there is nothing here to distinguish it from a key
+// another controller owns.
+func mergePodTemplateMetadata(existing, desired *corev1.PodTemplateSpec) {
+	annotations := mergeStringMaps(existing.Annotations, desired.Annotations)
+	labels := mergeStringMaps(existing.Labels, desired.Labels)
+
+	existing.ObjectMeta = desired.ObjectMeta
+	existing.Annotations = annotations
+	existing.Labels = labels
+}

--- a/internal/controller/controller_volume.go
+++ b/internal/controller/controller_volume.go
@@ -96,7 +96,7 @@ func (r *SeaweedReconciler) ensureVolumeServerStatefulSet(ctx context.Context, s
 		desiredStatefulSet := desired.(*appsv1.StatefulSet)
 
 		existingStatefulSet.Spec.Replicas = desiredStatefulSet.Spec.Replicas
-		existingStatefulSet.Spec.Template.ObjectMeta = desiredStatefulSet.Spec.Template.ObjectMeta
+		mergePodTemplateMetadata(&existingStatefulSet.Spec.Template, &desiredStatefulSet.Spec.Template)
 		existingStatefulSet.Spec.Template.Spec = desiredStatefulSet.Spec.Template.Spec
 		existingStatefulSet.Spec.PersistentVolumeClaimRetentionPolicy = desiredStatefulSet.Spec.PersistentVolumeClaimRetentionPolicy
 
@@ -132,7 +132,7 @@ func (r *SeaweedReconciler) ensureVolumeServerDaemonSet(ctx context.Context, sea
 		existingDaemonSet := existing.(*appsv1.DaemonSet)
 		desiredDaemonSet := desired.(*appsv1.DaemonSet)
 
-		existingDaemonSet.Spec.Template.ObjectMeta = desiredDaemonSet.Spec.Template.ObjectMeta
+		mergePodTemplateMetadata(&existingDaemonSet.Spec.Template, &desiredDaemonSet.Spec.Template)
 		existingDaemonSet.Spec.Template.Spec = desiredDaemonSet.Spec.Template.Spec
 		existingDaemonSet.Spec.UpdateStrategy = desiredDaemonSet.Spec.UpdateStrategy
 
@@ -264,7 +264,7 @@ func (r *SeaweedReconciler) ensureVolumeServerTopologyStatefulSet(ctx context.Co
 		desiredStatefulSet := desired.(*appsv1.StatefulSet)
 
 		existingStatefulSet.Spec.Replicas = desiredStatefulSet.Spec.Replicas
-		existingStatefulSet.Spec.Template.ObjectMeta = desiredStatefulSet.Spec.Template.ObjectMeta
+		mergePodTemplateMetadata(&existingStatefulSet.Spec.Template, &desiredStatefulSet.Spec.Template)
 		existingStatefulSet.Spec.Template.Spec = desiredStatefulSet.Spec.Template.Spec
 		existingStatefulSet.Spec.PersistentVolumeClaimRetentionPolicy = desiredStatefulSet.Spec.PersistentVolumeClaimRetentionPolicy
 


### PR DESCRIPTION
Fixes #371.

`existingStatefulSet.Spec.Template.ObjectMeta = desiredStatefulSet.Spec.Template.ObjectMeta` replaces annotations and labels in full rather than merging, so any key written by another controller is discarded on the next reconcile. That breaks the usual way of triggering a restart — annotate the pod template — which `kubectl rollout restart`, Reloader and the Vault Secrets Operator's `rolloutRestartTargets` all use.

The part that makes it hard to spot is that it does not cleanly cancel the restart. The StatefulSet controller rolls the highest ordinal first, so that replica is already recreated by the time the operator reverts the template. Ordinal 0 was sitting on the canonical template all along, so after the revert it matches and is never rolled. Same half every time, no event, no error.

On our cluster the filer runs 2 replicas with rotating Postgres credentials injected from a Secret. `filer-0` kept the credential it started with until it was revoked, at which point every query failed, the liveness probe (`httpGet /` on 8888, which does a `listDirectory`) failed with it, and the kubelet restarted the container. SeaweedFS shuts down gracefully, so it surfaced as `exitCode: 0, reason: Completed` — nothing that reads as a crash. Seven credential rotations, seven restarts on `filer-0`, zero on `filer-1`.

## The change

Merge the maps instead of assigning, with the operator's own keys authoritative. Six sites, one shared helper:

- `controller_master.go`
- `controller_filer.go`
- `controller_admin.go`
- `controller_volume.go` — volume StatefulSet, volume DaemonSet, and volume server StatefulSet

The issue text lists five; `controller_admin.go:50` has the same pattern and is included here.

The rest of `ObjectMeta` is still replaced outright, so this does not soften anything else about template reconciliation.

## One limitation worth naming

A key the operator previously set and no longer sets is now kept rather than removed, because nothing in the pod template distinguishes it from a key another controller owns. In practice that means removing an entry from `spec.<component>.annotations` leaves the old annotation behind until the workload is recreated.

Fixing that properly needs the operator to record which keys it manages — there is precedent for the approach in `writeAppliedAccessAnnotation` — or server-side apply with a dedicated field manager, which would solve the general case since the operator would then only own fields it actually sets. Both are larger changes than this one and I did not want to bundle them. Happy to follow up with either if you would take it.

## Testing

`TestMergePodTemplateMetadata*` covers external keys surviving, operator keys winning on conflict, the rest of `ObjectMeta` still being replaced, and nil maps on a freshly created workload. Verified they fail against the old behaviour.

`go build ./...`, `go vet ./...` and `go test ./internal/...` all pass. envtest-tagged tests skip locally without `KUBEBUILDER_ASSETS`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved labels and annotations added by external tools during workload updates.
  * Ensured operator-managed metadata continues to be updated correctly without removing unrelated metadata.
  * Applied consistent metadata preservation across admin, filer, master, and volume-server workloads.

* **Tests**
  * Added coverage for preserving external metadata, replacing other template metadata appropriately, and handling empty metadata maps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->