### PR TITLE
Guard S3 credential Secrets by owner

### DIFF
--- a/api/v1/s3credentials_types.go
+++ b/api/v1/s3credentials_types.go
@@ -37,18 +37,13 @@ type S3IdentityRef struct {
 // secret key. The Secret defaults to the same namespace as the S3Credentials
 // resource; set Namespace to reference a Secret in another namespace.
 //
-// On first reconcile the controller reads the Secret: if both keys are
-// already present it adopts them (registering the access key on the IAM user
-// if needed); otherwise it generates a fresh key pair and writes it back.
-// A Secret created by the controller is labelled as operator-managed and is
-// removed together with the IAM access key when the CR is deleted with
-// reclaimPolicy: Delete. A pre-existing (user-managed) Secret is never
-// deleted by the controller.
+// In the same namespace, the controller creates and owns the Secret. It
+// refuses to adopt an existing Secret that it does not control.
 //
 // A cross-namespace reference is denied unless a ResourceReferenceGrant in the
 // Secret's namespace permits it (the CR stays Pending until then). A
-// cross-namespace Secret must already exist; the controller never creates
-// Secrets in foreign namespaces.
+// cross-namespace Secret must already exist and supplies the key pair; the
+// controller never creates Secrets in foreign namespaces.
 type S3SecretRef struct {
 	// Name of the Secret. Defaults to .metadata.name of the S3Credentials.
 	// +optional

--- a/internal/controller/iam_controller_test.go
+++ b/internal/controller/iam_controller_test.go
@@ -31,6 +31,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -432,6 +433,95 @@ func TestS3Credentials_RejectsUnownedExistingSecret(t *testing.T) {
 	}
 }
 
+// A Secret that appears between the lookup and the create belongs to someone
+// else. The reconcile must back off into the ownership conflict without having
+// minted an IAM key that status never recorded and deletion could never revoke.
+func TestS3Credentials_SecretRacesIntoExistence_LeaksNoKey(t *testing.T) {
+	scheme := iamTestScheme(t)
+	cred := &seaweedv1.S3Credentials{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "alice-creds",
+			Namespace:  "media",
+			UID:        "alice-uid",
+			Finalizers: []string{s3CredentialsFinalizer},
+		},
+		Spec: seaweedv1.S3CredentialsSpec{
+			SeaweedRef:  iamSeaweedRef(),
+			IdentityRef: seaweedv1.S3IdentityRef{Name: "alice"},
+			SecretRef:   seaweedv1.S3SecretRef{Name: "alice-secret"},
+		},
+	}
+	rival := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "alice-secret", Namespace: "media"},
+		Data: map[string][]byte{
+			defaultAccessKeyField: []byte("AKIARIVAL"),
+			defaultSecretKeyField: []byte("rivalsecret"),
+		},
+	}
+	planted := false
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(append(defaultTestRefGrants(), newTestSeaweed(), cred)...).
+		WithStatusSubresource(&seaweedv1.S3Credentials{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, isSecret := obj.(*corev1.Secret); isSecret && !planted {
+					planted = true
+					if err := c.Create(ctx, rival.DeepCopy()); err != nil {
+						return err
+					}
+				}
+				return c.Create(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	fa := newFakeIAMAdmin()
+	fa.seedUser("alice")
+	r := &S3CredentialsReconciler{Client: cli, Log: logf.FromContext(context.Background()), Scheme: scheme}
+	r.AdminFactory = fakeIAMFactory(fa)
+
+	key := types.NamespacedName{Namespace: "media", Name: "alice-creds"}
+	if res := reconcileOnce(t, r, key); !res.Requeue {
+		t.Fatalf("expected immediate requeue after losing the create race, got %+v", res)
+	}
+	if !planted {
+		t.Fatal("setup: rival Secret was never planted")
+	}
+	if keys := fa.userKeys("alice"); len(keys) != 0 {
+		t.Fatalf("lost create race minted IAM keys: %v", keys)
+	}
+
+	if res := reconcileOnce(t, r, key); res.RequeueAfter == 0 {
+		t.Fatal("expected ownership conflict to requeue")
+	}
+	if keys := fa.userKeys("alice"); len(keys) != 0 {
+		t.Fatalf("ownership conflict created IAM keys: %v", keys)
+	}
+
+	var secret corev1.Secret
+	if err := cli.Get(context.Background(), client.ObjectKeyFromObject(rival), &secret); err != nil {
+		t.Fatalf("get secret: %v", err)
+	}
+	if got := string(secret.Data[defaultAccessKeyField]); got != "AKIARIVAL" {
+		t.Errorf("rival secret access key = %q, want unchanged", got)
+	}
+	if metav1.IsControlledBy(&secret, cred) {
+		t.Errorf("rival secret was adopted: %v", secret.OwnerReferences)
+	}
+
+	var got seaweedv1.S3Credentials
+	if err := cli.Get(context.Background(), key, &got); err != nil {
+		t.Fatalf("get credentials: %v", err)
+	}
+	if got.Status.Phase != seaweedv1.S3PhaseFailed || got.Status.AccessKey != "" {
+		t.Errorf("status = %+v, want Failed with no access key", got.Status)
+	}
+	ready := meta.FindStatusCondition(got.Status.Conditions, seaweedv1.S3ConditionReady)
+	if ready == nil || ready.Reason != "SecretOwnershipConflict" {
+		t.Errorf("Ready condition = %+v", ready)
+	}
+}
+
 // Rotating only the secretKey in the referenced Secret — the access key id
 // stays put, as External Secrets does when it refreshes one field — must be
 // applied to the identity, so the pair the Secret holds is the pair that
@@ -746,52 +836,72 @@ func TestS3Credentials_Delete_RemovesKeyAndManagedSecret(t *testing.T) {
 	}
 }
 
+// Retain must leave both the access key and the Secret behind. The controller
+// owner reference is what would let garbage collection take the Secret, so it
+// has to go even when the managed annotation was stripped from an otherwise
+// controlled Secret.
 func TestS3Credentials_Delete_RetainKeepsKeyAndOrphansSecret(t *testing.T) {
-	scheme := iamTestScheme(t)
-	cred := &seaweedv1.S3Credentials{
-		ObjectMeta: metav1.ObjectMeta{Name: "alice-creds", Namespace: "media"},
-		Spec: seaweedv1.S3CredentialsSpec{
-			SeaweedRef:    iamSeaweedRef(),
-			IdentityRef:   seaweedv1.S3IdentityRef{Name: "alice"},
-			SecretRef:     seaweedv1.S3SecretRef{Name: "alice-secret"},
-			ReclaimPolicy: seaweedv1.S3ReclaimRetain,
-		},
-	}
-	cli := iamTestClient(t, scheme, newTestSeaweed(), cred)
-	fa := newFakeIAMAdmin()
-	fa.seedUser("alice")
-	r := &S3CredentialsReconciler{Client: cli, Log: logf.FromContext(context.Background()), Scheme: scheme}
-	r.AdminFactory = fakeIAMFactory(fa)
+	for _, tc := range []struct {
+		name            string
+		stripAnnotation bool
+	}{
+		{name: "managed"},
+		{name: "annotation stripped", stripAnnotation: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := iamTestScheme(t)
+			cred := &seaweedv1.S3Credentials{
+				ObjectMeta: metav1.ObjectMeta{Name: "alice-creds", Namespace: "media"},
+				Spec: seaweedv1.S3CredentialsSpec{
+					SeaweedRef:    iamSeaweedRef(),
+					IdentityRef:   seaweedv1.S3IdentityRef{Name: "alice"},
+					SecretRef:     seaweedv1.S3SecretRef{Name: "alice-secret"},
+					ReclaimPolicy: seaweedv1.S3ReclaimRetain,
+				},
+			}
+			cli := iamTestClient(t, scheme, newTestSeaweed(), cred)
+			fa := newFakeIAMAdmin()
+			fa.seedUser("alice")
+			r := &S3CredentialsReconciler{Client: cli, Log: logf.FromContext(context.Background()), Scheme: scheme}
+			r.AdminFactory = fakeIAMFactory(fa)
 
-	key := types.NamespacedName{Namespace: "media", Name: "alice-creds"}
-	reconcileStable(t, r, key, 5)
+			key := types.NamespacedName{Namespace: "media", Name: "alice-creds"}
+			reconcileStable(t, r, key, 5)
 
-	secretKey := types.NamespacedName{Namespace: "media", Name: "alice-secret"}
-	var secret corev1.Secret
-	if err := cli.Get(context.Background(), secretKey, &secret); err != nil {
-		t.Fatalf("get secret: %v", err)
-	}
-	if len(secret.OwnerReferences) == 0 {
-		t.Fatal("setup: operator-created secret should have an owner reference")
-	}
+			secretKey := types.NamespacedName{Namespace: "media", Name: "alice-secret"}
+			var secret corev1.Secret
+			if err := cli.Get(context.Background(), secretKey, &secret); err != nil {
+				t.Fatalf("get secret: %v", err)
+			}
+			if len(secret.OwnerReferences) == 0 {
+				t.Fatal("setup: operator-created secret should have an owner reference")
+			}
+			if tc.stripAnnotation {
+				delete(secret.Annotations, s3CredentialsManagedAnnotation)
+				if err := cli.Update(context.Background(), &secret); err != nil {
+					t.Fatalf("strip annotation: %v", err)
+				}
+			}
 
-	var live seaweedv1.S3Credentials
-	if err := cli.Get(context.Background(), key, &live); err != nil {
-		t.Fatalf("get: %v", err)
-	}
-	if err := cli.Delete(context.Background(), &live); err != nil {
-		t.Fatalf("delete: %v", err)
-	}
-	reconcileOnce(t, r, key)
+			var live seaweedv1.S3Credentials
+			if err := cli.Get(context.Background(), key, &live); err != nil {
+				t.Fatalf("get: %v", err)
+			}
+			if err := cli.Delete(context.Background(), &live); err != nil {
+				t.Fatalf("delete: %v", err)
+			}
+			reconcileOnce(t, r, key)
 
-	if k := fa.userKeys("alice"); len(k) != 1 {
-		t.Errorf("Retain should keep the access key, got %v", k)
-	}
-	if err := cli.Get(context.Background(), secretKey, &secret); err != nil {
-		t.Fatalf("secret should survive Retain: %v", err)
-	}
-	if len(secret.OwnerReferences) != 0 {
-		t.Errorf("Retain should orphan the secret (strip owner refs), got %v", secret.OwnerReferences)
+			if k := fa.userKeys("alice"); len(k) != 1 {
+				t.Errorf("Retain should keep the access key, got %v", k)
+			}
+			if err := cli.Get(context.Background(), secretKey, &secret); err != nil {
+				t.Fatalf("secret should survive Retain: %v", err)
+			}
+			if len(secret.OwnerReferences) != 0 {
+				t.Errorf("Retain should orphan the secret (strip owner refs), got %v", secret.OwnerReferences)
+			}
+		})
 	}
 }
 

--- a/internal/controller/iam_controller_test.go
+++ b/internal/controller/iam_controller_test.go
@@ -795,6 +795,69 @@ func TestS3Credentials_Delete_RetainKeepsKeyAndOrphansSecret(t *testing.T) {
 	}
 }
 
