### PR TITLE
Retry remote manifest downloads in kind-prepare

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,13 @@ PROMETHEUS_OPERATOR_VERSION ?= v0.74.0
 # renovate: datasource=github-tags depName=jetstack/cert-manager
 CERT_MANAGER_VERSION ?= v1.15.0
 
+# Remote manifests are downloaded with curl before being handed to kubectl.
+# `kubectl apply -f <url>` performs a single GET with no retry, so one transient
+# GitHub 5xx (seen in CI) fails the whole kind-prepare run. curl's --retry
+# already treats 408/429/5xx as transient; --retry-all-errors also covers
+# connection resets and similar network blips.
+CURL_FETCH ?= curl --fail --silent --show-error --location --retry 5 --retry-delay 5 --retry-all-errors
+
 ifndef ignore-not-found
   ignore-not-found = false
 endif
@@ -255,12 +262,14 @@ kind-delete: kind ## Create kubernetes cluster using Kind.
 	fi
 
 .PHONY: kind-prepare
-kind-prepare: kind-create
+kind-prepare: kind-create $(LOCALBIN)
 	# Install prometheus operator
-	$(KUBECTL) apply --server-side -f "https://github.com/prometheus-operator/prometheus-operator/releases/download/$(PROMETHEUS_OPERATOR_VERSION)/bundle.yaml"
+	$(CURL_FETCH) -o $(LOCALBIN)/prometheus-operator-bundle.yaml "https://github.com/prometheus-operator/prometheus-operator/releases/download/$(PROMETHEUS_OPERATOR_VERSION)/bundle.yaml"
+	$(KUBECTL) apply --server-side -f $(LOCALBIN)/prometheus-operator-bundle.yaml
 	$(KUBECTL) wait deployment.apps/prometheus-operator --for condition=Available --namespace default --timeout 5m
 	# Install cert-manager operator
-	$(KUBECTL) apply --server-side -f "https://github.com/jetstack/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.yaml"
+	$(CURL_FETCH) -o $(LOCALBIN)/cert-manager.yaml "https://github.com/jetstack/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.yaml"
+	$(KUBECTL) apply --server-side -f $(LOCALBIN)/cert-manager.yaml
 	$(KUBECTL) wait deployment.apps/cert-manager-webhook --for condition=Available --namespace cert-manager --timeout 5m
 
 ##@ Dependencies

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -79,7 +79,10 @@ var _ = AfterSuite(func() {
 		return
 	}
 	By("cleanup", func() {
-		cmd := exec.Command("make", "undeploy")
+		// AfterSuite also runs when BeforeSuite fails part-way, before the
+		// operator was deployed. Tolerate NotFound so the cleanup does not
+		// report a second failure that buries the real setup error.
+		cmd := exec.Command("make", "undeploy", "ignore-not-found=true")
 		_, err := utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
## Summary

Fixes the e2e failure in https://github.com/seaweedfs/seaweedfs-operator/actions/runs/33809617770/job/100828130780.

**Root cause:** `make kind-prepare` ran `kubectl apply --server-side -f "https://github.com/jetstack/cert-manager/releases/download/v1.15.0/cert-manager.yaml"` and GitHub's release CDN returned a transient `500 Internal Server Error`. `kubectl apply -f <url>` performs a single GET with no retry, so one network blip failed `BeforeSuite`, and the other two matrix jobs were cancelled by fail-fast.

**Secondary noise:** because setup died before `make deploy`, the `AfterSuite` cleanup's `make undeploy` (default `--ignore-not-found=false`) then failed on every NotFound, reporting a second failure that buried the real one.

Changes:

- **Makefile** – add a `CURL_FETCH` helper (`curl --fail --silent --show-error --location --retry 5 --retry-delay 5 --retry-all-errors`) and have `kind-prepare` download the prometheus-operator and cert-manager manifests into `$(LOCALBIN)` before `kubectl apply`-ing the local file. curl's `--retry` already treats 408/429/5xx as transient; `--retry-all-errors` also covers connection resets. `--fail` guarantees an error body or partial download is never handed to kubectl. `curl` is already a dependency of the `helm` target.
- **test/e2e/e2e_suite_test.go** – run the AfterSuite `make undeploy` with `ignore-not-found=true` (already supported by the Makefile) so a partial setup failure surfaces as exactly one failure.

#### Test plan

- [x] `make -n kind-prepare` shows the expected `curl ... -o bin/<manifest>` followed by `kubectl apply --server-side -f bin/<manifest>` for both operators
- [x] Real fetch of both manifests via `CURL_FETCH` succeeds through the GitHub redirect; files contain the `prometheus-operator` and `cert-manager-webhook` Deployments the subsequent `kubectl wait` targets
- [x] Against `https://httpbin.org/status/500`, `CURL_FETCH` retries the configured number of times, exits non-zero, and writes no output file
- [x] `make -n undeploy ignore-not-found=true` renders `kubectl delete ... --ignore-not-found=true`
- [x] `gofmt -l`, `go vet`, and `go test -c` on `./test/e2e/` are clean
- [ ] CI: `test-e2e` matrix passes

Generated with [Devin](https://devin.ai)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs-operator/pull/379" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->