### PR TITLE
admin: bind the wildcard when auth is enabled

### DIFF
--- a/internal/controller/controller_admin_statefulset.go
+++ b/internal/controller/controller_admin_statefulset.go
@@ -32,13 +32,10 @@ func buildAdminStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string {
 		commands = append(commands, fmt.Sprintf("-metricsPort=%d", *m.Spec.Admin.MetricsPort))
 	}
 
-	// weed admin binds to 127.0.0.1 by default, which the kubelet cannot
-	// reach on the pod IP, so liveness/readiness probes always fail (#384).
-	// Bind to the wildcard so probes can connect. weed admin refuses to
-	// bind a non-loopback address without authentication (adminPassword or
-	// [https.admin] mTLS in security.toml), so only do this when a
-	// CredentialsSecret is mounted — which is also when authentication is
-	// enabled. Place it before extraArgs so a user can still override -ip.
+	// weed admin defaults to 127.0.0.1, which the kubelet can't reach on the
+	// pod IP, so probes fail (#384). Bind the wildcard when auth is enabled,
+	// since weed admin refuses a non-loopback bind without authentication.
+	// Place before extraArgs so a user can still override -ip.
 	hasCredentials := m.Spec.Admin.CredentialsSecret != nil && m.Spec.Admin.CredentialsSecret.Name != ""
 	if hasCredentials {
 		commands = append(commands, "-ip=0.0.0.0")

--- a/internal/controller/controller_admin_statefulset.go
+++ b/internal/controller/controller_admin_statefulset.go
@@ -25,42 +25,42 @@ const adminCredentialsMountPath = "/etc/sw/admin"
 var adminCredentialKeys = []string{"adminUser", "adminPassword", "readOnlyUser", "readOnlyPassword"}
 
 func buildAdminStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string {
-	commands := weedPreamble(m, m.BaseAdminSpec().LoggingArgs(), "admin")
-	commands = append(commands, fmt.Sprintf("-port=%d", seaweedv1.AdminHTTPPort))
-	commands = append(commands, fmt.Sprintf("-master=%s", getMasterPeersString(m)))
+	pre := weedPreamble(m, m.BaseAdminSpec().LoggingArgs(), "admin")
+	pre = append(pre, fmt.Sprintf("-port=%d", seaweedv1.AdminHTTPPort))
+	pre = append(pre, fmt.Sprintf("-master=%s", getMasterPeersString(m)))
 	if m.Spec.Admin.MetricsPort != nil {
-		commands = append(commands, fmt.Sprintf("-metricsPort=%d", *m.Spec.Admin.MetricsPort))
+		pre = append(pre, fmt.Sprintf("-metricsPort=%d", *m.Spec.Admin.MetricsPort))
 	}
 
-	// weed admin defaults to 127.0.0.1, which the kubelet can't reach on the
-	// pod IP, so probes fail (#384). Bind the wildcard when auth is enabled,
-	// since weed admin refuses a non-loopback bind without authentication.
-	// Place before extraArgs so a user can still override -ip.
 	hasCredentials := m.Spec.Admin.CredentialsSecret != nil && m.Spec.Admin.CredentialsSecret.Name != ""
-	if hasCredentials {
-		commands = append(commands, "-ip=0.0.0.0")
-	}
-	commands = append(commands, extraArgs...)
 
-	weedCmd := strings.Join(commands, " ")
-
-	// When a CredentialsSecret is mounted, resolve each well-known key from
-	// the projected files into `-<key>=<value>` flags at container start, so
-	// weed admin boots with authentication enabled. Keys with no file on disk
-	// are skipped, keeping readOnlyUser/readOnlyPassword optional. `set --`
-	// builds positional parameters so values containing spaces or special
-	// characters expand safely through `"$@"`. `exec` replaces the /bin/sh
-	// wrapper with weed so SIGTERM from the kubelet reaches weed directly.
-	if hasCredentials {
-		preamble := "set --; " +
-			"for key in " + strings.Join(adminCredentialKeys, " ") + "; do " +
-			`f="` + adminCredentialsMountPath + `/$key"; ` +
-			`[ -f "$f" ] && set -- "$@" "-$key=$(cat "$f")"; ` +
-			"done; "
-		return preamble + "exec " + weedCmd + ` "$@"`
+	// Without a CredentialsSecret, weed admin must stay on loopback: it
+	// refuses a non-loopback bind without authentication.
+	if !hasCredentials {
+		cmd := append(pre, extraArgs...)
+		return "exec " + strings.Join(cmd, " ")
 	}
 
-	return "exec " + weedCmd
+	// With a CredentialsSecret, bind the wildcard so the kubelet's probes can
+	// reach the admin HTTP port on the pod IP (#384). Gate -ip=0.0.0.0 on the
+	// adminPassword key actually being present in the mounted secret, so a
+	// secret missing that key can't expose the admin API unauthenticated on
+	// weed builds that lack the upstream non-loopback auth guard. The shell
+	// sets ipArg before extraArgs (baked into the string below) so a user can
+	// still override -ip; fla9 takes the last flag occurrence.
+	preCmd := strings.Join(pre, " ")
+	extraCmd := ""
+	if len(extraArgs) > 0 {
+		extraCmd = " " + strings.Join(extraArgs, " ")
+	}
+	preamble := "set --; " +
+		"for key in " + strings.Join(adminCredentialKeys, " ") + "; do " +
+		`f="` + adminCredentialsMountPath + `/$key"; ` +
+		`[ -f "$f" ] && set -- "$@" "-$key=$(cat "$f")"; ` +
+		"done; " +
+		`ipArg=""; ` +
+		`[ -f ` + adminCredentialsMountPath + `/adminPassword ] && ipArg="-ip=0.0.0.0"; `
+	return preamble + "exec " + preCmd + " $ipArg" + extraCmd + ` "$@"`
 }
 
 // adminURLPrefix scans weed admin ExtraArgs for a -urlPrefix flag and returns

--- a/internal/controller/controller_admin_statefulset.go
+++ b/internal/controller/controller_admin_statefulset.go
@@ -42,12 +42,11 @@ func buildAdminStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string {
 	}
 
 	// With a CredentialsSecret, bind the wildcard so the kubelet's probes can
-	// reach the admin HTTP port on the pod IP (#384). Gate -ip=0.0.0.0 on the
-	// adminPassword key actually being present in the mounted secret, so a
-	// secret missing that key can't expose the admin API unauthenticated on
-	// weed builds that lack the upstream non-loopback auth guard. The shell
-	// sets ipArg before extraArgs (baked into the string below) so a user can
-	// still override -ip; fla9 takes the last flag occurrence.
+	// reach the admin HTTP port on the pod IP (#384). Fail closed if the
+	// adminPassword key is missing: weed admin refuses a non-loopback bind
+	// without authentication, and silently falling back to loopback would
+	// leave probes broken with no visible error. $ipArg lands before
+	// extraArgs so a user can still override -ip.
 	preCmd := strings.Join(pre, " ")
 	extraCmd := ""
 	if len(extraArgs) > 0 {
@@ -58,9 +57,8 @@ func buildAdminStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string {
 		`f="` + adminCredentialsMountPath + `/$key"; ` +
 		`[ -f "$f" ] && set -- "$@" "-$key=$(cat "$f")"; ` +
 		"done; " +
-		`ipArg=""; ` +
-		`[ -f ` + adminCredentialsMountPath + `/adminPassword ] && ipArg="-ip=0.0.0.0"; `
-	return preamble + "exec " + preCmd + " $ipArg" + extraCmd + ` "$@"`
+		`[ -f ` + adminCredentialsMountPath + `/adminPassword ] || { echo "admin: CredentialsSecret mounted without adminPassword key; refusing to bind 0.0.0.0 without authentication" >&2; exit 1; }; `
+	return preamble + "exec " + preCmd + " -ip=0.0.0.0" + extraCmd + ` "$@"`
 }
 
 // adminURLPrefix scans weed admin ExtraArgs for a -urlPrefix flag and returns

--- a/internal/controller/controller_admin_statefulset.go
+++ b/internal/controller/controller_admin_statefulset.go
@@ -31,6 +31,18 @@ func buildAdminStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string {
 	if m.Spec.Admin.MetricsPort != nil {
 		commands = append(commands, fmt.Sprintf("-metricsPort=%d", *m.Spec.Admin.MetricsPort))
 	}
+
+	// weed admin binds to 127.0.0.1 by default, which the kubelet cannot
+	// reach on the pod IP, so liveness/readiness probes always fail (#384).
+	// Bind to the wildcard so probes can connect. weed admin refuses to
+	// bind a non-loopback address without authentication (adminPassword or
+	// [https.admin] mTLS in security.toml), so only do this when a
+	// CredentialsSecret is mounted — which is also when authentication is
+	// enabled. Place it before extraArgs so a user can still override -ip.
+	hasCredentials := m.Spec.Admin.CredentialsSecret != nil && m.Spec.Admin.CredentialsSecret.Name != ""
+	if hasCredentials {
+		commands = append(commands, "-ip=0.0.0.0")
+	}
 	commands = append(commands, extraArgs...)
 
 	weedCmd := strings.Join(commands, " ")
@@ -42,7 +54,7 @@ func buildAdminStartupScript(m *seaweedv1.Seaweed, extraArgs ...string) string {
 	// builds positional parameters so values containing spaces or special
 	// characters expand safely through `"$@"`. `exec` replaces the /bin/sh
 	// wrapper with weed so SIGTERM from the kubelet reaches weed directly.
-	if m.Spec.Admin.CredentialsSecret != nil && m.Spec.Admin.CredentialsSecret.Name != "" {
+	if hasCredentials {
 		preamble := "set --; " +
 			"for key in " + strings.Join(adminCredentialKeys, " ") + "; do " +
 			`f="` + adminCredentialsMountPath + `/$key"; ` +

--- a/internal/controller/controller_admin_statefulset_test.go
+++ b/internal/controller/controller_admin_statefulset_test.go
@@ -65,8 +65,7 @@ func TestBuildAdminStartupScript(t *testing.T) {
 		if strings.Contains(got, adminCredentialsMountPath) {
 			t.Fatalf("expected no credentials preamble, got %q", got)
 		}
-		// Without authentication weed admin refuses to bind a non-loopback
-		// address, so the operator must not add -ip=0.0.0.0 here.
+		// Without auth, weed admin refuses a non-loopback bind.
 		if strings.Contains(got, "-ip=0.0.0.0") {
 			t.Fatalf("expected no -ip=0.0.0.0 without a credentials secret, got %q", got)
 		}
@@ -123,17 +122,14 @@ func TestBuildAdminStartupScript(t *testing.T) {
 		if !strings.HasSuffix(got, ` "$@"`) {
 			t.Errorf("expected weed command to expand positional parameters at the end, got %q", got)
 		}
-		// With authentication enabled, the operator binds the wildcard so the
-		// kubelet's liveness/readiness probes can reach the admin HTTP port
-		// on the pod IP (#384).
+		// With auth enabled, bind the wildcard so probes can reach the pod IP (#384).
 		if !strings.Contains(got, "-ip=0.0.0.0") {
 			t.Errorf("expected -ip=0.0.0.0 with a credentials secret, got %q", got)
 		}
 	})
 
 	t.Run("credentials secret extraArgs override -ip", func(t *testing.T) {
-		// -ip=0.0.0.0 is placed before extraArgs so a user can still pin a
-		// different bind address; fla9 takes the last occurrence of a flag.
+		// -ip=0.0.0.0 lands before extraArgs so a user can still override it.
 		m := &seaweedv1.Seaweed{
 			ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
 			Spec: seaweedv1.SeaweedSpec{

--- a/internal/controller/controller_admin_statefulset_test.go
+++ b/internal/controller/controller_admin_statefulset_test.go
@@ -122,14 +122,18 @@ func TestBuildAdminStartupScript(t *testing.T) {
 		if !strings.HasSuffix(got, ` "$@"`) {
 			t.Errorf("expected weed command to expand positional parameters at the end, got %q", got)
 		}
-		// With auth enabled, bind the wildcard so probes can reach the pod IP (#384).
-		if !strings.Contains(got, "-ip=0.0.0.0") {
-			t.Errorf("expected -ip=0.0.0.0 with a credentials secret, got %q", got)
+		// -ip=0.0.0.0 is gated on the adminPassword key existing in the mounted
+		// secret, so a secret missing that key can't expose the admin API (#387).
+		if !strings.Contains(got, `[ -f `+adminCredentialsMountPath+`/adminPassword ] && ipArg="-ip=0.0.0.0"`) {
+			t.Errorf("expected adminPassword-gated ipArg assignment, got %q", got)
+		}
+		if !strings.Contains(got, `$ipArg`) {
+			t.Errorf("expected $ipArg expansion in the exec command, got %q", got)
 		}
 	})
 
 	t.Run("credentials secret extraArgs override -ip", func(t *testing.T) {
-		// -ip=0.0.0.0 lands before extraArgs so a user can still override it.
+		// $ipArg lands before extraArgs so a user can still override -ip.
 		m := &seaweedv1.Seaweed{
 			ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
 			Spec: seaweedv1.SeaweedSpec{
@@ -140,13 +144,13 @@ func TestBuildAdminStartupScript(t *testing.T) {
 			},
 		}
 		got := buildAdminStartupScript(m, "-ip=127.0.0.1")
-		defaultIdx := strings.Index(got, "-ip=0.0.0.0")
+		ipArgIdx := strings.Index(got, `$ipArg`)
 		overrideIdx := strings.Index(got, "-ip=127.0.0.1")
-		if defaultIdx < 0 || overrideIdx < 0 {
-			t.Fatalf("expected both the default and override -ip flags, got %q", got)
+		if ipArgIdx < 0 || overrideIdx < 0 {
+			t.Fatalf("expected $ipArg and the extraArgs override, got %q", got)
 		}
-		if !(defaultIdx < overrideIdx) {
-			t.Errorf("expected -ip=0.0.0.0 before the extraArgs override, got %q", got)
+		if !(ipArgIdx < overrideIdx) {
+			t.Errorf("expected $ipArg before the extraArgs override, got %q", got)
 		}
 	})
 

--- a/internal/controller/controller_admin_statefulset_test.go
+++ b/internal/controller/controller_admin_statefulset_test.go
@@ -65,6 +65,11 @@ func TestBuildAdminStartupScript(t *testing.T) {
 		if strings.Contains(got, adminCredentialsMountPath) {
 			t.Fatalf("expected no credentials preamble, got %q", got)
 		}
+		// Without authentication weed admin refuses to bind a non-loopback
+		// address, so the operator must not add -ip=0.0.0.0 here.
+		if strings.Contains(got, "-ip=0.0.0.0") {
+			t.Fatalf("expected no -ip=0.0.0.0 without a credentials secret, got %q", got)
+		}
 	})
 
 	t.Run("jwt signing adds the security config dir", func(t *testing.T) {
@@ -118,6 +123,35 @@ func TestBuildAdminStartupScript(t *testing.T) {
 		if !strings.HasSuffix(got, ` "$@"`) {
 			t.Errorf("expected weed command to expand positional parameters at the end, got %q", got)
 		}
+		// With authentication enabled, the operator binds the wildcard so the
+		// kubelet's liveness/readiness probes can reach the admin HTTP port
+		// on the pod IP (#384).
+		if !strings.Contains(got, "-ip=0.0.0.0") {
+			t.Errorf("expected -ip=0.0.0.0 with a credentials secret, got %q", got)
+		}
+	})
+
+	t.Run("credentials secret extraArgs override -ip", func(t *testing.T) {
+		// -ip=0.0.0.0 is placed before extraArgs so a user can still pin a
+		// different bind address; fla9 takes the last occurrence of a flag.
+		m := &seaweedv1.Seaweed{
+			ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
+			Spec: seaweedv1.SeaweedSpec{
+				Master: &seaweedv1.MasterSpec{Replicas: 1},
+				Admin: &seaweedv1.AdminSpec{
+					CredentialsSecret: &corev1.LocalObjectReference{Name: "admin-creds"},
+				},
+			},
+		}
+		got := buildAdminStartupScript(m, "-ip=127.0.0.1")
+		defaultIdx := strings.Index(got, "-ip=0.0.0.0")
+		overrideIdx := strings.Index(got, "-ip=127.0.0.1")
+		if defaultIdx < 0 || overrideIdx < 0 {
+			t.Fatalf("expected both the default and override -ip flags, got %q", got)
+		}
+		if !(defaultIdx < overrideIdx) {
+			t.Errorf("expected -ip=0.0.0.0 before the extraArgs override, got %q", got)
+		}
 	})
 
 	t.Run("empty credentials secret name skips preamble", func(t *testing.T) {
@@ -133,6 +167,9 @@ func TestBuildAdminStartupScript(t *testing.T) {
 		got := buildAdminStartupScript(m)
 		if strings.Contains(got, adminCredentialsMountPath) {
 			t.Fatalf("expected no credentials preamble for empty secret name, got %q", got)
+		}
+		if strings.Contains(got, "-ip=0.0.0.0") {
+			t.Fatalf("expected no -ip=0.0.0.0 for empty secret name, got %q", got)
 		}
 	})
 }

--- a/internal/controller/controller_admin_statefulset_test.go
+++ b/internal/controller/controller_admin_statefulset_test.go
@@ -122,18 +122,18 @@ func TestBuildAdminStartupScript(t *testing.T) {
 		if !strings.HasSuffix(got, ` "$@"`) {
 			t.Errorf("expected weed command to expand positional parameters at the end, got %q", got)
 		}
-		// -ip=0.0.0.0 is gated on the adminPassword key existing in the mounted
-		// secret, so a secret missing that key can't expose the admin API (#387).
-		if !strings.Contains(got, `[ -f `+adminCredentialsMountPath+`/adminPassword ] && ipArg="-ip=0.0.0.0"`) {
-			t.Errorf("expected adminPassword-gated ipArg assignment, got %q", got)
+		// Fail closed if adminPassword is missing, so a misconfigured secret
+		// can't expose the admin API or silently leave probes broken (#387).
+		if !strings.Contains(got, `[ -f `+adminCredentialsMountPath+`/adminPassword ] || { echo "admin: CredentialsSecret mounted without adminPassword key; refusing to bind 0.0.0.0 without authentication" >&2; exit 1; }`) {
+			t.Errorf("expected adminPassword fail-closed guard, got %q", got)
 		}
-		if !strings.Contains(got, `$ipArg`) {
-			t.Errorf("expected $ipArg expansion in the exec command, got %q", got)
+		if !strings.Contains(got, `-ip=0.0.0.0`) {
+			t.Errorf("expected -ip=0.0.0.0 with a credentials secret, got %q", got)
 		}
 	})
 
 	t.Run("credentials secret extraArgs override -ip", func(t *testing.T) {
-		// $ipArg lands before extraArgs so a user can still override -ip.
+		// -ip=0.0.0.0 lands before extraArgs so a user can still override it.
 		m := &seaweedv1.Seaweed{
 			ObjectMeta: metav1.ObjectMeta{Name: "sw", Namespace: "ns"},
 			Spec: seaweedv1.SeaweedSpec{
@@ -144,13 +144,13 @@ func TestBuildAdminStartupScript(t *testing.T) {
 			},
 		}
 		got := buildAdminStartupScript(m, "-ip=127.0.0.1")
-		ipArgIdx := strings.Index(got, `$ipArg`)
+		defaultIdx := strings.Index(got, "-ip=0.0.0.0")
 		overrideIdx := strings.Index(got, "-ip=127.0.0.1")
-		if ipArgIdx < 0 || overrideIdx < 0 {
-			t.Fatalf("expected $ipArg and the extraArgs override, got %q", got)
+		if defaultIdx < 0 || overrideIdx < 0 {
+			t.Fatalf("expected -ip=0.0.0.0 and the extraArgs override, got %q", got)
 		}
-		if !(ipArgIdx < overrideIdx) {
-			t.Errorf("expected $ipArg before the extraArgs override, got %q", got)
+		if !(defaultIdx < overrideIdx) {
+			t.Errorf("expected -ip=0.0.0.0 before the extraArgs override, got %q", got)
 		}
 	})
 


### PR DESCRIPTION
## Summary
- `weed admin` defaults to binding `127.0.0.1`, which the kubelet cannot reach on the pod IP, so the liveness/readiness probes always fail (#384).
- Add `-ip=0.0.0.0` to the admin startup script **when a `CredentialsSecret` is mounted** — the same condition that enables authentication. `weed admin` refuses to bind a non-loopback address without `adminPassword` or `[https.admin]` mTLS, so this is gated on the operator knowing auth is on.
- The flag is placed before `extraArgs`, so a user can still override `-ip` (fla9 takes the last occurrence). Deployments without a `CredentialsSecret` keep the loopback default and are unchanged.

This replaces the manual workaround from the issue:
```yaml
extraArgs:
  - "-ip"
  - "0.0.0.0"
```

Fixes #384

#### Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/controller/`
- [x] `gofmt` clean
- [x] `go test ./internal/controller/` (existing + new cases pass)
- [ ] Manually verify a cluster with `admin.credentialsSecret` set has healthy probes and the admin pod binds `0.0.0.0`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs-operator/pull/387" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed admin service health checks failing when credential-based admin access is configured.
  - The admin service now listens on the pod’s reachable address, allowing readiness and liveness checks to succeed.
  - Custom startup arguments continue to take precedence over the default network binding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->