### PR TITLE
Stop ServiceMonitors from double-scraping peer Services

### DIFF
--- a/internal/controller/controller_admin_service.go
+++ b/internal/controller/controller_admin_service.go
@@ -81,7 +81,7 @@ func (r *SeaweedReconciler) createAdminService(m *seaweedv1.Seaweed) *corev1.Ser
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      m.Name + "-admin",
 			Namespace: m.Namespace,
-			Labels:    labels,
+			Labels:    metricsServiceLabels(labels),
 			Annotations: map[string]string{
 				"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
 			},

--- a/internal/controller/controller_admin_servicemonitor.go
+++ b/internal/controller/controller_admin_servicemonitor.go
@@ -28,7 +28,7 @@ func (r *SeaweedReconciler) createAdminServiceMonitor(m *seaweedv1.Seaweed) *mon
 				},
 			},
 			Selector: metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: metricsServiceLabels(labels),
 			},
 		},
 	}

--- a/internal/controller/controller_filer_service.go
+++ b/internal/controller/controller_filer_service.go
@@ -135,7 +135,7 @@ func (r *SeaweedReconciler) createFilerService(m *seaweedv1.Seaweed) *corev1.Ser
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      m.Name + "-filer",
 			Namespace: m.Namespace,
-			Labels:    labels,
+			Labels:    metricsServiceLabels(labels),
 			Annotations: map[string]string{
 				"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
 			},

--- a/internal/controller/controller_filer_servicemonitor.go
+++ b/internal/controller/controller_filer_servicemonitor.go
@@ -24,7 +24,7 @@ func (r *SeaweedReconciler) createFilerServiceMonitor(m *seaweedv1.Seaweed) *mon
 				},
 			},
 			Selector: metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: metricsServiceLabels(labels),
 			},
 		},
 	}

--- a/internal/controller/controller_master_service.go
+++ b/internal/controller/controller_master_service.go
@@ -83,7 +83,7 @@ func (r *SeaweedReconciler) createMasterService(m *seaweedv1.Seaweed) *corev1.Se
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      m.Name + "-master",
 			Namespace: m.Namespace,
-			Labels:    labels,
+			Labels:    metricsServiceLabels(labels),
 			Annotations: map[string]string{
 				"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
 			},

--- a/internal/controller/controller_master_servicemonitor.go
+++ b/internal/controller/controller_master_servicemonitor.go
@@ -23,7 +23,7 @@ func (r *SeaweedReconciler) createMasterServiceMonitor(m *seaweedv1.Seaweed) *mo
 				},
 			},
 			Selector: metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: metricsServiceLabels(labels),
 			},
 		},
 	}