+func TestS3Credentials_Delete_DoesNotTouchAnotherCredentialsSecret(t *testing.T) {
+	for _, policy := range []seaweedv1.S3ReclaimPolicy{seaweedv1.S3ReclaimDelete, seaweedv1.S3ReclaimRetain} {
+		t.Run(string(policy), func(t *testing.T) {
+			scheme := iamTestScheme(t)
+			cred := &seaweedv1.S3Credentials{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "bob-creds",
+					Namespace:  "media",
+					UID:        "bob-uid",
+					Finalizers: []string{s3CredentialsFinalizer},
+				},
+				Spec: seaweedv1.S3CredentialsSpec{
+					SeaweedRef:    iamSeaweedRef(),
+					IdentityRef:   seaweedv1.S3IdentityRef{Name: "bob"},
+					SecretRef:     seaweedv1.S3SecretRef{Name: "shared-secret"},
+					ReclaimPolicy: policy,
+				},
+			}
+			controller := true
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "shared-secret",
+					Namespace:   "media",
+					UID:         "secret-uid",
+					Annotations: map[string]string{s3CredentialsManagedAnnotation: "true"},
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion: seaweedv1.GroupVersion.String(),
+						Kind:       "S3Credentials",
+						Name:       "alice-creds",
+						UID:        "alice-uid",
+						Controller: &controller,
+					}},
+				},
+			}
+			cli := iamTestClient(t, scheme, newTestSeaweed(), secret, cred)
+			fa := newFakeIAMAdmin()
+			r := &S3CredentialsReconciler{Client: cli, Log: logf.FromContext(context.Background()), Scheme: scheme}
+			r.AdminFactory = fakeIAMFactory(fa)
+
+			credKey := client.ObjectKeyFromObject(cred)
+			if err := cli.Delete(context.Background(), cred); err != nil {
+				t.Fatalf("delete credentials: %v", err)
+			}
+			reconcileOnce(t, r, credKey)
+
+			var got corev1.Secret
+			if err := cli.Get(context.Background(), client.ObjectKeyFromObject(secret), &got); err != nil {
+				t.Fatalf("another credential's Secret was removed: %v", err)
+			}
+			if !metav1.IsControlledBy(&got, &seaweedv1.S3Credentials{ObjectMeta: metav1.ObjectMeta{UID: "alice-uid"}}) {
+				t.Fatalf("another credential's owner reference changed: %v", got.OwnerReferences)
+			}
+
+			var after seaweedv1.S3Credentials
+			if err := cli.Get(context.Background(), credKey, &after); err != nil && !apierrors.IsNotFound(err) {
+				t.Fatalf("get deleted credentials: %v", err)
+			} else if err == nil && len(after.Finalizers) != 0 {
+				t.Fatalf("finalizer was not cleared: %v", after.Finalizers)
+			}
+		})
+	}
+}
+
 // --- S3PolicyBinding ---
 
 func TestS3PolicyBinding_AttachesAndDetaches(t *testing.T) {

--- a/internal/controller/iam_controller_test.go
+++ b/internal/controller/iam_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/grpc"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -344,44 +345,90 @@ func TestS3Credentials_GeneratesAndStores(t *testing.T) {
 	}
 }
 
