### PR TITLE
Release finalizers when the referenced Seaweed cluster is already gone

### DIFF
--- a/api/v1/bucket_types.go
+++ b/api/v1/bucket_types.go
@@ -208,8 +208,10 @@ type BucketSpec struct {
 	// +kubebuilder:validation:XValidation:rule="oldSelf == '' || self == oldSelf",message="bucket name is immutable once set"
 	Name string `json:"name,omitempty"`
 
-	// ClusterRef points at the Seaweed CR that owns this bucket.
+	// ClusterRef points at the Seaweed CR that owns this bucket. Immutable;
+	// moving a bucket between clusters is not supported.
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="clusterRef is immutable"
 	ClusterRef BucketClusterRef `json:"clusterRef"`
 
 	// ReclaimPolicy controls what happens to the underlying bucket when

--- a/api/v1/s3credentials_types.go
+++ b/api/v1/s3credentials_types.go
@@ -80,8 +80,9 @@ type S3SecretRef struct {
 // bound to an identity and mirrored into a Kubernetes Secret.
 type S3CredentialsSpec struct {
 	// SeaweedRef points at the Seaweed cluster whose IAM service owns the
-	// identity.
+	// identity. Immutable; access keys cannot be moved between clusters.
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="seaweedRef is immutable"
 	SeaweedRef SeaweedReference `json:"seaweedRef"`
 
 	// IdentityRef names the IAM identity (user) the credential belongs to.

--- a/api/v1/s3identity_types.go
+++ b/api/v1/s3identity_types.go
@@ -40,8 +40,9 @@ type S3Account struct {
 // change without touching the identity itself.
 type S3IdentitySpec struct {
 	// SeaweedRef points at the Seaweed cluster whose IAM service owns this
-	// identity.
+	// identity. Immutable; identities cannot be moved between clusters.
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="seaweedRef is immutable"
 	SeaweedRef SeaweedReference `json:"seaweedRef"`
 
 	// Name is the IAM user name. Defaults to .metadata.name. Immutable once

--- a/api/v1/s3oidcprovider_types.go
+++ b/api/v1/s3oidcprovider_types.go
@@ -27,8 +27,9 @@ import (
 // without the static -iam.config file (which freezes the dynamic IAM store).
 type S3OIDCProviderSpec struct {
 	// SeaweedRef points at the Seaweed cluster whose IAM service owns this
-	// provider.
+	// provider. Immutable; providers cannot be moved between clusters.
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="seaweedRef is immutable"
 	SeaweedRef SeaweedReference `json:"seaweedRef"`
 
 	// IssuerURL is the OIDC issuer URL (e.g. "https://accounts.google.com" or

--- a/api/v1/s3policy_types.go
+++ b/api/v1/s3policy_types.go
@@ -68,8 +68,9 @@ type S3PolicyStatement struct {
 // +kubebuilder:validation:XValidation:rule="(has(self.statements) && size(self.statements) > 0) != (has(self.policyDocument) && size(self.policyDocument) > 0)",message="set exactly one of spec.statements or spec.policyDocument"
 type S3PolicySpec struct {
 	// SeaweedRef points at the Seaweed cluster whose IAM service owns this
-	// policy.
+	// policy. Immutable; policies cannot be moved between clusters.
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="seaweedRef is immutable"
 	SeaweedRef SeaweedReference `json:"seaweedRef"`
 
 	// Name is the IAM policy name. Defaults to .metadata.name. Immutable

--- a/api/v1/s3policybinding_types.go
+++ b/api/v1/s3policybinding_types.go
@@ -62,8 +62,10 @@ type S3Subject struct {
 // intact).
 type S3PolicyBindingSpec struct {
 	// SeaweedRef points at the Seaweed cluster whose IAM service owns the
-	// policy and identities.
+	// policy and identities. Immutable; bindings cannot be moved between
+	// clusters.
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="seaweedRef is immutable"
 	SeaweedRef SeaweedReference `json:"seaweedRef"`
 
 	// PolicyRef names the IAM policy to attach. The policy must already

--- a/config/crd/bases/seaweed.seaweedfs.com_buckets.yaml
+++ b/config/crd/bases/seaweed.seaweedfs.com_buckets.yaml
@@ -93,6 +93,9 @@ spec:
                 required:
                 - name
                 type: object
+                x-kubernetes-validations:
+                - message: clusterRef is immutable
+                  rule: self == oldSelf
               name:
                 pattern: ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$
                 type: string

--- a/config/crd/bases/seaweed.seaweedfs.com_s3credentials.yaml
+++ b/config/crd/bases/seaweed.seaweedfs.com_s3credentials.yaml
@@ -77,6 +77,9 @@ spec:
                 required:
                 - name
                 type: object
+                x-kubernetes-validations:
+                - message: seaweedRef is immutable
+                  rule: self == oldSelf
               secretRef:
                 properties:
                   accessKeyField:

--- a/config/crd/bases/seaweed.seaweedfs.com_s3identities.yaml
+++ b/config/crd/bases/seaweed.seaweedfs.com_s3identities.yaml
@@ -79,6 +79,9 @@ spec:
                 required:
                 - name
                 type: object
+                x-kubernetes-validations:
+                - message: seaweedRef is immutable
+                  rule: self == oldSelf
             required:
             - seaweedRef
             type: object

--- a/config/crd/bases/seaweed.seaweedfs.com_s3oidcproviders.yaml
+++ b/config/crd/bases/seaweed.seaweedfs.com_s3oidcproviders.yaml
@@ -74,6 +74,9 @@ spec:
                 required:
                 - name
                 type: object
+                x-kubernetes-validations:
+                - message: seaweedRef is immutable
+                  rule: self == oldSelf
               thumbprints:
                 items:
                   pattern: ^[A-Fa-f0-9]{40}$

--- a/config/crd/bases/seaweed.seaweedfs.com_s3policies.yaml
+++ b/config/crd/bases/seaweed.seaweedfs.com_s3policies.yaml
@@ -68,6 +68,9 @@ spec:
                 required:
                 - name
                 type: object
+                x-kubernetes-validations:
+                - message: seaweedRef is immutable
+                  rule: self == oldSelf
               statements:
                 items:
                   properties:

--- a/config/crd/bases/seaweed.seaweedfs.com_s3policybindings.yaml
+++ b/config/crd/bases/seaweed.seaweedfs.com_s3policybindings.yaml
@@ -71,6 +71,9 @@ spec:
                 required:
                 - name
                 type: object
+                x-kubernetes-validations:
+                - message: seaweedRef is immutable
+                  rule: self == oldSelf
               subjects:
                 items:
                   properties:

--- a/deploy/helm/templates/crd-seaweed.yaml
+++ b/deploy/helm/templates/crd-seaweed.yaml
@@ -977,6 +977,9 @@ spec:
                   required:
                     - name
                   type: object
+                  x-kubernetes-validations:
+                    - message: clusterRef is immutable
+                      rule: self == oldSelf
                 name:
                   pattern: ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$
                   type: string
@@ -1359,6 +1362,9 @@ spec:
                   required:
                     - name
                   type: object
+                  x-kubernetes-validations:
+                    - message: seaweedRef is immutable
+                      rule: self == oldSelf
                 secretRef:
                   properties:
                     accessKeyField:
@@ -1524,6 +1530,9 @@ spec:
                   required:
                     - name
                   type: object
+                  x-kubernetes-validations:
+                    - message: seaweedRef is immutable
+                      rule: self == oldSelf
               required:
                 - seaweedRef
               type: object
@@ -1663,6 +1672,9 @@ spec:
                   required:
                     - name
                   type: object
+                  x-kubernetes-validations:
+                    - message: seaweedRef is immutable
+                      rule: self == oldSelf
                 thumbprints:
                   items:
                     pattern: ^[A-Fa-f0-9]{40}$
@@ -1804,6 +1816,9 @@ spec:
                   required:
                     - name
                   type: object
+                  x-kubernetes-validations:
+                    - message: seaweedRef is immutable
+                      rule: self == oldSelf
                 statements:
                   items:
                     properties:
@@ -1972,6 +1987,9 @@ spec:
                   required:
                     - name
                   type: object
+                  x-kubernetes-validations:
+                    - message: seaweedRef is immutable
+                      rule: self == oldSelf
                 subjects:
                   items:
                     properties:

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -155,6 +155,12 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	var seaweed seaweedv1.Seaweed
 	if err := r.Get(ctx, types.NamespacedName{Namespace: seaweedNS, Name: bucket.Spec.ClusterRef.Name}, &seaweed); err != nil {
 		if apierrors.IsNotFound(err) {
+			// The bucket lives in the cluster, so with the cluster gone there is
+			// nothing for handleDeletion to do. Release rather than requeue on a
+			// reference that will never resolve.
+			if handled, err := releaseFinalizerIfDeleting(ctx, r.Client, &bucket, BucketFinalizer); handled {
+				return ctrl.Result{}, err
+			}
 			r.setCondition(&bucket, seaweedv1.BucketConditionClusterReachable, metav1.ConditionFalse, "ClusterRefNotFound",
 				fmt.Sprintf("Seaweed %q not found in namespace %q", bucket.Spec.ClusterRef.Name, seaweedNS))
 			bucket.Status.Phase = seaweedv1.BucketPhasePending

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -169,7 +169,7 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	// move is to surface the error and let the user recreate. This check follows
 	// missing-cluster deletion cleanup so an invalid rename cannot trap the
 	// finalizer after the cluster is gone.
-	if bucket.Status.BucketName != "" && bucket.Status.BucketName != bucketName {
+	if bucket.DeletionTimestamp.IsZero() && bucket.Status.BucketName != "" && bucket.Status.BucketName != bucketName {
 		msg := fmt.Sprintf("bucket name change from %q to %q is not supported; restore the original name or recreate the resource",
 			bucket.Status.BucketName, bucketName)
 		return r.failPhase(ctx, &bucket, seaweedv1.BucketPhaseFailed, "BucketRenameNotSupported", msg)

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -118,16 +118,6 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	bucketName := resolvedBucketName(&bucket)
 
-	// Refuse rename attempts. Once a bucket is provisioned, status.bucketName
-	// pins the name; any divergence indicates the user changed spec.name
-	// after the fact. Renames in S3 / SeaweedFS are not a thing — the safe
-	// move is to surface the error and let the user recreate.
-	if bucket.Status.BucketName != "" && bucket.Status.BucketName != bucketName {
-		msg := fmt.Sprintf("bucket name change from %q to %q is not supported; restore the original name or recreate the resource",
-			bucket.Status.BucketName, bucketName)
-		return r.failPhase(ctx, &bucket, seaweedv1.BucketPhaseFailed, "BucketRenameNotSupported", msg)
-	}
-
 	// Resolve the cluster reference. A cross-namespace clusterRef needs a
 	// ResourceReferenceGrant; skip on deletion to not block cleanup.
 	seaweedNS := bucket.Spec.ClusterRef.Namespace
@@ -172,6 +162,18 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, err
 	}
 	r.setCondition(&bucket, seaweedv1.BucketConditionClusterReachable, metav1.ConditionTrue, "Reachable", "")
+
+	// Refuse rename attempts. Once a bucket is provisioned, status.bucketName
+	// pins the name; any divergence indicates the user changed spec.name
+	// after the fact. Renames in S3 / SeaweedFS are not a thing — the safe
+	// move is to surface the error and let the user recreate. This check follows
+	// missing-cluster deletion cleanup so an invalid rename cannot trap the
+	// finalizer after the cluster is gone.
+	if bucket.Status.BucketName != "" && bucket.Status.BucketName != bucketName {
+		msg := fmt.Sprintf("bucket name change from %q to %q is not supported; restore the original name or recreate the resource",
+			bucket.Status.BucketName, bucketName)
+		return r.failPhase(ctx, &bucket, seaweedv1.BucketPhaseFailed, "BucketRenameNotSupported", msg)
+	}
 
 	masters := getMasterPeersString(&seaweed)
 	filer := getFilerAddress(&seaweed)

--- a/internal/controller/cluster_ref_immutability_envtest_test.go
+++ b/internal/controller/cluster_ref_immutability_envtest_test.go
@@ -1,0 +1,113 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+)
+
+// Finalizer cleanup uses the referenced cluster as the identity of the remote
+// state it owns. If that reference could change, a missing replacement cluster
+// could make the controller release its finalizer while state remains active on
+// the original cluster.
+func TestManagedResourceClusterReferencesAreImmutable(t *testing.T) {
+	_, cli := mustEnvtest(t)
+	ctx := context.Background()
+	ns := newTestNamespace(t, ctx, cli, "cluster-ref-immutable")
+
+	bucket := &seaweedv1.Bucket{
+		ObjectMeta: metav1.ObjectMeta{Name: "photos", Namespace: ns},
+		Spec: seaweedv1.BucketSpec{
+			ClusterRef: seaweedv1.BucketClusterRef{Name: "cluster-a"},
+		},
+	}
+	identity := &seaweedv1.S3Identity{
+		ObjectMeta: metav1.ObjectMeta{Name: "alice", Namespace: ns},
+		Spec: seaweedv1.S3IdentitySpec{
+			SeaweedRef: seaweedv1.SeaweedReference{Name: "cluster-a"},
+		},
+	}
+	credentials := &seaweedv1.S3Credentials{
+		ObjectMeta: metav1.ObjectMeta{Name: "alice-credentials", Namespace: ns},
+		Spec: seaweedv1.S3CredentialsSpec{
+			SeaweedRef:  seaweedv1.SeaweedReference{Name: "cluster-a"},
+			IdentityRef: seaweedv1.S3IdentityRef{Name: "alice"},
+		},
+	}
+	policy := &seaweedv1.S3Policy{
+		ObjectMeta: metav1.ObjectMeta{Name: "read", Namespace: ns},
+		Spec: seaweedv1.S3PolicySpec{
+			SeaweedRef:     seaweedv1.SeaweedReference{Name: "cluster-a"},
+			PolicyDocument: `{}`,
+		},
+	}
+	binding := &seaweedv1.S3PolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "read-alice", Namespace: ns},
+		Spec: seaweedv1.S3PolicyBindingSpec{
+			SeaweedRef: seaweedv1.SeaweedReference{Name: "cluster-a"},
+			PolicyRef:  seaweedv1.S3PolicyRef{Name: "read"},
+			Subjects: []seaweedv1.S3Subject{{
+				Kind: seaweedv1.S3SubjectKindIdentity,
+				Name: "alice",
+			}},
+		},
+	}
+	provider := &seaweedv1.S3OIDCProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "accounts", Namespace: ns},
+		Spec: seaweedv1.S3OIDCProviderSpec{
+			SeaweedRef: seaweedv1.SeaweedReference{Name: "cluster-a"},
+			IssuerURL:  "https://accounts.example.com",
+			ClientIDs:  []string{"client-a"},
+		},
+	}
+
+	tests := []struct {
+		name   string
+		object client.Object
+		mutate func()
+	}{
+		{"Bucket", bucket, func() { bucket.Spec.ClusterRef.Name = "cluster-b" }},
+		{"S3Identity", identity, func() { identity.Spec.SeaweedRef.Name = "cluster-b" }},
+		{"S3Credentials", credentials, func() { credentials.Spec.SeaweedRef.Name = "cluster-b" }},
+		{"S3Policy", policy, func() { policy.Spec.SeaweedRef.Name = "cluster-b" }},
+		{"S3PolicyBinding", binding, func() { binding.Spec.SeaweedRef.Name = "cluster-b" }},
+		{"S3OIDCProvider", provider, func() { provider.Spec.SeaweedRef.Name = "cluster-b" }},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := cli.Create(ctx, tc.object); err != nil {
+				t.Fatalf("create: %v", err)
+			}
+			t.Cleanup(func() { _ = cli.Delete(context.Background(), tc.object) })
+
+			tc.mutate()
+			if err := cli.Update(ctx, tc.object); err == nil {
+				t.Fatal("expected cluster reference update to be rejected")
+			} else if !apierrors.IsInvalid(err) {
+				t.Fatalf("expected an Invalid error, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/controller/controller_finalizer_release_test.go
+++ b/internal/controller/controller_finalizer_release_test.go
@@ -216,3 +216,52 @@ func TestReconcile_ClusterGoneWhileDeleting_RenameMismatchDoesNotBlock(t *testin
 		}
 	})
 }
+
+// A rename attempt must not strand the finalizer. The rename guard runs before
+// the deletion path, so a Bucket whose spec.name diverged from
+// status.bucketName could never be deleted — the same stuck-finalizer symptom
+// as a missing cluster, from a different trigger.
+func TestReconcile_RenamedWhileDeleting_StillReleases(t *testing.T) {
+	now := metav1.Now()
+	bucket := newTestBucket("photos")
+	bucket.Spec.ReclaimPolicy = seaweedv1.BucketReclaimRetain
+	// Provisioned as "photos", spec since changed — a rename the operator refuses.
+	bucket.Status.BucketName = "photos-original"
+	bucket.Finalizers = []string{BucketFinalizer}
+	bucket.DeletionTimestamp = &now
+
+	fa := newFakeAdmin()
+	r, cli := testReconciler(t, fa, newTestSeaweed(), bucket)
+	key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	got := &seaweedv1.Bucket{}
+	if err := cli.Get(context.Background(), key, got); err == nil {
+		t.Errorf("a renamed bucket could not be deleted; still present with finalizers %v", got.Finalizers)
+	}
+}
+
+// The guard must still refuse a rename on a live object.
+func TestReconcile_RenamedWhileLive_StillRefused(t *testing.T) {
+	bucket := newTestBucket("photos")
+	bucket.Status.BucketName = "photos-original"
+
+	fa := newFakeAdmin()
+	r, cli := testReconciler(t, fa, newTestSeaweed(), bucket)
+	key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	got := &seaweedv1.Bucket{}
+	if err := cli.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status.Phase != seaweedv1.BucketPhaseFailed {
+		t.Errorf("phase = %q, want Failed for a rename on a live bucket", got.Status.Phase)
+	}
+}

--- a/internal/controller/controller_finalizer_release_test.go
+++ b/internal/controller/controller_finalizer_release_test.go
@@ -1,0 +1,124 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+)
+
+func finalizerTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("clientgoscheme: %v", err)
+	}
+	if err := seaweedv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("seaweedv1: %v", err)
+	}
+	return scheme
+}
+
+func TestReleaseFinalizerIfDeleting(t *testing.T) {
+	scheme := finalizerTestScheme(t)
+	ctx := context.Background()
+
+	t.Run("live object is left alone", func(t *testing.T) {
+		bucket := newTestBucket("photos")
+		bucket.Finalizers = []string{BucketFinalizer}
+		cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bucket).Build()
+
+		handled, err := releaseFinalizerIfDeleting(ctx, cli, bucket, BucketFinalizer)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if handled {
+			t.Error("an object that is not being deleted must fall through to normal reconciliation")
+		}
+		if len(bucket.Finalizers) != 1 {
+			t.Errorf("finalizer was removed from a live object: %v", bucket.Finalizers)
+		}
+	})
+
+	t.Run("deleting object has its finalizer dropped", func(t *testing.T) {
+		now := metav1.Now()
+		bucket := newTestBucket("photos")
+		bucket.Finalizers = []string{BucketFinalizer}
+		bucket.DeletionTimestamp = &now
+		cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bucket).Build()
+
+		handled, err := releaseFinalizerIfDeleting(ctx, cli, bucket, BucketFinalizer)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !handled {
+			t.Fatal("expected the deletion to be handled")
+		}
+
+		// No other holders, so the fake client reaps it immediately.
+		got := &seaweedv1.Bucket{}
+		key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
+		if err := cli.Get(ctx, key, got); err == nil {
+			t.Errorf("expected the object to be gone, still present with finalizers %v", got.Finalizers)
+		}
+	})
+
+	t.Run("finalizer already absent is still handled", func(t *testing.T) {
+		now := metav1.Now()
+		bucket := newTestBucket("photos")
+		// A second finalizer keeps the object alive for the assertion.
+		bucket.Finalizers = []string{"example.com/other"}
+		bucket.DeletionTimestamp = &now
+		cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bucket).Build()
+
+		handled, err := releaseFinalizerIfDeleting(ctx, cli, bucket, BucketFinalizer)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !handled {
+			t.Error("a deleting object must be reported as handled even when our finalizer is already gone")
+		}
+		if len(bucket.Finalizers) != 1 || bucket.Finalizers[0] != "example.com/other" {
+			t.Errorf("another controller's finalizer must survive, got %v", bucket.Finalizers)
+		}
+	})
+}
+
+// A Bucket whose cluster was deleted first must not be stuck forever. The
+// cluster lookup used to return RequeueAfter before the deletion path was
+// reached, so the finalizer was never removed and the object could not go away.
+func TestReconcile_ClusterGoneWhileDeleting_ReleasesBucket(t *testing.T) {
+	now := metav1.Now()
+	bucket := newTestBucket("photos")
+	bucket.Spec.ReclaimPolicy = seaweedv1.BucketReclaimDelete
+	bucket.Status.BucketName = "photos"
+	bucket.Finalizers = []string{BucketFinalizer}
+	bucket.DeletionTimestamp = &now
+
+	fa := newFakeAdmin()
+	// Deliberately no newTestSeaweed(): the cluster is already gone.
+	r, cli := testReconciler(t, fa, bucket)
+	key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	got := &seaweedv1.Bucket{}
+	if err := cli.Get(context.Background(), key, got); err == nil {
+		t.Errorf("bucket still present after its cluster was deleted, finalizers %v", got.Finalizers)
+	}
+
+	for _, c := range fa.calls {
+		if c != "" {
+			t.Errorf("no admin call should be attempted against a cluster that does not exist, got: %s", c)
+		}
+	}
+}

--- a/internal/controller/controller_finalizer_release_test.go
+++ b/internal/controller/controller_finalizer_release_test.go
@@ -1,9 +1,26 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package controller
 
 import (
 	"context"
 	"testing"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -65,8 +82,8 @@ func TestReleaseFinalizerIfDeleting(t *testing.T) {
 		// No other holders, so the fake client reaps it immediately.
 		got := &seaweedv1.Bucket{}
 		key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
-		if err := cli.Get(ctx, key, got); err == nil {
-			t.Errorf("expected the object to be gone, still present with finalizers %v", got.Finalizers)
+		if err := cli.Get(ctx, key, got); !apierrors.IsNotFound(err) {
+			t.Fatalf("expected the object to be gone, got %v with finalizers %v", err, got.Finalizers)
 		}
 	})
 
@@ -112,8 +129,8 @@ func TestReconcile_ClusterGoneWhileDeleting_ReleasesBucket(t *testing.T) {
 	}
 
 	got := &seaweedv1.Bucket{}
-	if err := cli.Get(context.Background(), key, got); err == nil {
-		t.Errorf("bucket still present after its cluster was deleted, finalizers %v", got.Finalizers)
+	if err := cli.Get(context.Background(), key, got); !apierrors.IsNotFound(err) {
+		t.Fatalf("bucket still present after its cluster was deleted: %v, finalizers %v", err, got.Finalizers)
 	}
 
 	for _, c := range fa.calls {
@@ -121,4 +138,81 @@ func TestReconcile_ClusterGoneWhileDeleting_ReleasesBucket(t *testing.T) {
 			t.Errorf("no admin call should be attempted against a cluster that does not exist, got: %s", c)
 		}
 	}
+}
+
+// The API permits an unset name override to be set once. If that first value
+// differs from the metadata-name fallback already recorded in status, normal
+// reconciliation rejects the rename. Deletion must nevertheless release the
+// finalizer when the target cluster no longer exists.
+func TestReconcile_ClusterGoneWhileDeleting_RenameMismatchDoesNotBlock(t *testing.T) {
+	now := metav1.Now()
+
+	t.Run("bucket", func(t *testing.T) {
+		bucket := newTestBucket("photos")
+		bucket.Spec.Name = "renamed-photos"
+		bucket.Status.BucketName = "photos"
+		bucket.Finalizers = []string{BucketFinalizer}
+		bucket.DeletionTimestamp = &now
+
+		r, cli := testReconciler(t, newFakeAdmin(), bucket)
+		key := types.NamespacedName{Namespace: bucket.Namespace, Name: bucket.Name}
+		if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key}); err != nil {
+			t.Fatalf("reconcile: %v", err)
+		}
+		if err := cli.Get(context.Background(), key, &seaweedv1.Bucket{}); !apierrors.IsNotFound(err) {
+			t.Fatalf("deleting Bucket remains after missing-cluster reconcile: %v", err)
+		}
+	})
+
+	t.Run("identity", func(t *testing.T) {
+		scheme := finalizerTestScheme(t)
+		identity := &seaweedv1.S3Identity{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "alice",
+				Namespace:         "media",
+				Finalizers:        []string{s3IdentityFinalizer},
+				DeletionTimestamp: &now,
+			},
+			Spec: seaweedv1.S3IdentitySpec{
+				SeaweedRef: seaweedv1.SeaweedReference{Name: "prod"},
+				Name:       "renamed-alice",
+			},
+			Status: seaweedv1.S3IdentityStatus{IdentityName: "alice"},
+		}
+		cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(identity).Build()
+		r := &S3IdentityReconciler{Client: cli}
+		key := types.NamespacedName{Namespace: identity.Namespace, Name: identity.Name}
+		if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key}); err != nil {
+			t.Fatalf("reconcile: %v", err)
+		}
+		if err := cli.Get(context.Background(), key, &seaweedv1.S3Identity{}); !apierrors.IsNotFound(err) {
+			t.Fatalf("deleting S3Identity remains after missing-cluster reconcile: %v", err)
+		}
+	})
+
+	t.Run("policy", func(t *testing.T) {
+		scheme := finalizerTestScheme(t)
+		policy := &seaweedv1.S3Policy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "read",
+				Namespace:         "media",
+				Finalizers:        []string{s3PolicyFinalizer},
+				DeletionTimestamp: &now,
+			},
+			Spec: seaweedv1.S3PolicySpec{
+				SeaweedRef: seaweedv1.SeaweedReference{Name: "prod"},
+				Name:       "renamed-read",
+			},
+			Status: seaweedv1.S3PolicyStatus{PolicyName: "read"},
+		}
+		cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(policy).Build()
+		r := &S3PolicyReconciler{Client: cli}
+		key := types.NamespacedName{Namespace: policy.Namespace, Name: policy.Name}
+		if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key}); err != nil {
+			t.Fatalf("reconcile: %v", err)
+		}
+		if err := cli.Get(context.Background(), key, &seaweedv1.S3Policy{}); !apierrors.IsNotFound(err) {
+			t.Fatalf("deleting S3Policy remains after missing-cluster reconcile: %v", err)
+		}
+	})
 }