--- a/internal/controller/controller_servicemonitor_labels_test.go
+++ b/internal/controller/controller_servicemonitor_labels_test.go
@@ -1,0 +1,211 @@
+package controller
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+	"github.com/seaweedfs/seaweedfs-operator/internal/controller/label"
+)
+
+// metricsPort is a helper to build a *int32.
+func metricsPort(p int32) *int32 { return &p }
+
+// selectorMatches reports whether matchLabels matches serviceLabels.
+func selectorMatches(matchLabels, serviceLabels map[string]string) bool {
+	sel := labels.Set(matchLabels)
+	for k, v := range serviceLabels {
+		if sel.Has(k) && sel.Get(k) != v {
+			return false
+		}
+	}
+	for k, v := range sel {
+		if serviceLabels[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// TestServiceMonitorDoesNotDoubleScrape verifies the ServiceMonitor selector
+// matches the regular Service but not the peer Service.
+func TestServiceMonitorDoesNotDoubleScrape(t *testing.T) {
+	m := &seaweedv1.Seaweed{
+		ObjectMeta: metav1.ObjectMeta{Name: "seaweedfs", Namespace: "test"},
+		Spec: seaweedv1.SeaweedSpec{
+			Master: &seaweedv1.MasterSpec{Replicas: 1, MetricsPort: metricsPort(8080)},
+			Volume: &seaweedv1.VolumeSpec{
+				Replicas: 1,
+				VolumeServerConfig: seaweedv1.VolumeServerConfig{
+					MetricsPort: metricsPort(8080),
+				},
+			},
+			Filer: &seaweedv1.FilerSpec{Replicas: 1, MetricsPort: metricsPort(8080)},
+			Admin: &seaweedv1.AdminSpec{MetricsPort: metricsPort(9327)},
+		},
+	}
+	r := &SeaweedReconciler{}
+
+	type svcPair struct {
+		name     string
+		regular  map[string]string
+		peer     map[string]string
+		selector map[string]string
+	}
+	var pairs []svcPair
+
+	// master
+	{
+		sm := r.createMasterServiceMonitor(m)
+		pairs = append(pairs, svcPair{
+			name:     "master",
+			regular:  r.createMasterService(m).Labels,
+			peer:     r.createMasterPeerService(m).Labels,
+			selector: sm.Spec.Selector.MatchLabels,
+		})
+	}
+	// filer
+	{
+		sm := r.createFilerServiceMonitor(m)
+		pairs = append(pairs, svcPair{
+			name:     "filer",
+			regular:  r.createFilerService(m).Labels,
+			peer:     r.createFilerPeerService(m).Labels,
+			selector: sm.Spec.Selector.MatchLabels,
+		})
+	}
+	// volume (per-pod service for index 0)
+	{
+		sm := r.createVolumeServerServiceMonitor(m)
+		pairs = append(pairs, svcPair{
+			name:     "volume",
+			regular:  r.createVolumeServerService(m, 0).Labels,
+			peer:     r.createVolumeServerPeerService(m).Labels,
+			selector: sm.Spec.Selector.MatchLabels,
+		})
+	}
+	// admin
+	{
+		sm := r.createAdminServiceMonitor(m)
+		pairs = append(pairs, svcPair{
+			name:     "admin",
+			regular:  r.createAdminService(m).Labels,
+			peer:     r.createAdminPeerService(m).Labels,
+			selector: sm.Spec.Selector.MatchLabels,
+		})
+	}
+
+	for _, p := range pairs {
+		t.Run(p.name, func(t *testing.T) {
+			if p.regular[label.MetricsServiceLabelKey] != "true" {
+				t.Errorf("regular %s Service missing %q marker label; labels=%v",
+					p.name, label.MetricsServiceLabelKey, p.regular)
+			}
+			if p.selector[label.MetricsServiceLabelKey] != "true" {
+				t.Errorf("%s ServiceMonitor selector missing %q marker label; selector=%v",
+					p.name, label.MetricsServiceLabelKey, p.selector)
+			}
+			if _, ok := p.peer[label.MetricsServiceLabelKey]; ok {
+				t.Errorf("peer %s Service must NOT carry %q marker label; labels=%v",
+					p.name, label.MetricsServiceLabelKey, p.peer)
+			}
+
+			if !selectorMatches(p.selector, p.regular) {
+				t.Errorf("%s ServiceMonitor selector does not match the regular Service: selector=%v service=%v",
+					p.name, p.selector, p.regular)
+			}
+			if selectorMatches(p.selector, p.peer) {
+				t.Errorf("%s ServiceMonitor selector matches the peer Service, causing double scrape: selector=%v peer=%v",
+					p.name, p.selector, p.peer)
+			}
+		})
+	}
+}
+
+// TestVolumeTopologyServiceMonitorDoesNotDoubleScrape covers the volume topology variant.
+func TestVolumeTopologyServiceMonitorDoesNotDoubleScrape(t *testing.T) {
+	topology := &seaweedv1.VolumeTopologySpec{
+		Replicas:   1,
+		Rack:       "rack1",
+		DataCenter: "dc1",
+		VolumeServerConfig: seaweedv1.VolumeServerConfig{
+			MetricsPort: metricsPort(8080),
+		},
+	}
+	m := &seaweedv1.Seaweed{
+		ObjectMeta: metav1.ObjectMeta{Name: "seaweedfs", Namespace: "test"},
+		Spec: seaweedv1.SeaweedSpec{
+			Master: &seaweedv1.MasterSpec{Replicas: 1},
+			VolumeTopology: map[string]*seaweedv1.VolumeTopologySpec{
+				"rack1": topology,
+			},
+		},
+	}
+	r := &SeaweedReconciler{}
+
+	sm := r.createVolumeServerTopologyServiceMonitor(m, "rack1", topology)
+	regular := r.createVolumeServerTopologyService(m, "rack1", 0).Labels
+	peer := r.createVolumeServerTopologyPeerService(m, "rack1").Labels
+	selector := sm.Spec.Selector.MatchLabels
+
+	if regular[label.MetricsServiceLabelKey] != "true" {
+		t.Errorf("regular topology volume Service missing %q marker label; labels=%v",
+			label.MetricsServiceLabelKey, regular)
+	}
+	if selector[label.MetricsServiceLabelKey] != "true" {
+		t.Errorf("topology volume ServiceMonitor selector missing %q marker label; selector=%v",
+			label.MetricsServiceLabelKey, selector)
+	}
+	if _, ok := peer[label.MetricsServiceLabelKey]; ok {
+		t.Errorf("peer topology volume Service must NOT carry %q marker label; labels=%v",
+			label.MetricsServiceLabelKey, peer)
+	}
+	if !selectorMatches(selector, regular) {
+		t.Errorf("topology ServiceMonitor selector does not match the regular Service: selector=%v service=%v",
+			selector, regular)
+	}
+	if selectorMatches(selector, peer) {
+		t.Errorf("topology ServiceMonitor selector matches the peer Service, causing double scrape: selector=%v peer=%v",
+			selector, peer)
+	}
+}
+
+// TestPeerServicesKeepPodSelecting ensures the marker label does not leak into
+// Spec.Selector, which must keep matching pods.
+func TestPeerServicesKeepPodSelecting(t *testing.T) {
+	m := &seaweedv1.Seaweed{
+		ObjectMeta: metav1.ObjectMeta{Name: "seaweedfs", Namespace: "test"},
+		Spec: seaweedv1.SeaweedSpec{
+			Master: &seaweedv1.MasterSpec{Replicas: 1, MetricsPort: metricsPort(8080)},
+			Volume: &seaweedv1.VolumeSpec{
+				Replicas: 1,
+				VolumeServerConfig: seaweedv1.VolumeServerConfig{
+					MetricsPort: metricsPort(8080),
+				},
+			},
+			Filer: &seaweedv1.FilerSpec{Replicas: 1, MetricsPort: metricsPort(8080)},
+			Admin: &seaweedv1.AdminSpec{MetricsPort: metricsPort(9327)},
+		},
+	}
+	r := &SeaweedReconciler{}
+
+	checks := []struct {
+		name     string
+		selector map[string]string
+	}{
+		{"master", r.createMasterService(m).Spec.Selector},
+		{"filer", r.createFilerService(m).Spec.Selector},
+		{"volume", r.createVolumeServerService(m, 0).Spec.Selector},
+		{"admin", r.createAdminService(m).Spec.Selector},
+	}
+	for _, c := range checks {
+		t.Run(c.name, func(t *testing.T) {
+			if _, ok := c.selector[label.MetricsServiceLabelKey]; ok {
+				t.Errorf("%s Service Spec.Selector must not contain the marker label (pods do not have it): %v",
+					c.name, c.selector)
+			}
+		})
+	}
+}

--- a/internal/controller/controller_volume_service.go
+++ b/internal/controller/controller_volume_service.go
@@ -85,7 +85,7 @@ func (r *SeaweedReconciler) createVolumeServerService(m *seaweedv1.Seaweed, i in
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceName,
 			Namespace: m.Namespace,
-			Labels:    labels,
+			Labels:    metricsServiceLabels(labels),
 			Annotations: map[string]string{
 				"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
 			},
@@ -197,7 +197,7 @@ func (r *SeaweedReconciler) createVolumeServerTopologyService(m *seaweedv1.Seawe
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceName,
 			Namespace: m.Namespace,
-			Labels:    labels,
+			Labels:    metricsServiceLabels(labels),
 			Annotations: map[string]string{
 				"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
 			},

--- a/internal/controller/controller_volume_servicemonitor.go
+++ b/internal/controller/controller_volume_servicemonitor.go
@@ -24,7 +24,7 @@ func (r *SeaweedReconciler) createVolumeServerServiceMonitor(m *seaweedv1.Seawee
 				},
 			},
 			Selector: metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: metricsServiceLabels(labels),
 			},
 		},
 	}
@@ -49,7 +49,7 @@ func (r *SeaweedReconciler) createVolumeServerTopologyServiceMonitor(m *seaweedv
 				},
 			},
 			Selector: metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: metricsServiceLabels(labels),
 			},
 		},
 	}

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -9,6 +9,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	seaweedv1 "github.com/seaweedfs/seaweedfs-operator/api/v1"
+	"github.com/seaweedfs/seaweedfs-operator/internal/controller/label"
 )
 
 const (
@@ -117,6 +118,13 @@ func mergeLabels(base, override map[string]string) map[string]string {
 	}
 
 	return merged
+}
+
+// metricsServiceLabels returns labels with the metrics-service marker added.
+// Used on regular Service ObjectMeta and ServiceMonitor selectors, never on
+// Spec.Selector or peer Services.
+func metricsServiceLabels(labels map[string]string) map[string]string {
+	return mergeLabels(labels, map[string]string{label.MetricsServiceLabelKey: "true"})
 }
 
 // mergeAnnotations merges cluster-level annotations with component-level annotations