-func TestS3Credentials_AdoptsExistingSecret(t *testing.T) {
-	scheme := iamTestScheme(t)
-	existing := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: "alice-secret", Namespace: "media"},
-		Data: map[string][]byte{
-			defaultAccessKeyField: []byte("AKIAADOPTED"),
-			defaultSecretKeyField: []byte("supersecret"),
-		},
-	}
-	cred := &seaweedv1.S3Credentials{
-		ObjectMeta: metav1.ObjectMeta{Name: "alice-creds", Namespace: "media"},
-		Spec: seaweedv1.S3CredentialsSpec{
-			SeaweedRef:  iamSeaweedRef(),
-			IdentityRef: seaweedv1.S3IdentityRef{Name: "alice"},
-			SecretRef:   seaweedv1.S3SecretRef{Name: "alice-secret"},
-		},
-	}
-	cli := iamTestClient(t, scheme, newTestSeaweed(), existing, cred)
-	fa := newFakeIAMAdmin()
-	fa.seedUser("alice")
-	r := &S3CredentialsReconciler{Client: cli, Log: logf.FromContext(context.Background()), Scheme: scheme}
-	r.AdminFactory = fakeIAMFactory(fa)
+func TestS3Credentials_RejectsUnownedExistingSecret(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		managed  bool
+		complete bool
+		owner    string
+		ownerUID types.UID
+	}{
+		{name: "unmanaged", complete: true},
+		{name: "managed by another credential", managed: true, owner: "other-creds", ownerUID: "other-uid"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := iamTestScheme(t)
+			cred := &seaweedv1.S3Credentials{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "alice-creds",
+					Namespace:  "media",
+					UID:        "alice-uid",
+					Finalizers: []string{s3CredentialsFinalizer},
+				},
+				Spec: seaweedv1.S3CredentialsSpec{
+					SeaweedRef:  iamSeaweedRef(),
+					IdentityRef: seaweedv1.S3IdentityRef{Name: "alice"},
+					SecretRef:   seaweedv1.S3SecretRef{Name: "alice-secret"},
+				},
+			}
+			existing := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "alice-secret", Namespace: "media"},
+				Data: map[string][]byte{
+					defaultAccessKeyField: []byte("AKIAEXISTING"),
+				},
+			}
+			if tc.complete {
+				existing.Data[defaultSecretKeyField] = []byte("supersecret")
+			}
+			if tc.managed {
+				controller := true
+				existing.Annotations = map[string]string{s3CredentialsManagedAnnotation: "true"}
+				existing.OwnerReferences = []metav1.OwnerReference{{
+					APIVersion: seaweedv1.GroupVersion.String(),
+					Kind:       "S3Credentials",
+					Name:       tc.owner,
+					UID:        tc.ownerUID,
+					Controller: &controller,
+				}}
+			}
 
