### PR TITLE
filer: make Lance an explicit opt-in like Iceberg

### DIFF
--- a/api/v1/seaweed_types.go
+++ b/api/v1/seaweed_types.go
@@ -693,7 +693,6 @@ type IcebergConfig struct {
 }
 
 // LanceConfig defines the Lance Namespace REST API configuration.
-// Absent means enabled: weed serves the namespace by default.
 type LanceConfig struct {
 	// +kubebuilder:default:=true
 	Enabled bool `json:"enabled,omitempty"`
@@ -786,7 +785,7 @@ func (c *IcebergConfig) IcebergEffectivePort() int32 {
 }
 
 // LanceEffectivePort returns the Lance Namespace port, FilerLancePort (9101)
-// when unconfigured; nil-safe because an absent config still means the default.
+// when unconfigured; nil-safe.
 func (c *LanceConfig) LanceEffectivePort() int32 {
 	if c != nil && c.Port != nil {
 		return *c.Port
@@ -794,10 +793,11 @@ func (c *LanceConfig) LanceEffectivePort() int32 {
 	return FilerLancePort
 }
 
-// ServesLance reports whether the filer serves the Lance Namespace API:
-// matching weed's default-on, only an explicit enabled: false turns it off.
+// ServesLance reports whether the filer serves the Lance Namespace API.
+// Explicit opt-in like Iceberg: spec.image may predate Lance, so an absent
+// block must not advertise a port nothing listens on.
 func (f *FilerSpec) ServesLance() bool {
-	return f != nil && (f.Lance == nil || f.Lance.Enabled)
+	return f != nil && f.Lance != nil && f.Lance.Enabled
 }
 
 // AdminSpec is the spec for the admin server (single instance, stateless)

--- a/api/v1/seaweed_types.go
+++ b/api/v1/seaweed_types.go
@@ -795,7 +795,8 @@ func (c *LanceConfig) LanceEffectivePort() int32 {
 
 // ServesLance reports whether the filer serves the Lance Namespace API.
 // Explicit opt-in like Iceberg: spec.image may predate Lance, so an absent
-// block must not advertise a port nothing listens on.
+// block must not advertise a port nothing listens on, nor render a flag
+// that older images' fla9 drops along with every argument after it.
 func (f *FilerSpec) ServesLance() bool {
 	return f != nil && f.Lance != nil && f.Lance.Enabled
 }

--- a/api/v1/seaweed_webhook_test.go
+++ b/api/v1/seaweed_webhook_test.go
@@ -377,18 +377,21 @@ func TestValidateWorker(t *testing.T) {
 		sw := newWorker()
 		port := int32(WorkerLanceMetricsPort)
 		sw.Spec.Worker.MetricsPort = &port
+		sw.Spec.Filer.Lance = &LanceConfig{Enabled: true}
 		if errs := sw.validateWorker(); len(errs) != 1 || !strings.Contains(errs[0].Error(), "worker-lance") {
 			t.Fatalf("expected the port clash error, got %v", errs)
 		}
 	})
 
 	t.Run("metricsPort 9328 without the sidecar is fine", func(t *testing.T) {
-		sw := newWorker()
-		port := int32(WorkerLanceMetricsPort)
-		sw.Spec.Worker.MetricsPort = &port
-		sw.Spec.Filer.Lance = &LanceConfig{Enabled: false}
-		if errs := sw.validateWorker(); len(errs) != 0 {
-			t.Fatalf("unexpected errors: %v", errs)
+		for _, lance := range []*LanceConfig{nil, {Enabled: false}} {
+			sw := newWorker()
+			port := int32(WorkerLanceMetricsPort)
+			sw.Spec.Worker.MetricsPort = &port
+			sw.Spec.Filer.Lance = lance
+			if errs := sw.validateWorker(); len(errs) != 0 {
+				t.Fatalf("lance %+v: unexpected errors: %v", lance, errs)
+			}
 		}
 	})
 

--- a/internal/controller/controller_filer_statefulset.go
+++ b/internal/controller/controller_filer_statefulset.go
@@ -53,8 +53,7 @@ func buildFilerStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string {
 	if m.Spec.Filer.Iceberg != nil && m.Spec.Filer.Iceberg.Enabled {
 		commands = append(commands, fmt.Sprintf("-s3.port.iceberg=%d", m.Spec.Filer.Iceberg.IcebergEffectivePort()))
 	}
-	// Explicit config only: older images' fla9 drops an unknown flag and all args after it.
-	if m.Spec.Filer.Lance != nil && m.Spec.Filer.Lance.Enabled {
+	if m.Spec.Filer.ServesLance() {
 		commands = append(commands, fmt.Sprintf("-s3.port.lance=%d", m.Spec.Filer.Lance.LanceEffectivePort()))
 	}
 	commands = append(commands, extraArgs...)

--- a/internal/controller/controller_filer_statefulset_test.go
+++ b/internal/controller/controller_filer_statefulset_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -50,6 +51,66 @@ func TestBuildFilerStartupScript_MaxMB(t *testing.T) {
 			t.Errorf("expected no -maxMB flag when unset, got %q", got)
 		}
 	})
+}
+
+// The -s3.port.lance flag, the container port and both Service ports must
+// agree: an absent spec.filer.lance advertises nothing, since spec.image may
+// predate Lance and a port nobody listens on would still roll the filer.
+func TestFilerLanceExposureFollowsFlag(t *testing.T) {
+	customPort := int32(19101)
+	cases := []struct {
+		name     string
+		lance    *seaweedv1.LanceConfig
+		wantPort int32 // 0 means off everywhere
+	}{
+		{name: "unset", lance: nil},
+		{name: "disabled", lance: &seaweedv1.LanceConfig{Enabled: false}},
+		{name: "enabled", lance: &seaweedv1.LanceConfig{Enabled: true}, wantPort: seaweedv1.FilerLancePort},
+		{name: "custom port", lance: &seaweedv1.LanceConfig{Enabled: true, Port: &customPort}, wantPort: customPort},
+	}
+	namedPort := func(ports []corev1.ServicePort) int32 {
+		for _, p := range ports {
+			if p.Name == "filer-lance" {
+				return p.Port
+			}
+		}
+		return 0
+	}
+	r := &SeaweedReconciler{}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &seaweedv1.Seaweed{
+				ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
+				Spec: seaweedv1.SeaweedSpec{
+					Master: &seaweedv1.MasterSpec{Replicas: 1},
+					Filer:  &seaweedv1.FilerSpec{Replicas: 1, Lance: tc.lance},
+				},
+			}
+
+			script := buildFilerStartupScript(m)
+			if hasFlag := strings.Contains(script, "-s3.port.lance="); hasFlag != (tc.wantPort != 0) {
+				t.Errorf("-s3.port.lance rendered = %v, want %v: %q", hasFlag, tc.wantPort != 0, script)
+			} else if hasFlag && !strings.Contains(script, fmt.Sprintf("-s3.port.lance=%d", tc.wantPort)) {
+				t.Errorf("expected -s3.port.lance=%d in %q", tc.wantPort, script)
+			}
+
+			var got int32
+			for _, p := range filerContainer(t, &r.createFilerStatefulSet(m).Spec.Template.Spec).Ports {
+				if p.Name == "filer-lance" {
+					got = p.ContainerPort
+				}
+			}
+			if got != tc.wantPort {
+				t.Errorf("filer-lance container port = %d, want %d", got, tc.wantPort)
+			}
+
+			for _, svc := range []*corev1.Service{r.createFilerService(m), r.createFilerPeerService(m)} {
+				if got := namedPort(svc.Spec.Ports); got != tc.wantPort {
+					t.Errorf("%s filer-lance port = %d, want %d", svc.Name, got, tc.wantPort)
+				}
+			}
+		})
+	}
 }
 
 // Without the marker on the pod template, turning a section on changes only

