### PR TITLE
Grant the CSI controller's RBAC only when csiDriver.enabled

### DIFF
--- a/CSI_SUPPORT.md
+++ b/CSI_SUPPORT.md
@@ -76,6 +76,13 @@ csiDriver:
   enabled: true
 ```
 
+The same value grants the manager the RBAC this controller needs and nothing
+else does — `CSIDriver` and `StorageClass` management, node and
+`PersistentVolume` access, and cluster-wide `bind`/`escalate` on roles so it
+can create the driver's own ClusterRoles. A chart install with the controller
+off holds none of those. Setting `ENABLE_CSI_DRIVER` through `extraEnv` is
+rejected at render time for that reason.
+
 A CSI driver is **node-global**: the kubelet registers exactly one driver per
 `driverName` per node, regardless of how many SeaweedFS clusters run on it.
 For that reason the driver is modeled as its own opt-in resource rather than a

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -1,6 +1,6 @@
 # seaweedfs-operator
 
-![Version: 0.1.36](https://img.shields.io/badge/Version-0.1.36-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.33](https://img.shields.io/badge/AppVersion-1.0.33-informational?style=flat-square)
+![Version: 0.1.40](https://img.shields.io/badge/Version-0.1.40-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.37](https://img.shields.io/badge/AppVersion-1.0.37-informational?style=flat-square)
 
 A Helm chart for the seaweedfs-operator
 
@@ -19,8 +19,8 @@ A Helm chart for the seaweedfs-operator
 | commonAnnotations | object | `{}` | Annotations for all the deployed objects |
 | commonLabels | object | `{}` | Labels for all the deployed objects |
 | crds.create | bool | `true` | Install the Seaweed CRD as part of the release. Set to false when the CRD is managed out-of-band (e.g., cluster-scoped GitOps or a shared CRD across namespaces) so `helm install/upgrade` won't try to create or adopt it. |
-| csiDriver.enabled | bool | `false` | Register the SeaweedCSIDriver controller by setting ENABLE_CSI_DRIVER=true on the manager. Off by default, matching the manager's own default. |
-| extraEnv | list | `[]` | Additional environment variables for the manager container. Takes the usual env list form, so a value can come from a secretKeyRef or fieldRef as well as a literal. |
+| csiDriver.enabled | bool | `false` | Register the SeaweedCSIDriver controller by setting ENABLE_CSI_DRIVER=true on the manager, and grant the manager the extra RBAC that controller needs (CSIDrivers, StorageClasses, nodes, PersistentVolumes, and cluster-wide bind/escalate on roles so it can create the driver's own ClusterRoles). Off by default, matching the manager's own default; a default install gets none of those grants. |
+| extraEnv | list | `[]` | Additional environment variables for the manager container. Takes the usual env list form, so a value can come from a secretKeyRef or fieldRef as well as a literal. ENABLE_CSI_DRIVER is rejected here — set csiDriver.enabled, which also grants the matching RBAC. |
 | fullnameOverride | string | `""` | String to fully override common.names.fullname template |
 | global | object | `{"imageRegistry":""}` | Global Docker image parameters. global.imageRegistry, when set, overrides the registry of every image in the chart; leave empty to use each image's own. |
 | grafanaDashboard.additionalLabels | object | `{"grafana_dashboard":"1"}` | Labels added to the Grafana Dashboard ConfigMap so the Grafana sidecar discovers it. kube-prometheus-stack only matches `grafana_dashboard: "1"`; the standalone grafana chart matches any value. Set a key to `null` to drop it — an empty map merges with the default rather than replacing it. |

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -66,6 +66,11 @@ spec:
         {{- end }}
         {{- end }}
         {{- with .Values.extraEnv }}
+        {{- range . }}
+        {{- if eq .name "ENABLE_CSI_DRIVER" }}
+        {{- fail "set csiDriver.enabled instead of ENABLE_CSI_DRIVER in extraEnv: that value also grants the manager the RBAC the SeaweedCSIDriver controller needs" }}
+        {{- end }}
+        {{- end }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
         ports:

--- a/deploy/helm/templates/rbac/role.yaml
+++ b/deploy/helm/templates/rbac/role.yaml
@@ -10,13 +10,7 @@ rules:
   - ""
   resources:
   - configmaps
-  - events
-  - nodes
-  - persistentvolumeclaims
-  - persistentvolumes
-  - pods
   - secrets
-  - serviceaccounts
   - services
   verbs:
   - create
@@ -29,7 +23,15 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - namespaces
+  - pods
   verbs:
   - get
   - list
@@ -75,18 +77,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - extensions
   - networking.k8s.io
   resources:
@@ -103,6 +93,108 @@ rules:
   - monitoring.coreos.com
   resources:
   - servicemonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - seaweed.seaweedfs.com
+  resources:
+  - adminscripts
+  - bucketlifecyclepolicies
+  - buckets
+  - s3credentials
+  - s3identities
+  - s3oidcproviders
+  - s3policies
+  - s3policybindings
+  - seaweedbackups
+  - seaweedrestores
+  - seaweeds
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - seaweed.seaweedfs.com
+  resources:
+  - adminscripts/finalizers
+  - bucketlifecyclepolicies/finalizers
+  - buckets/finalizers
+  - s3credentials/finalizers
+  - s3identities/finalizers
+  - s3oidcproviders/finalizers
+  - s3policies/finalizers
+  - s3policybindings/finalizers
+  - seaweedbackups/finalizers
+  - seaweedrestores/finalizers
+  - seaweeds/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - seaweed.seaweedfs.com
+  resources:
+  - adminscripts/status
+  - bucketlifecyclepolicies/status
+  - buckets/status
+  - s3credentials/status
+  - s3identities/status
+  - s3oidcproviders/status
+  - s3policies/status
+  - s3policybindings/status
+  - seaweedbackups/status
+  - seaweedrestores/status
+  - seaweeds/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - seaweed.seaweedfs.com
+  resources:
+  - resourcereferencegrants
+  verbs:
+  - get
+  - list
+  - watch
+{{- if .Values.csiDriver }}
+{{- if .Values.csiDriver.enabled }}
+# Rules only the SeaweedCSIDriver controller needs, from the kubebuilder
+# markers in internal/controller/seaweedcsidriver_controller.go. The manager
+# registers that controller only when csiDriver.enabled sets
+# ENABLE_CSI_DRIVER=true, so the same value gates the grants: a default
+# install cannot manage CSIDrivers, cluster-wide RBAC (bind/escalate), nodes,
+# or PersistentVolumes. test/helm/rbac_drift_test.go checks both renders
+# against the markers.
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - nodes
+  - persistentvolumeclaims
+  - persistentvolumes
+  - pods
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
   verbs:
   - create
   - delete
@@ -131,18 +223,7 @@ rules:
 - apiGroups:
   - seaweed.seaweedfs.com
   resources:
-  - adminscripts
-  - bucketlifecyclepolicies
-  - buckets
-  - s3credentials
-  - s3identities
-  - s3oidcproviders
-  - s3policies
-  - s3policybindings
-  - seaweedbackups
   - seaweedcsidrivers
-  - seaweedrestores
-  - seaweeds
   verbs:
   - create
   - delete
@@ -154,47 +235,17 @@ rules:
 - apiGroups:
   - seaweed.seaweedfs.com
   resources:
-  - adminscripts/finalizers
-  - bucketlifecyclepolicies/finalizers
-  - buckets/finalizers
-  - s3credentials/finalizers
-  - s3identities/finalizers
-  - s3oidcproviders/finalizers
-  - s3policies/finalizers
-  - s3policybindings/finalizers
-  - seaweedbackups/finalizers
   - seaweedcsidrivers/finalizers
-  - seaweedrestores/finalizers
-  - seaweeds/finalizers
   verbs:
   - update
 - apiGroups:
   - seaweed.seaweedfs.com
   resources:
-  - adminscripts/status
-  - bucketlifecyclepolicies/status
-  - buckets/status
-  - s3credentials/status
-  - s3identities/status
-  - s3oidcproviders/status
-  - s3policies/status
-  - s3policybindings/status
-  - seaweedbackups/status
   - seaweedcsidrivers/status
-  - seaweedrestores/status
-  - seaweeds/status
   verbs:
   - get
   - patch
   - update
-- apiGroups:
-  - seaweed.seaweedfs.com
-  resources:
-  - resourcereferencegrants
-  verbs:
-  - get
-  - list
-  - watch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -227,4 +278,6 @@ rules:
   - patch
   - update
   - watch
+{{- end }}
+{{- end }}
 {{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -75,12 +75,17 @@ replicaCount: 1
 ## silently does nothing, which is a confusing way to find out it is off.
 csiDriver:
   # -- Register the SeaweedCSIDriver controller by setting ENABLE_CSI_DRIVER=true
-  # on the manager. Off by default, matching the manager's own default.
+  # on the manager, and grant the manager the extra RBAC that controller needs
+  # (CSIDrivers, StorageClasses, nodes, PersistentVolumes, and cluster-wide
+  # bind/escalate on roles so it can create the driver's own ClusterRoles).
+  # Off by default, matching the manager's own default; a default install gets
+  # none of those grants.
   enabled: false
 
 # -- Additional environment variables for the manager container. Takes the usual
 # env list form, so a value can come from a secretKeyRef or fieldRef as well as
-# a literal.
+# a literal. ENABLE_CSI_DRIVER is rejected here — set csiDriver.enabled, which
+# also grants the matching RBAC.
 extraEnv: []
 #  - name: SOME_FLAG
 #    value: "true"

--- a/test/helm/rbac_drift_test.go
+++ b/test/helm/rbac_drift_test.go
@@ -31,8 +31,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
+	"strings"
 	"testing"
 
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -44,34 +46,146 @@ import (
 // the chart-rendered manager ClusterRole. Extra rules in the Helm chart
 // (e.g., the conditional ServiceMonitor block) are allowed; missing
 // rules are not.
+//
+// config/rbac/role.yaml is generated from every controller's markers,
+// including the SeaweedCSIDriver controller's, so the chart is rendered
+// with csiDriver.enabled=true: that is the state in which the manager
+// registers every controller the kustomize role accounts for.
+// TestHelmManagerRoleCSIGate covers the default render.
 func TestHelmManagerRoleIsSupersetOfKustomize(t *testing.T) {
 	root := projectRoot(t)
 
-	helmRules := helmManagerRules(t, filepath.Join(root, "deploy", "helm"))
+	helmRules := helmManagerRules(t, filepath.Join(root, "deploy", "helm"), "--set", "csiDriver.enabled=true")
 	kustomizeRules := kustomizeManagerRules(t, filepath.Join(root, "config", "rbac", "role.yaml"))
 
-	helmTriples := flattenRules(helmRules)
-	kustomizeTriples := flattenRules(kustomizeRules)
-
-	var missing []ruleTriple
-	for triple := range kustomizeTriples {
-		if !helmTriples[triple] {
-			missing = append(missing, triple)
-		}
-	}
+	missing := missingTriples(flattenRules(kustomizeRules), flattenRules(helmRules))
 	if len(missing) == 0 {
 		return
 	}
 
-	sort.Slice(missing, func(i, j int) bool {
-		return missing[i].String() < missing[j].String()
-	})
 	t.Errorf("Helm chart manager-role is missing %d (apiGroup, resource, verb) triple(s) granted by config/rbac/role.yaml.", len(missing))
 	t.Errorf("Update deploy/helm/templates/rbac/role.yaml to include these rules:")
 	for _, m := range missing {
 		t.Errorf("  - %s", m)
 	}
 	t.Errorf("Reason this matters: kubebuilder regenerates config/rbac/role.yaml from controller markers, but the Helm chart's RBAC is hand-maintained. Without parity, fresh Helm installs deploy with stale permissions and the operator fails to watch its own resources at startup.")
+}
+
+// csiControllerFile declares the only controller the manager registers
+// conditionally, on ENABLE_CSI_DRIVER (see cmd/main.go). The chart sets
+// that variable from csiDriver.enabled and gates the controller's RBAC on
+// the same value, so a default install does not hold cluster-wide
+// bind/escalate, CSIDriver, node, or PersistentVolume grants it cannot use.
+const csiControllerFile = "seaweedcsidriver_controller.go"
+
+// TestHelmManagerRoleCSIGate pins both sides of the csiDriver.enabled RBAC
+// gate against the kubebuilder markers in internal/controller:
+//
+//   - the default render must still grant every triple declared by the
+//     always-on controllers, so the gate cannot swallow a rule some other
+//     controller needs (a marker added elsewhere for a resource the CSI
+//     block currently owns shows up here);
+//   - the default render must grant none of the triples only the CSI
+//     controller declares, so the gate stays a gate.
+//
+// Rendering with the flag on is covered by
+// TestHelmManagerRoleIsSupersetOfKustomize.
+func TestHelmManagerRoleCSIGate(t *testing.T) {
+	root := projectRoot(t)
+	chartDir := filepath.Join(root, "deploy", "helm")
+
+	csiTriples, otherTriples := controllerMarkerTriples(t, filepath.Join(root, "internal", "controller"))
+	if len(csiTriples) == 0 || len(otherTriples) == 0 {
+		t.Fatalf("parsed %d CSI and %d non-CSI rbac markers from internal/controller; expected both non-empty", len(csiTriples), len(otherTriples))
+	}
+	defaultTriples := flattenRules(helmManagerRules(t, chartDir))
+
+	if missing := missingTriples(otherTriples, defaultTriples); len(missing) > 0 {
+		t.Errorf("Default Helm render is missing %d triple(s) declared by controllers that run regardless of ENABLE_CSI_DRIVER:", len(missing))
+		for _, m := range missing {
+			t.Errorf("  - %s", m)
+		}
+		t.Errorf("Move these out of the csiDriver.enabled block in deploy/helm/templates/rbac/role.yaml (or add them); a marker outside %s now needs them.", csiControllerFile)
+	}
+
+	csiOnly := map[ruleTriple]bool{}
+	for triple := range csiTriples {
+		if !otherTriples[triple] {
+			csiOnly[triple] = true
+		}
+	}
+	var leaked []ruleTriple
+	for triple := range csiOnly {
+		if defaultTriples[triple] {
+			leaked = append(leaked, triple)
+		}
+	}
+	if len(leaked) > 0 {
+		sort.Slice(leaked, func(i, j int) bool { return leaked[i].String() < leaked[j].String() })
+		t.Errorf("Default Helm render grants %d triple(s) only the SeaweedCSIDriver controller declares; they belong inside the csiDriver.enabled block in deploy/helm/templates/rbac/role.yaml:", len(leaked))
+		for _, l := range leaked {
+			t.Errorf("  - %s", l)
+		}
+	}
+}
+
+// missingTriples returns, sorted, every triple in want that got lacks.
+func missingTriples(want, got map[ruleTriple]bool) []ruleTriple {
+	var missing []ruleTriple
+	for triple := range want {
+		if !got[triple] {
+			missing = append(missing, triple)
+		}
+	}
+	sort.Slice(missing, func(i, j int) bool { return missing[i].String() < missing[j].String() })
+	return missing
+}
+
+// rbacMarker matches one `// +kubebuilder:rbac:groups=...,resources=...,verbs=...`
+// line. Only the three fields the manager role is generated from are
+// parsed; namespace-scoped markers are not used in this repo.
+var rbacMarker = regexp.MustCompile(`\+kubebuilder:rbac:groups=([^,]*),resources=([^,\s]*),verbs=([^,\s]*)`)
+
+// controllerMarkerTriples reads every non-test Go file in dir and returns
+// the (apiGroup, resource, verb) triples declared by csiControllerFile and
+// by all other files. This mirrors what controller-gen feeds into
+// config/rbac/role.yaml, but keeps the per-controller attribution the
+// generated role flattens away.
+func controllerMarkerTriples(t *testing.T, dir string) (csi, other map[ruleTriple]bool) {
+	t.Helper()
+	csi, other = map[ruleTriple]bool{}, map[ruleTriple]bool{}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		into := other
+		if name == csiControllerFile {
+			into = csi
+		}
+		for _, m := range rbacMarker.FindAllStringSubmatch(string(data), -1) {
+			for _, g := range strings.Split(m[1], ";") {
+				// controller-gen accepts both spellings of the core group.
+				if g = strings.Trim(g, `"`); g == "core" {
+					g = ""
+				}
+				for _, res := range strings.Split(m[2], ";") {
+					for _, v := range strings.Split(m[3], ";") {
+						into[ruleTriple{apiGroup: g, resource: res, verb: v}] = true
+					}
+				}
+			}
+		}
+	}
+	return csi, other
 }
 
 // ruleTriple is one (apiGroup, resource, verb) grant. PolicyRule is a