-	key := types.NamespacedName{Namespace: "media", Name: "alice-creds"}
-	reconcileStable(t, r, key, 5)
+			cli := iamTestClient(t, scheme, newTestSeaweed(), existing, cred)
+			fa := newFakeIAMAdmin()
+			fa.seedUser("alice")
+			r := &S3CredentialsReconciler{Client: cli, Log: logf.FromContext(context.Background()), Scheme: scheme}
+			r.AdminFactory = fakeIAMFactory(fa)
 
-	if keys := fa.userKeys("alice"); len(keys) != 1 || keys[0] != "AKIAADOPTED" {
-		t.Fatalf("expected adopted key AKIAADOPTED, got %v", keys)
-	}
-	if sk := fa.secretKeyFor("alice", "AKIAADOPTED"); sk != "supersecret" {
-		t.Errorf("adopted secret key mismatch: %q", sk)
-	}
-	var secret corev1.Secret
-	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "media", Name: "alice-secret"}, &secret); err != nil {
-		t.Fatalf("get secret: %v", err)
-	}
-	if secret.Annotations[s3CredentialsManagedAnnotation] == "true" {
-		t.Error("pre-existing secret must not be marked managed")
+			key := types.NamespacedName{Namespace: "media", Name: "alice-creds"}
+			if res := reconcileOnce(t, r, key); res.RequeueAfter == 0 {
+				t.Fatal("expected ownership conflict to requeue")
+			}
+			if keys := fa.userKeys("alice"); len(keys) != 0 {
+				t.Fatalf("ownership conflict created IAM keys: %v", keys)
+			}
+
+			var secret corev1.Secret
+			if err := cli.Get(context.Background(), client.ObjectKeyFromObject(existing), &secret); err != nil {
+				t.Fatalf("get secret: %v", err)
+			}
+			if got := string(secret.Data[defaultAccessKeyField]); got != "AKIAEXISTING" {
+				t.Errorf("secret access key = %q, want unchanged", got)
+			}
+			if _, found := secret.Data[defaultSecretKeyField]; found != tc.complete {
+				t.Errorf("secret key presence = %v, want %v", found, tc.complete)
+			}
+
+			var got seaweedv1.S3Credentials
+			if err := cli.Get(context.Background(), key, &got); err != nil {
+				t.Fatalf("get credentials: %v", err)
+			}
+			if got.Status.Phase != seaweedv1.S3PhaseFailed {
+				t.Errorf("phase = %q, want Failed", got.Status.Phase)
+			}
+			ready := meta.FindStatusCondition(got.Status.Conditions, seaweedv1.S3ConditionReady)
+			if ready == nil || ready.Reason != "SecretOwnershipConflict" {
+				t.Errorf("Ready condition = %+v", ready)
+			}
+		})
 	}
 }
 
