### PR TITLE
Add a chart value for ENABLE_CSI_DRIVER, and an extraEnv escape hatch

### DIFF
--- a/CSI_SUPPORT.md
+++ b/CSI_SUPPORT.md
@@ -68,6 +68,14 @@ operator's manager container:
 ENABLE_CSI_DRIVER=true
 ```
 
+With the Helm chart, set it through the chart value rather than patching the
+Deployment:
+
+```yaml
+csiDriver:
+  enabled: true
+```
+
 A CSI driver is **node-global**: the kubelet registers exactly one driver per
 `driverName` per node, regardless of how many SeaweedFS clusters run on it.
 For that reason the driver is modeled as its own opt-in resource rather than a

--- a/README.md
+++ b/README.md
@@ -876,7 +876,7 @@ filesystem alternative to the S3 API above.
 A CSI driver is node-global, so it is managed through its own opt-in
 `SeaweedCSIDriver` resource rather than a field on the `Seaweed` CR, and the
 controller is **off by default** — enable it with `ENABLE_CSI_DRIVER=true` on
-the operator manager. The driver can mount an operator-managed cluster
+the operator manager, or `csiDriver.enabled: true` with the Helm chart. The driver can mount an operator-managed cluster
 (`seaweedRef`, grant-gated across namespaces) or any external filer
 (`filerAddress`):
 

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -19,6 +19,8 @@ A Helm chart for the seaweedfs-operator
 | commonAnnotations | object | `{}` | Annotations for all the deployed objects |
 | commonLabels | object | `{}` | Labels for all the deployed objects |
 | crds.create | bool | `true` | Install the Seaweed CRD as part of the release. Set to false when the CRD is managed out-of-band (e.g., cluster-scoped GitOps or a shared CRD across namespaces) so `helm install/upgrade` won't try to create or adopt it. |
+| csiDriver.enabled | bool | `false` | Register the SeaweedCSIDriver controller by setting ENABLE_CSI_DRIVER=true on the manager. Off by default, matching the manager's own default. |
+| extraEnv | list | `[]` | Additional environment variables for the manager container. Takes the usual env list form, so a value can come from a secretKeyRef or fieldRef as well as a literal. |
 | fullnameOverride | string | `""` | String to fully override common.names.fullname template |
 | global | object | `{"imageRegistry":""}` | Global Docker image parameters. global.imageRegistry, when set, overrides the registry of every image in the chart; leave empty to use each image's own. |
 | grafanaDashboard.additionalLabels | object | `{"grafana_dashboard":"1"}` | Labels added to the Grafana Dashboard ConfigMap so the Grafana sidecar discovers it. kube-prometheus-stack only matches `grafana_dashboard: "1"`; the standalone grafana chart matches any value. Set a key to `null` to drop it — an empty map merges with the default rather than replacing it. |

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -59,6 +59,15 @@ spec:
         - name: ENABLE_WEBHOOKS
           value: "false"
         {{- end }}
+        {{- if .Values.csiDriver }}
+        {{- if .Values.csiDriver.enabled }}
+        - name: ENABLE_CSI_DRIVER
+          value: "true"
+        {{- end }}
+        {{- end }}
+        {{- with .Values.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         ports:
         - name: {{ .Values.port.name }}
           containerPort: {{ .Values.port.number }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -69,6 +69,22 @@ image:
 # -- Set number of pod replicas
 replicaCount: 1
 
+## The SeaweedCSIDriver controller, which reconciles SeaweedCSIDriver resources
+## into the CSI driver's node and mount DaemonSets. The manager registers it only
+## when ENABLE_CSI_DRIVER=true; otherwise a SeaweedCSIDriver CR is accepted and
+## silently does nothing, which is a confusing way to find out it is off.
+csiDriver:
+  # -- Register the SeaweedCSIDriver controller by setting ENABLE_CSI_DRIVER=true
+  # on the manager. Off by default, matching the manager's own default.
+  enabled: false
+
+# -- Additional environment variables for the manager container. Takes the usual
+# env list form, so a value can come from a secretKeyRef or fieldRef as well as
+# a literal.
+extraEnv: []
+#  - name: SOME_FLAG
+#    value: "true"
+
 # -- Bucket usage stats refresh configuration. The operator periodically
 # calls collection.list per Seaweed cluster and patches status.usage on
 # each Bucket. Leave refreshInterval empty to use the in-binary default


### PR DESCRIPTION
Fixes #349.

`cmd/main.go` registers the `SeaweedCSIDriver` controller only when `ENABLE_CSI_DRIVER=true`, but `deploy/helm/templates/deployment.yaml` templates just `ENABLE_WEBHOOKS`, and `values.yaml` has no way to add an environment variable at all. On a chart-managed install the only way to turn the controller on is to patch the rendered Deployment, which does not survive `helm upgrade` and is awkward to express under GitOps.

The symptom is easy to misread. A `SeaweedCSIDriver` CR is accepted by the apiserver and then does nothing, because the controller was never registered — the manager says so in its log, but the CR looks fine. Reading the RBAC does not help either: the manager ClusterRole grants `seaweedcsidrivers` plus `csidrivers`, `storageclasses`, `csinodes` and `volumeattachments`, which reads like an implemented, enabled feature.

## The change

```yaml
csiDriver:
  enabled: false   # default, matching the manager's own default

extraEnv: []
```

`csiDriver.enabled: true` emits `ENABLE_CSI_DRIVER=true`. `extraEnv` is the general form of the same gap and takes the usual env list, so a value can come from a `secretKeyRef` or `fieldRef` rather than only a literal.

Nothing changes for existing installs — with both at their defaults the rendered `env:` block is byte-identical to before.

Docs updated in `CSI_SUPPORT.md`, the top-level `README.md`, and the generated values table.

## Testing

`helm lint` clean. Rendered across the combinations:

| values | rendered `env` |
|---|---|
| defaults | `null` — unchanged from before |
| `csiDriver.enabled=true` | `ENABLE_CSI_DRIVER=true` |
| `extraEnv` literal | the literal only |
| both, plus `webhook.enabled=false` | all three, in that order |
| `extraEnv` with `valueFrom.secretKeyRef` | passes through intact |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Helm deployments can now enable the CSI driver with `csiDriver.enabled: true`.
  * Helm charts support additional manager container environment variables through `extraEnv`, including references to secrets and fields.
* **Documentation**
  * Updated CSI driver setup guidance to cover both Helm configuration and the `ENABLE_CSI_DRIVER` environment variable.
  * Documented the new Helm configuration values and their defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->