--- a/internal/controller/controller_util.go
+++ b/internal/controller/controller_util.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // the following is adapted from tidb-operator/pkg/controller/generic_control.go
@@ -549,4 +550,24 @@ func mergePodTemplateMetadata(owner metav1.Object, existing, desired *corev1.Pod
 	owner.SetAnnotations(mergeStringMaps(owner.GetAnnotations(), map[string]string{
 		LastAppliedPodTemplateKeys: string(rendered),
 	}))
+}
+
+// releaseFinalizerIfDeleting drops finalizer from obj when obj is being deleted
+// and the Seaweed cluster it refers to no longer exists.
+//
+// A finalizer here exists to clean state out of that cluster. Once the cluster
+// is gone there is nothing left to clean, and requeuing on the missing
+// reference keeps the finalizer in place forever, so the object can never be
+// deleted. Removing a cluster before the resources that reference it is an
+// ordinary thing to do -- deleting a namespace does exactly that.
+//
+// Reports whether it handled obj; when true the caller returns immediately.
+func releaseFinalizerIfDeleting(ctx context.Context, c client.Client, obj client.Object, finalizer string) (bool, error) {
+	if obj.GetDeletionTimestamp().IsZero() {
+		return false, nil
+	}
+	if !controllerutil.RemoveFinalizer(obj, finalizer) {
+		return true, nil
+	}
+	return true, c.Update(ctx, obj)
 }