--- a/internal/controller/controller_worker_deployment_test.go
+++ b/internal/controller/controller_worker_deployment_test.go
@@ -10,7 +10,7 @@ import (
 	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
 )
 
-// newWorkerCluster leaves spec.filer.lance unset, the default-on shape most CRs have.
+// newWorkerCluster leaves spec.filer.lance unset; tests that need the sidecar enable it.
 func newWorkerCluster(worker *seaweedv1.WorkerSpec) *seaweedv1.Seaweed {
 	return &seaweedv1.Seaweed{
 		ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
@@ -117,8 +117,15 @@ func TestBuildRustWorkerStartupScript_CustomLancePort(t *testing.T) {
 func TestCreateWorkerDeploymentLanceSidecar(t *testing.T) {
 	r := &SeaweedReconciler{}
 
+	// The sidecar exits 1 on images without weed-worker, so an unset block must not run it.
 	m := newWorkerCluster(&seaweedv1.WorkerSpec{Replicas: 1})
 	pod := &r.createWorkerDeployment(m).Spec.Template.Spec
+	if podContainer(t, pod, "worker-lance") != nil {
+		t.Errorf("expected no sidecar with lance unset, got %v", pod.Containers)
+	}
+
+	m.Spec.Filer.Lance = &seaweedv1.LanceConfig{Enabled: true}
+	pod = &r.createWorkerDeployment(m).Spec.Template.Spec
 
 	worker := podContainer(t, pod, "worker")
 	if worker == nil {
@@ -158,6 +165,7 @@ func TestCreateWorkerDeploymentPersistencePlacement(t *testing.T) {
 		Replicas:    1,
 		Persistence: &seaweedv1.PersistenceSpec{Enabled: true},
 	})
+	m.Spec.Filer.Lance = &seaweedv1.LanceConfig{Enabled: true}
 	r := &SeaweedReconciler{}
 	pod := &r.createWorkerDeployment(m).Spec.Template.Spec
 


### PR DESCRIPTION
## Summary

Fixes #374.

`ServesLance()` treated an absent `spec.filer.lance` as enabled while the `-s3.port.lance` flag was only rendered for an explicit block. A CR with no `lance` block therefore grew a `filer-lance` containerPort (rolling the filer StatefulSet), a `filer-lance` port on both filer Services, and a `worker-lance` sidecar — with nothing listening on 9101 when `spec.image` predates Lance, and the sidecar exiting 1 for want of `/usr/bin/weed-worker`.

- **`ServesLance()` now requires `Lance != nil && Lance.Enabled`** — the same condition the flag already used and the same shape Iceberg has everywhere. The container port, both Service ports, the sidecar and the webhook's `metricsPort` 9328 check all follow it, so an absent block means off everywhere. `enabled: false` keeps working.
- **`-s3.port.lance` is rendered through `ServesLance()`** too, so the flag and the port can no longer drift apart. No behaviour change on its own.

Users who relied on the implicit default get Lance back with:

```yaml
spec:
  filer:
    lance:
      enabled: true
```

Generated CRD/deepcopy are unchanged (`enabled` already defaults to `true` *inside* the block, as with `iceberg`).

#### Test plan
- [x] New `TestFilerLanceExposureFollowsFlag`: for unset / disabled / enabled / custom port, asserts the flag, the `filer-lance` containerPort and both Services' `filer-lance` port agree
- [x] `TestCreateWorkerDeploymentLanceSidecar`: unset block → no sidecar; `enabled: true` → sidecar; `enabled: false` → no sidecar
- [x] `TestValidateWorker`: `metricsPort: 9328` rejected only with `lance.enabled: true`; fine with unset or `enabled: false`
- [x] `make test` (envtest), `make fmt vet nilaway-lint`, `make manifests generate` leave the tree clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs-operator/pull/381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - Lance Namespace API exposure is now opt-in. It remains disabled when no Lance configuration is provided or when Lance is explicitly disabled.
  - Enable Lance explicitly to expose its API, ports, services, and related worker components.
  - Filer and worker deployments now consistently follow the Lance enablement setting, including custom port configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->