@@ -391,19 +438,31 @@ func TestS3Credentials_AdoptsExistingSecret(t *testing.T) {
 // authenticates and the superseded secret stops working.
 func TestS3Credentials_AppliesRotatedSecretKey(t *testing.T) {
 	scheme := iamTestScheme(t)
-	existing := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: "alice-secret", Namespace: "media"},
-		Data: map[string][]byte{
-			defaultAccessKeyField: []byte("AKIAROTATE"),
-			defaultSecretKeyField: []byte("oldsecret"),
-		},
-	}
 	cred := &seaweedv1.S3Credentials{
-		ObjectMeta: metav1.ObjectMeta{Name: "alice-creds", Namespace: "media"},
+		ObjectMeta: metav1.ObjectMeta{Name: "alice-creds", Namespace: "media", UID: "alice-uid"},
 		Spec: seaweedv1.S3CredentialsSpec{
 			SeaweedRef:  iamSeaweedRef(),
 			IdentityRef: seaweedv1.S3IdentityRef{Name: "alice"},
 			SecretRef:   seaweedv1.S3SecretRef{Name: "alice-secret"},
+		},
+	}
+	controller := true
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "alice-secret",
+			Namespace:   "media",
+			Annotations: map[string]string{s3CredentialsManagedAnnotation: "true"},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: seaweedv1.GroupVersion.String(),
+				Kind:       "S3Credentials",
+				Name:       cred.Name,
+				UID:        cred.UID,
+				Controller: &controller,
+			}},
+		},
+		Data: map[string][]byte{
+			defaultAccessKeyField: []byte("AKIAROTATE"),
+			defaultSecretKeyField: []byte("oldsecret"),
 		},
 	}
 	cli := iamTestClient(t, scheme, newTestSeaweed(), existing, cred)

--- a/internal/controller/iam_controller_test.go
+++ b/internal/controller/iam_controller_test.go
@@ -743,6 +743,81 @@ func TestS3Credentials_CrossNamespaceSecret_MissingEntersPending(t *testing.T) {
 	}
 }
 