--- a/internal/controller/s3credentials_controller.go
+++ b/internal/controller/s3credentials_controller.go
@@ -118,6 +118,12 @@ func (r *S3CredentialsReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 	if !found {
+		// Still run the deletion path with no admin: the IAM calls are moot
+		// with the cluster gone, but the managed Secret is a local object and
+		// reclaimPolicy still decides what happens to it.
+		if !cred.DeletionTimestamp.IsZero() {
+			return r.handleDeletion(ctx, &cred, user, secretName, secretNamespace, nil)
+		}
 		return r.clusterNotFound(ctx, &cred)
 	}
 	setIAMCondition(&cred.Status.Conditions, cred.Generation, seaweedv1.S3ConditionClusterReachable, metav1.ConditionTrue, "Reachable", "")
@@ -282,7 +288,8 @@ func (r *S3CredentialsReconciler) handleDeletion(ctx context.Context, cred *seaw
 	cred.Status.Phase = seaweedv1.S3PhaseTerminating
 
 	if cred.Spec.ReclaimPolicy != seaweedv1.S3ReclaimRetain {
-		if cred.Status.AccessKey != "" {
+		// A nil admin means the cluster is gone, so the access key went with it.
+		if admin != nil && cred.Status.AccessKey != "" {
 			// Idempotent: a key already gone must not block finalizer removal.
 			if err := admin.DeleteAccessKey(ctx, user, cred.Status.AccessKey); err != nil && !errors.Is(err, ErrIAMNotFound) {
 				setIAMCondition(&cred.Status.Conditions, cred.Generation, seaweedv1.S3ConditionReady, metav1.ConditionFalse, "DeleteAccessKeyFailed", err.Error())

--- a/internal/controller/s3identity_controller.go
+++ b/internal/controller/s3identity_controller.go
@@ -103,7 +103,7 @@ func (r *S3IdentityReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// Refuse rename attempts once provisioned. This check follows missing-cluster
 	// deletion cleanup so an invalid rename cannot trap the finalizer after the
 	// cluster is gone.
-	if identity.Status.IdentityName != "" && identity.Status.IdentityName != name {
+	if identity.DeletionTimestamp.IsZero() && identity.Status.IdentityName != "" && identity.Status.IdentityName != name {
 		return r.fail(ctx, &identity, "IdentityRenameNotSupported",
 			fmt.Sprintf("identity name change from %q to %q is not supported; restore the original name or recreate the resource",
 				identity.Status.IdentityName, name))

--- a/internal/controller/s3identity_controller.go
+++ b/internal/controller/s3identity_controller.go
@@ -64,13 +64,6 @@ func (r *S3IdentityReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		name = identity.Name
 	}
 
-	// Refuse rename attempts once provisioned.
-	if identity.Status.IdentityName != "" && identity.Status.IdentityName != name {
-		return r.fail(ctx, &identity, "IdentityRenameNotSupported",
-			fmt.Sprintf("identity name change from %q to %q is not supported; restore the original name or recreate the resource",
-				identity.Status.IdentityName, name))
-	}
-
 	// Cross-namespace seaweedRef needs a grant; skip on deletion to not block cleanup.
 	if identity.DeletionTimestamp.IsZero() {
 		permitted, err := seaweedRefPermitted(ctx, r.Client, identity.Spec.SeaweedRef, kindS3Identity, identity.Namespace)
@@ -106,6 +99,15 @@ func (r *S3IdentityReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return r.clusterNotFound(ctx, &identity)
 	}
 	setIAMCondition(&identity.Status.Conditions, identity.Generation, seaweedv1.S3ConditionClusterReachable, metav1.ConditionTrue, "Reachable", "")
+
+	// Refuse rename attempts once provisioned. This check follows missing-cluster
+	// deletion cleanup so an invalid rename cannot trap the finalizer after the
+	// cluster is gone.
+	if identity.Status.IdentityName != "" && identity.Status.IdentityName != name {
+		return r.fail(ctx, &identity, "IdentityRenameNotSupported",
+			fmt.Sprintf("identity name change from %q to %q is not supported; restore the original name or recreate the resource",
+				identity.Status.IdentityName, name))
+	}
 
 	admin, err := r.getIAMAdmin(target, log)
 	if err != nil {

--- a/internal/controller/s3identity_controller.go
+++ b/internal/controller/s3identity_controller.go
@@ -100,6 +100,9 @@ func (r *S3IdentityReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 	if !found {
+		if handled, err := releaseFinalizerIfDeleting(ctx, r.Client, &identity, s3IdentityFinalizer); handled {
+			return ctrl.Result{}, err
+		}
 		return r.clusterNotFound(ctx, &identity)
 	}
 	setIAMCondition(&identity.Status.Conditions, identity.Generation, seaweedv1.S3ConditionClusterReachable, metav1.ConditionTrue, "Reachable", "")

--- a/internal/controller/s3oidcprovider_controller.go
+++ b/internal/controller/s3oidcprovider_controller.go
@@ -76,14 +76,8 @@ func (r *S3OIDCProviderReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, err
 	}
 	if !found {
-		// Cluster already gone: nothing to clean up from its IAM service, so let
-		// deletion proceed instead of requeuing forever on a missing reference.
-		if !provider.DeletionTimestamp.IsZero() {
-			controllerutil.RemoveFinalizer(&provider, s3OIDCProviderFinalizer)
-			if err := r.Update(ctx, &provider); err != nil {
-				return ctrl.Result{}, err
-			}
-			return ctrl.Result{}, nil
+		if handled, err := releaseFinalizerIfDeleting(ctx, r.Client, &provider, s3OIDCProviderFinalizer); handled {
+			return ctrl.Result{}, err
 		}
 		return r.clusterNotFound(ctx, &provider)
 	}

--- a/internal/controller/s3policy_controller.go
+++ b/internal/controller/s3policy_controller.go
@@ -63,12 +63,6 @@ func (r *S3PolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		name = policy.Name
 	}
 
-	if policy.Status.PolicyName != "" && policy.Status.PolicyName != name {
-		return r.fail(ctx, &policy, "PolicyRenameNotSupported",
-			fmt.Sprintf("policy name change from %q to %q is not supported; restore the original name or recreate the resource",
-				policy.Status.PolicyName, name))
-	}
-
 	// Cross-namespace seaweedRef needs a grant; skip on deletion to not block cleanup.
 	if policy.DeletionTimestamp.IsZero() {
 		permitted, err := seaweedRefPermitted(ctx, r.Client, policy.Spec.SeaweedRef, kindS3Policy, policy.Namespace)
@@ -104,6 +98,15 @@ func (r *S3PolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return r.clusterNotFound(ctx, &policy)
 	}
 	setIAMCondition(&policy.Status.Conditions, policy.Generation, seaweedv1.S3ConditionClusterReachable, metav1.ConditionTrue, "Reachable", "")
+
+	// Refuse rename attempts once provisioned. This check follows missing-cluster
+	// deletion cleanup so an invalid rename cannot trap the finalizer after the
+	// cluster is gone.
+	if policy.Status.PolicyName != "" && policy.Status.PolicyName != name {
+		return r.fail(ctx, &policy, "PolicyRenameNotSupported",
+			fmt.Sprintf("policy name change from %q to %q is not supported; restore the original name or recreate the resource",
+				policy.Status.PolicyName, name))
+	}
 
 	admin, err := r.getIAMAdmin(target, log)
 	if err != nil {

--- a/internal/controller/s3policy_controller.go
+++ b/internal/controller/s3policy_controller.go
@@ -102,7 +102,7 @@ func (r *S3PolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// Refuse rename attempts once provisioned. This check follows missing-cluster
 	// deletion cleanup so an invalid rename cannot trap the finalizer after the
 	// cluster is gone.
-	if policy.Status.PolicyName != "" && policy.Status.PolicyName != name {
+	if policy.DeletionTimestamp.IsZero() && policy.Status.PolicyName != "" && policy.Status.PolicyName != name {
 		return r.fail(ctx, &policy, "PolicyRenameNotSupported",
 			fmt.Sprintf("policy name change from %q to %q is not supported; restore the original name or recreate the resource",
 				policy.Status.PolicyName, name))

--- a/internal/controller/s3policy_controller.go
+++ b/internal/controller/s3policy_controller.go
@@ -98,6 +98,9 @@ func (r *S3PolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, err
 	}
 	if !found {
+		if handled, err := releaseFinalizerIfDeleting(ctx, r.Client, &policy, s3PolicyFinalizer); handled {
+			return ctrl.Result{}, err
+		}
 		return r.clusterNotFound(ctx, &policy)
 	}
 	setIAMCondition(&policy.Status.Conditions, policy.Generation, seaweedv1.S3ConditionClusterReachable, metav1.ConditionTrue, "Reachable", "")

--- a/internal/controller/s3policybinding_controller.go
+++ b/internal/controller/s3policybinding_controller.go
@@ -95,6 +95,9 @@ func (r *S3PolicyBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 	if !found {
+		if handled, err := releaseFinalizerIfDeleting(ctx, r.Client, &binding, s3PolicyBindingFinalizer); handled {
+			return ctrl.Result{}, err
+		}
 		return r.clusterNotFound(ctx, &binding)
 	}
 	setIAMCondition(&binding.Status.Conditions, binding.Generation, seaweedv1.S3ConditionClusterReachable, metav1.ConditionTrue, "Reachable", "")


### PR DESCRIPTION
Fixes #352.

The issue reports a `Bucket` that cannot be deleted once its Seaweed cluster is gone. That turns out to be one instance of a pattern shared by five controllers.

`bucket`, `s3identity`, `s3policy`, `s3policybinding` and `s3credentials` all resolve the cluster before reaching their deletion path. When the lookup misses they set a `ClusterRefNotFound` condition and return `RequeueAfter`, so the deletion path is never reached and the finalizer is never removed. The object stays until someone edits the finalizer out by hand, and a namespace containing one will not finish terminating.

Deleting a cluster before the resources that reference it is not an unusual thing to do — deleting a namespace does it by definition.

## The rule already exists here

Two controllers do it correctly. `s3oidcprovider`:

```go
// Cluster already gone: nothing to clean up from its IAM service, so let
// deletion proceed instead of requeuing forever on a missing reference.
```

and `bucketlifecyclepolicy`:

```go
// The cluster is gone, and the bucket with it; release rather than block.
```

This applies the same rule to the other five through one helper, `releaseFinalizerIfDeleting`, and moves `s3oidcprovider` onto it so the logic exists once rather than twice.

`seaweedcsidriver` handles deletion before any cluster lookup and is unaffected.

## s3credentials needs more than a finalizer drop

Its deletion path also manages a Kubernetes Secret, and that is local state which outlives the cluster:

- under `Delete` it removes the Secret
- under `Retain` it deliberately **orphans** it, because an operator-created Secret carries a controller owner reference and would otherwise be garbage collected along with the access key that was explicitly being kept

Dropping the finalizer directly would reintroduce exactly the bug that comment guards against — `reclaimPolicy: Retain` would lose the Secret. So it keeps running `handleDeletion`, with a `nil` admin to mean "the cluster is gone"; the IAM call is skipped and the Secret half still happens.

## Testing

`TestReleaseFinalizerIfDeleting` covers the three cases: a live object falls through untouched, a deleting object loses the finalizer, and a deleting object whose finalizer is already absent is still reported as handled without disturbing another controller's finalizer.

`TestReconcile_ClusterGoneWhileDeleting_ReleasesBucket` drives the real `Reconcile` with no Seaweed object present and asserts the Bucket is reaped and no admin call is attempted. Verified it fails without the fix.

`go build ./...`, `go vet ./...` and `go test ./internal/...` pass.

One gap worth stating: the IAM controllers have no unit-test files at all, so `s3identity`, `s3policy`, `s3policybinding` and the `s3credentials` Secret behaviour are covered by inspection and by the shared helper's tests rather than directly. Happy to add a fake-client harness for them if you would like it in this PR rather than a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Cluster references for Buckets, S3 credentials, identities, OIDC providers, policies, and policy bindings can no longer be changed after creation.
* **Bug Fixes**
  * Resources can now finish deletion when their referenced Seaweed cluster is unavailable.
  * Deletion is no longer blocked by rename mismatches or missing clusters.
  * Managed Secret cleanup continues according to the configured reclaim policy when cluster-related credentials are unavailable.
* **Tests**
  * Added coverage for deletion handling, finalizer cleanup, and immutable cluster references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs-operator/pull/376" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->