--- a/internal/controller/label/label.go
+++ b/internal/controller/label/label.go
@@ -19,4 +19,8 @@ const (
 	// PodName is to select pod by name
 	// https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-selector
 	PodName string = "statefulset.kubernetes.io/pod-name"
+
+	// MetricsServiceLabelKey marks Services a ServiceMonitor should scrape.
+	// Set only on regular Services, not headless peer Services.
+	MetricsServiceLabelKey string = "seaweedfs-operator/metrics-service"
 )


### PR DESCRIPTION
## Summary

When `metricsPort` is set, the operator generates a `ServiceMonitor` per component. The `ServiceMonitor` selector used the same component labels as **both** the regular Service and the headless peer Service, so Prometheus selected both and scraped each target twice.

This adds a `seaweedfs-operator/metrics-service: "true"` marker label to **only** the regular (per-pod) Services and includes it in the `ServiceMonitor` selectors. The headless peer Services do not carry the marker, so each target is now scraped exactly once — the fix recommended in the issue.

The marker is added to the Services' `ObjectMeta.Labels` only, never to `Spec.Selector`, so the Services continue routing traffic to pods (which don't have the marker).

Affected components (those with peer Services): master, filer, volume (+ topology), admin. `s3`/`sftp`/`worker` only have a single Service each, so they were already correct and are unchanged.

## Changes
- `internal/controller/label/label.go`: new `MetricsServiceLabelKey` constant.
- `internal/controller/helper.go`: `metricsServiceLabels` helper that layers the marker on top of the component labels.
- Regular Services (master, filer, volume, volume-topology, admin): `ObjectMeta.Labels` now use the marker-augmented labels.
- ServiceMonitors (master, filer, volume, volume-topology, admin): `Selector.MatchLabels` now use the marker-augmented labels.

#### Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/controller/` (incl. new `TestServiceMonitorDoesNotDoubleScrape`, `TestVolumeTopologyServiceMonitorDoesNotDoubleScrape`, `TestPeerServicesKeepPodSelecting`)
- [x] `go test ./api/...` and `go test ./test/helm/`
- [ ] e2e (requires a kind cluster; not run locally — environment had no kindest images)