+// A foreign Secret is consumed, never repaired: when it lacks either field the
+// credential waits for whoever owns it to fill it in rather than overwriting
+// the fields it does hold with a generated pair.
+func TestS3Credentials_CrossNamespaceSecret_IncompleteStaysUntouched(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		data map[string][]byte
+	}{
+		{name: "missing secret key", data: map[string][]byte{defaultAccessKeyField: []byte("AKIAXNAMESPACE")}},
+		{name: "missing access key", data: map[string][]byte{defaultSecretKeyField: []byte("xnssecretkey")}},
+		{name: "empty", data: nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := iamTestScheme(t)
+			existing := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "shared-secret", Namespace: "secrets"},
+				Data:       tc.data,
+			}
+			cred := &seaweedv1.S3Credentials{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "alice-creds",
+					Namespace:  "media",
+					Finalizers: []string{s3CredentialsFinalizer},
+				},
+				Spec: seaweedv1.S3CredentialsSpec{
+					SeaweedRef:  iamSeaweedRef(),
+					IdentityRef: seaweedv1.S3IdentityRef{Name: "alice"},
+					SecretRef:   seaweedv1.S3SecretRef{Name: "shared-secret", Namespace: "secrets"},
+				},
+			}
+			cli := iamTestClient(t, scheme, newTestSeaweed(), existing, cred)
+			fa := newFakeIAMAdmin()
+			fa.seedUser("alice")
+			r := &S3CredentialsReconciler{Client: cli, Log: logf.FromContext(context.Background()), Scheme: scheme}
+			r.AdminFactory = fakeIAMFactory(fa)
+
+			key := types.NamespacedName{Namespace: "media", Name: "alice-creds"}
+			if res := reconcileOnce(t, r, key); res.RequeueAfter == 0 {
+				t.Fatal("expected requeue while waiting for the foreign secret to be completed")
+			}
+			if keys := fa.userKeys("alice"); len(keys) != 0 {
+				t.Fatalf("incomplete foreign secret minted IAM keys: %v", keys)
+			}
+
+			var secret corev1.Secret
+			if err := cli.Get(context.Background(), client.ObjectKeyFromObject(existing), &secret); err != nil {
+				t.Fatalf("get secret: %v", err)
+			}
+			if len(secret.Data) != len(tc.data) {
+				t.Fatalf("foreign secret data was modified: %v", secret.Data)
+			}
+			for k, v := range tc.data {
+				if string(secret.Data[k]) != string(v) {
+					t.Errorf("foreign secret %s = %q, want %q", k, secret.Data[k], v)
+				}
+			}
+			if secret.Annotations[s3CredentialsManagedAnnotation] == "true" || len(secret.OwnerReferences) != 0 {
+				t.Errorf("foreign secret was claimed: annotations=%v owners=%v", secret.Annotations, secret.OwnerReferences)
+			}
+
+			var got seaweedv1.S3Credentials
+			if err := cli.Get(context.Background(), key, &got); err != nil {
+				t.Fatalf("get credentials: %v", err)
+			}
+			if got.Status.Phase != seaweedv1.S3PhasePending || got.Status.AccessKey != "" {
+				t.Errorf("status = %+v, want Pending with no access key", got.Status)
+			}
+			ready := meta.FindStatusCondition(got.Status.Conditions, seaweedv1.S3ConditionReady)
+			if ready == nil || ready.Reason != "SecretIncomplete" {
+				t.Errorf("Ready condition = %+v", ready)
+			}
+		})
+	}
+}
+
 func TestS3Credentials_CrossNamespaceSecret_DeleteDoesNotTouchForeignSecret(t *testing.T) {
 	scheme := iamTestScheme(t)
 	// A secret in a foreign namespace that happens to carry the managed annotation

--- a/internal/controller/iam_name_claim_test.go
+++ b/internal/controller/iam_name_claim_test.go
@@ -373,6 +373,7 @@ func TestS3Credentials_PinnedIdentitySurvivesShadowingResource(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "ext-creds",
 			Namespace:  "media",
+			UID:        "ext-creds-uid",
 			Finalizers: []string{s3CredentialsFinalizer},
 		},
 		Spec: seaweedv1.S3CredentialsSpec{
@@ -381,9 +382,21 @@ func TestS3Credentials_PinnedIdentitySurvivesShadowingResource(t *testing.T) {
 		},
 		Status: seaweedv1.S3CredentialsStatus{AccessKey: "AKIA123", IdentityName: "external"},
 	}
+	controller := true
 	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: "ext-creds", Namespace: "media"},
-		Data:       map[string][]byte{"accessKey": []byte("AKIA123"), "secretKey": []byte("sk")},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "ext-creds",
+			Namespace:   "media",
+			Annotations: map[string]string{s3CredentialsManagedAnnotation: "true"},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: seaweedv1.GroupVersion.String(),
+				Kind:       "S3Credentials",
+				Name:       cred.Name,
+				UID:        cred.UID,
+				Controller: &controller,
+			}},
+		},
+		Data: map[string][]byte{"accessKey": []byte("AKIA123"), "secretKey": []byte("sk")},
 	}
 	cli := iamTestClient(t, scheme, newTestSeaweed(), shadow, cred, secret)
 	fa := newFakeIAMAdmin()