@@ -108,11 +222,11 @@ func flattenRules(rules []rbacv1.PolicyRule) map[ruleTriple]bool {
 	return out
 }
 
-func helmManagerRules(t *testing.T, chartDir string) []rbacv1.PolicyRule {
+func helmManagerRules(t *testing.T, chartDir string, extraArgs ...string) []rbacv1.PolicyRule {
 	t.Helper()
-	// Render with the chart's default values — exactly what
-	// `helm install seaweedfs/seaweedfs-operator` produces for a
-	// fresh user. Rendering with every feature toggle enabled
+	// Render with the chart's default values unless the caller says
+	// otherwise — exactly what `helm install seaweedfs/seaweedfs-operator`
+	// produces for a fresh user. Rendering with feature toggles enabled
 	// (e.g., serviceMonitor.enabled=true) would compare against the
 	// unconditional kustomize role and mask any rule gated behind a
 	// values flag — users hit the operator running with default-Helm
@@ -124,8 +238,12 @@ func helmManagerRules(t *testing.T, chartDir string) []rbacv1.PolicyRule {
 	// scoped to "only granted when feature X is enabled" is fine in
 	// principle, but it has to be tied to a runtime signal the
 	// operator code itself observes — not a Helm value the operator
-	// binary knows nothing about.
-	cmd := exec.Command("helm", "template", "drift-test", chartDir)
+	// binary knows nothing about. csiDriver.enabled is the one toggle
+	// that qualifies: it is what sets ENABLE_CSI_DRIVER, so the
+	// controller that needs the gated rules only runs when they are
+	// granted. TestHelmManagerRoleCSIGate holds the two together.
+	args := append([]string{"template", "drift-test", chartDir}, extraArgs...)
+	cmd := exec.Command("helm", args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr


### PR DESCRIPTION
Follow-up to #375, which added `csiDriver.enabled` and `extraEnv` to the chart.

## Problem

`deploy/helm/templates/rbac/role.yaml` grants every rule the `SeaweedCSIDriver` controller declares whether or not that controller runs. On a default install the manager never registers it (`ENABLE_CSI_DRIVER` unset, see `cmd/main.go`), yet its ServiceAccount holds:

- `bind` + `escalate` on `clusterroles`, `clusterrolebindings`, `roles`, `rolebindings` — cluster-wide
- full control of `csidrivers`, `storageclasses`, `nodes`, `persistentvolumes`, `persistentvolumeclaims`, `serviceaccounts`
- `create`/`update`/`patch`/`delete` on `pods` and `get`/`list`/`watch`/`update`/`delete` on `events`
- cluster-wide `leases` (leader election already has a namespaced Role)
- `volumesnapshots`, `volumeattachments`, `csinodes`

None of it comes from any other controller's markers. Before the CSI feature reached the chart (`7c1e446`) the role had `pods: get/list/watch`, `events: create/patch`, and none of the rest. #375 notes this is also what makes the feature *look* enabled when it isn't.

## Change

- **`rbac/role.yaml`**: the unconditional section goes back to the pre-CSI shape. A `{{ if .Values.csiDriver.enabled }}` block carries exactly the CSI controller's marker rules, minus the ones other controllers already need (`secrets`, `deployments`, `daemonsets`).
- **`deployment.yaml`**: `csiDriver.enabled` is what sets `ENABLE_CSI_DRIVER`, so controller and grants can't drift apart — except via `extraEnv`. That is now rejected at render time:
  ```
  Error: set csiDriver.enabled instead of ENABLE_CSI_DRIVER in extraEnv: that value also grants the manager the RBAC the SeaweedCSIDriver controller needs
  ```
  This is the condition `rbac_drift_test.go` already spells out for gated RBAC: the Helm value has to be tied to a runtime signal the binary observes.
- **`values.yaml` / `README.md` / `CSI_SUPPORT.md`**: say so. Chart README regenerated with the pinned `helm-docs v1.13.1` (the version badge catches up to `Chart.yaml` as a side effect).

Rendered manager role, defaults (unchanged rules omitted):

| apiGroup | resources | verbs |
|---|---|---|
| `""` | configmaps, secrets, services | full |
| `""` | events | create, patch |
| `""` | namespaces, pods | get, list, watch |

With `csiDriver.enabled=true`, additionally:

| apiGroup | resources | verbs |
|---|---|---|
| `""` | events, nodes, persistentvolumeclaims, persistentvolumes, pods, serviceaccounts | full |
| coordination.k8s.io | leases | full |
| rbac.authorization.k8s.io | clusterrolebindings, clusterroles, rolebindings, roles | full + bind, escalate |
| seaweed.seaweedfs.com | seaweedcsidrivers (+ /status, /finalizers) | as before |
| snapshot.storage.k8s.io | volumesnapshotcontents, volumesnapshots | get, list |
| storage.k8s.io | csidrivers, storageclasses | full |
| storage.k8s.io | csinodes, volumeattachments | get, list, patch, update, watch |

## Tests

- `TestHelmManagerRoleIsSupersetOfKustomize` now renders with `csiDriver.enabled=true`, since `config/rbac/role.yaml` is generated from all markers including the CSI ones. Its comment explains why this toggle qualifies where `serviceMonitor.enabled` did not.
- New `TestHelmManagerRoleCSIGate` parses the `+kubebuilder:rbac` markers in `internal/controller` (non-test files), splits them into CSI-controller vs. everything else, and asserts against the default render: (a) every triple the always-on controllers declare is present — so the gate can't swallow a rule another controller later adds a marker for; (b) no triple that only the CSI controller declares is present — so the gate stays a gate.

Verified each assertion fails when it should by mutating `role.yaml`: leaking `nodes` into the default block, dropping `daemonsets` from it, and dropping `csinodes` from the CSI block are all reported with the offending triples.

#### Test plan
- [x] `go test ./test/helm/` — all pass, including the two changed/new tests
- [x] `helm lint` clean with defaults and with `csiDriver.enabled=true`
- [x] `helm template` with `extraEnv[].name=ENABLE_CSI_DRIVER` fails with the message above; other `extraEnv` entries (including entries without `name`) render as before
- [x] Confirmed outside the CSI controller, pods are only listed (`controller_master.go`) and events go through the recorder, matching the tightened default verbs
- [ ] `helm-install-test` CI (default-values install into kind, scrapes logs for RBAC errors) — the runtime check for the tightened default role
- [ ] `make-test-e2e` unaffected (kustomize path, unconditional role)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs-operator/pull/382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Helm configuration to enable the CSI driver and grant its required permissions.
  * Added support for passing additional manager environment variables through Helm.
  * Helm now rejects configuring the CSI driver through `extraEnv`; use the dedicated CSI setting instead.

* **Documentation**
  * Updated CSI driver setup guidance and Helm value documentation.
  * Updated Helm chart version badges and configuration tables.

* **Bug Fixes**
  * Default Helm installations no longer receive CSI-specific permissions unless the driver is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