--- a/internal/controller/s3credentials_controller.go
+++ b/internal/controller/s3credentials_controller.go
@@ -298,17 +298,13 @@ func (r *S3CredentialsReconciler) handleDeletion(ctx context.Context, cred *seaw
 		// Never touch a Secret in a foreign namespace. The controller did not
 		// create it there and another S3Credentials may legitimately own it.
 		if secretNamespace == cred.Namespace {
-			if err := r.deleteManagedSecret(ctx, secretNamespace, secretName); err != nil {
+			if err := r.deleteManagedSecret(ctx, cred, secretNamespace, secretName); err != nil {
 				return ctrl.Result{}, err
 			}
 		}
 	} else {
-		// Retain: an operator-created Secret carries a controller owner
-		// reference, so removing the finalizer would let garbage collection
-		// delete it along with the access key we are deliberately keeping.
-		// Orphan it first so both the key and the Secret survive.
 		if secretNamespace == cred.Namespace {
-			if err := r.orphanManagedSecret(ctx, secretNamespace, secretName); err != nil {
+			if err := r.orphanManagedSecret(ctx, cred, secretNamespace, secretName); err != nil {
 				return ctrl.Result{}, err
 			}
 		}
@@ -321,35 +317,34 @@ func (r *S3CredentialsReconciler) handleDeletion(ctx context.Context, cred *seaw
 	return ctrl.Result{}, nil
 }
 
-// deleteManagedSecret removes the Secret only if the operator created it
-// (carries the managed annotation). A user-managed Secret is left untouched.
-func (r *S3CredentialsReconciler) deleteManagedSecret(ctx context.Context, namespace, name string) error {
+// deleteManagedSecret removes a Secret managed by cred.
+func (r *S3CredentialsReconciler) deleteManagedSecret(ctx context.Context, cred *seaweedv1.S3Credentials, namespace, name string) error {
 	secret, found, err := r.getSecret(ctx, namespace, name)
 	if err != nil || !found {
 		return err
 	}
-	if secret.Annotations[s3CredentialsManagedAnnotation] != "true" {
+	if secret.Annotations[s3CredentialsManagedAnnotation] != "true" || !metav1.IsControlledBy(secret, cred) {
 		return nil
 	}
-	if err := r.Delete(ctx, secret); err != nil && !apierrors.IsNotFound(err) {
+	uid := secret.UID
+	if err := r.Delete(ctx, secret, client.Preconditions{UID: &uid}); err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
 	return nil
 }
 
-// orphanManagedSecret strips the controller owner reference from an
-// operator-created Secret so it is not garbage-collected when the
-// S3Credentials CR is deleted under reclaimPolicy: Retain. A user-managed
-// Secret (no managed annotation) is left untouched.
-func (r *S3CredentialsReconciler) orphanManagedSecret(ctx context.Context, namespace, name string) error {
+// orphanManagedSecret removes cred's controller reference for Retain.
+func (r *S3CredentialsReconciler) orphanManagedSecret(ctx context.Context, cred *seaweedv1.S3Credentials, namespace, name string) error {
 	secret, found, err := r.getSecret(ctx, namespace, name)
 	if err != nil || !found {
 		return err
 	}
-	if secret.Annotations[s3CredentialsManagedAnnotation] != "true" || len(secret.OwnerReferences) == 0 {
+	if secret.Annotations[s3CredentialsManagedAnnotation] != "true" || !metav1.IsControlledBy(secret, cred) {
 		return nil
 	}
-	secret.OwnerReferences = nil
+	if err := controllerutil.RemoveControllerReference(cred, secret, r.Scheme); err != nil {
+		return err
+	}
 	return r.Update(ctx, secret)
 }
 

--- a/internal/controller/s3credentials_controller.go
+++ b/internal/controller/s3credentials_controller.go
@@ -195,6 +195,12 @@ func (r *S3CredentialsReconciler) reconcileKey(ctx context.Context, cred *seawee
 		existingSK = string(secret.Data[skField])
 	}
 
+	// A foreign Secret is read-only: it supplies the pair or nothing happens.
+	if crossNamespace && (existingAK == "" || existingSK == "") {
+		return r.pending(ctx, cred, "SecretIncomplete",
+			fmt.Sprintf("cross-namespace Secret %s/%s must hold both %q and %q", secretNamespace, secretName, akField, skField))
+	}
+
 	desiredAK, desiredSK := existingAK, existingSK
 	if desiredAK == "" || desiredSK == "" {
 		// Generate a fresh key pair to provision and store.

--- a/internal/controller/s3credentials_controller.go
+++ b/internal/controller/s3credentials_controller.go
@@ -204,6 +204,17 @@ func (r *S3CredentialsReconciler) reconcileKey(ctx context.Context, cred *seawee
 		}
 	}
 
+	// Persist the pair before registering it: the Secret is the record the
+	// next pass reconciles the identity against, so a key is never minted
+	// without one. A Secret that appeared since the lookup is not ours;
+	// requeue so the ownership check above reports it.
+	if err := r.writeSecret(ctx, cred, secret, secretFound, secretName, secretNamespace, akField, skField, desiredAK, desiredSK); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
 	// Reconcile the identity against the pair the Secret holds: register the
 	// key when absent, rewrite its secret key when only that field rotated —
 	// the access key id stays, so there is no superseded pair to revoke below.
@@ -216,11 +227,6 @@ func (r *S3CredentialsReconciler) reconcileKey(ctx context.Context, cred *seawee
 		if err := admin.UpdateAccessKey(ctx, user, desiredAK, desiredSK); err != nil {
 			return r.fail(ctx, cred, "UpdateAccessKeyFailed", err.Error())
 		}
-	}
-
-	// Mirror the key pair into the Secret.
-	if err := r.writeSecret(ctx, cred, secret, secretFound, secretName, secretNamespace, akField, skField, desiredAK, desiredSK); err != nil {
-		return ctrl.Result{}, err
 	}
 
 	// Remove a previously generated key we just replaced.
@@ -333,13 +339,15 @@ func (r *S3CredentialsReconciler) deleteManagedSecret(ctx context.Context, cred 
 	return nil
 }
 
-// orphanManagedSecret removes cred's controller reference for Retain.
+// orphanManagedSecret removes cred's controller reference for Retain. The
+// owner reference alone is what lets garbage collection remove the Secret,
+// so it is stripped whenever cred controls the Secret, annotated or not.
 func (r *S3CredentialsReconciler) orphanManagedSecret(ctx context.Context, cred *seaweedv1.S3Credentials, namespace, name string) error {
 	secret, found, err := r.getSecret(ctx, namespace, name)
 	if err != nil || !found {
 		return err
 	}
-	if secret.Annotations[s3CredentialsManagedAnnotation] != "true" || !metav1.IsControlledBy(secret, cred) {
+	if !metav1.IsControlledBy(secret, cred) {
 		return nil
 	}
 	if err := controllerutil.RemoveControllerReference(cred, secret, r.Scheme); err != nil {

--- a/internal/controller/s3credentials_controller.go
+++ b/internal/controller/s3credentials_controller.go
@@ -183,6 +183,11 @@ func (r *S3CredentialsReconciler) reconcileKey(ctx context.Context, cred *seawee
 		return r.pending(ctx, cred, "SecretNotFound",
 			fmt.Sprintf("cross-namespace Secret %s/%s does not exist", secretNamespace, secretName))
 	}
+	if secretFound && !crossNamespace &&
+		(secret.Annotations[s3CredentialsManagedAnnotation] != "true" || !metav1.IsControlledBy(secret, cred)) {
+		return r.fail(ctx, cred, "SecretOwnershipConflict",
+			fmt.Sprintf("Secret %s/%s is not controlled by this S3Credentials", secretNamespace, secretName))
+	}
 
 	var existingAK, existingSK string
 	if secretFound {
@@ -241,9 +246,7 @@ func (r *S3CredentialsReconciler) reconcileKey(ctx context.Context, cred *seawee
 	return ctrl.Result{RequeueAfter: iamResyncInterval}, nil
 }
 
-// writeSecret creates or updates the Secret holding the key pair. A Secret the
-// operator creates is annotated as managed so the finalizer can delete it; a
-// pre-existing Secret is updated in place but never marked managed.
+// writeSecret creates or updates the Secret holding the key pair.
 func (r *S3CredentialsReconciler) writeSecret(ctx context.Context, cred *seaweedv1.S3Credentials, secret *corev1.Secret, secretFound bool, secretName, secretNamespace, akField, skField, ak, sk string) error {
 	if !secretFound {
 		newSecret := &corev1.Secret{


### PR DESCRIPTION
## Summary

- reject an existing same-namespace Secret unless it is operator-managed and controlled by the reconciling `S3Credentials`
- require that same ownership before Delete or Retain cleanup, with a UID-preconditioned delete
- preserve explicitly granted cross-namespace Secret consumption
- cover unmanaged adoption, cross-credential overwrite, deletion, and orphaning regressions

## Testing

- `make test`

Fixes #377
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs-operator/pull/378" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Same-namespace Secrets are protected from accidental adoption when unmanaged or owned by another resource.
  - Cross-namespace Secrets must already exist and provide the required credentials; they are not created automatically.
  - Incomplete cross-namespace Secrets remain unchanged until completed.
  - Credential creation is halted when Secret ownership conflicts occur.
  - Deleting a credentials resource no longer removes or alters a Secret owned by another credentials resource.

- **Documentation**
  - Updated Secret ownership and lifecycle guidance to reflect the enforced behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->